### PR TITLE
🔒 Fix configuration injection in input-map tool

### DIFF
--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -228,6 +228,13 @@ export async function handleInputMap(action: string, args: Record<string, unknow
       const configPath = getProjectGodotPath(projectPath)
       const actionName = args.action_name as string
       if (!actionName) throw new GodotMCPError('No action_name specified', 'INVALID_ARGS', 'Provide action_name.')
+      if (!/^[a-zA-Z0-9_-]+$/.test(actionName)) {
+        throw new GodotMCPError(
+          `Invalid action name: ${actionName}`,
+          'INVALID_ARGS',
+          'Action names must contain only alphanumeric characters, underscores, and hyphens.',
+        )
+      }
       const deadzone = (args.deadzone as number) || 0.5
 
       let content = readFileSync(configPath, 'utf-8')
@@ -254,6 +261,13 @@ export async function handleInputMap(action: string, args: Record<string, unknow
       const configPath = getProjectGodotPath(projectPath)
       const actionName = args.action_name as string
       if (!actionName) throw new GodotMCPError('No action_name specified', 'INVALID_ARGS', 'Provide action_name.')
+      if (!/^[a-zA-Z0-9_-]+$/.test(actionName)) {
+        throw new GodotMCPError(
+          `Invalid action name: ${actionName}`,
+          'INVALID_ARGS',
+          'Action names must contain only alphanumeric characters, underscores, and hyphens.',
+        )
+      }
 
       const content = readFileSync(configPath, 'utf-8')
       // Remove the action line(s) - handles multi-line format
@@ -278,6 +292,13 @@ export async function handleInputMap(action: string, args: Record<string, unknow
           'action_name, event_type, and event_value required',
           'INVALID_ARGS',
           'Provide action_name, event_type (key/mouse/joypad), and event_value (e.g., "KEY_SPACE").',
+        )
+      }
+      if (!/^[a-zA-Z0-9_-]+$/.test(actionName)) {
+        throw new GodotMCPError(
+          `Invalid action name: ${actionName}`,
+          'INVALID_ARGS',
+          'Action names must contain only alphanumeric characters, underscores, and hyphens.',
         )
       }
 


### PR DESCRIPTION
This PR fixes a configuration injection vulnerability in the input-map tool.

**Vulnerability:**
The `action_name` parameter was directly interpolated into the `project.godot` file content without validation. This allowed an attacker to inject arbitrary configuration settings or corrupt the file by including newlines and other special characters in the action name.

**Fix:**
Implemented strict validation for `action_name` using the regex `^[a-zA-Z0-9_-]+$`. This ensures that action names can only contain alphanumeric characters, underscores, and hyphens, preventing the injection of malicious payloads.

**Verification:**
- Added a reproduction test case `tests/composite/repro_input_map.test.ts` which confirmed the vulnerability (injection of a new section).
- After applying the fix, the reproduction test passed (injection was prevented).
- Existing tests `tests/composite/input-map.test.ts` also passed, ensuring no regressions.


---
*PR created automatically by Jules for task [8116056602277299528](https://jules.google.com/task/8116056602277299528) started by @n24q02m*