### PR TITLE
🔒 Fix Path Traversal in Script Creation

### DIFF
--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync,
 import { dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const SCRIPT_TEMPLATES: Record<string, string> = {
   Node: `extends Node
@@ -127,7 +128,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       const extendsType = (args.extends as string) || 'Node'
       const content = (args.content as string) || getTemplate(extendsType)
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), scriptPath)
       if (existsSync(fullPath)) {
         throw new GodotMCPError(
           `Script already exists: ${scriptPath}`,
@@ -145,7 +146,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       const scriptPath = args.script_path as string
       if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), scriptPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
 
@@ -160,7 +161,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       if (content === undefined || content === null)
         throw new GodotMCPError('No content specified', 'INVALID_ARGS', 'Provide content to write.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), scriptPath)
       mkdirSync(dirname(fullPath), { recursive: true })
       writeFileSync(fullPath, content, 'utf-8')
       return formatSuccess(`Written: ${scriptPath} (${content.length} chars)`)
@@ -178,7 +179,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
         )
       }
 
-      const sceneFullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const sceneFullPath = safeResolve(projectPath || process.cwd(), scenePath)
       if (!existsSync(sceneFullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
 
@@ -219,7 +220,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       if (!scriptPath)
         throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path to delete.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), scriptPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
 

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,0 +1,35 @@
+import { isAbsolute, relative, resolve, sep } from 'node:path'
+import { GodotMCPError } from './errors.js'
+
+/**
+ * Safely resolves a path against a base directory (project root).
+ * Prevents path traversal attacks by ensuring the resolved path is within the base directory.
+ *
+ * @param basePath - The project root directory
+ * @param relativePath - The path to resolve relative to the base directory
+ * @returns The absolute resolved path
+ * @throws GodotMCPError if the path is outside the base directory
+ */
+export function safeResolve(basePath: string, relativePath: string): string {
+  const resolvedBase = resolve(basePath)
+  const resolvedPath = resolve(resolvedBase, relativePath)
+
+  // Calculate relative path from base to resolved path
+  const rel = relative(resolvedBase, resolvedPath)
+
+  // Check if the path traverses outside the base directory
+  // 1. rel starts with '..' (or is '..') - meaning it's outside
+  // 2. rel is absolute - meaning it's on a different drive (Windows) or absolute path provided
+
+  const isOutside = rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)
+
+  if (isOutside) {
+    throw new GodotMCPError(
+      `Access denied: Path resolves outside the project directory.`,
+      'INVALID_ARGS',
+      'Ensure all paths are within the project directory.',
+    )
+  }
+
+  return resolvedPath
+}

--- a/tests/security/path_traversal.test.ts
+++ b/tests/security/path_traversal.test.ts
@@ -1,8 +1,8 @@
 import { existsSync, mkdirSync, rmSync } from 'node:fs'
-import type { GodotConfig } from '../../src/godot/types.js'
 import { tmpdir } from 'node:os'
 import { join, relative } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
 import { handleScripts } from '../../src/tools/composite/scripts.js'
 import { createTmpProject, makeConfig } from '../fixtures.js'
 

--- a/tests/security/path_traversal.test.ts
+++ b/tests/security/path_traversal.test.ts
@@ -1,0 +1,52 @@
+import { existsSync, mkdirSync, rmSync } from 'node:fs'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { tmpdir } from 'node:os'
+import { join, relative } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { handleScripts } from '../../src/tools/composite/scripts.js'
+import { createTmpProject, makeConfig } from '../fixtures.js'
+
+describe('Path Traversal Security', () => {
+  let projectPath: string
+  let outsidePath: string
+  let cleanup: () => void
+  let config: GodotConfig
+
+  beforeEach(() => {
+    const tmp = createTmpProject()
+    projectPath = tmp.projectPath
+    cleanup = tmp.cleanup
+    config = makeConfig({ projectPath })
+
+    // Create a directory outside the project
+    outsidePath = join(tmpdir(), `godot-mcp-outside-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(outsidePath)
+  })
+
+  afterEach(() => {
+    cleanup()
+    if (existsSync(outsidePath)) {
+      rmSync(outsidePath, { recursive: true, force: true })
+    }
+  })
+
+  it('should prevent writing scripts outside the project directory', async () => {
+    const sensitiveFile = join(outsidePath, 'pwned.gd')
+    const relativePath = relative(projectPath, sensitiveFile)
+
+    // Attempt to write outside the project
+    // This expects the promise to reject with an error mentioning access denied or similar
+    await expect(
+      handleScripts(
+        'create',
+        {
+          project_path: projectPath,
+          script_path: relativePath,
+        },
+        config,
+      ),
+    ).rejects.toThrow(/Access denied|outside project/i)
+
+    expect(existsSync(sensitiveFile)).toBe(false)
+  })
+})


### PR DESCRIPTION
Prevented writing files outside the project directory in the scripts tool.

⚠️ Risk:
Malicious users could overwrite sensitive files (e.g., `/etc/passwd`) if the `script_path` parameter was manipulated to include `..`.

🛡️ Solution:
Implemented `safeResolve` helper in `src/tools/helpers/paths.ts` which ensures that resolved paths are contained within the project root. Updated `src/tools/composite/scripts.ts` to use `safeResolve` for all file operations.

---
*PR created automatically by Jules for task [256468542306495489](https://jules.google.com/task/256468542306495489) started by @n24q02m*