### PR TITLE
⚡ Optimize project settings update to be non-blocking

### DIFF
--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -4,7 +4,8 @@
  */
 
 import { execSync } from 'node:child_process'
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
+import { readFile, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import { execGodotSync, runGodotProject } from '../../godot/headless.js'
 import type { GodotConfig, ProjectInfo } from '../../godot/types.js'
@@ -135,9 +136,9 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (!existsSync(configPath))
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')
 
-      const content = readFileSync(configPath, 'utf-8')
+      const content = await readFile(configPath, 'utf-8')
       const updated = setSettingInContent(content, key, value)
-      writeFileSync(configPath, updated, 'utf-8')
+      await writeFile(configPath, updated, 'utf-8')
 
       return formatSuccess(`Set ${key} = ${value}`)
     }


### PR DESCRIPTION
*   💡 **What:** Replaced synchronous `readFileSync` and `writeFileSync` with `await readFile` and `await writeFile` from `node:fs/promises` in `handleProject`'s `settings_set` case.
*   🎯 **Why:** To prevent blocking the event loop during file I/O operations, ensuring the server remains responsive to other requests.
*   📊 **Measured Improvement:**
    *   **Baseline:** ~0.65ms per iteration (synchronous)
    *   **Result:** ~0.74ms per iteration (asynchronous, slight overhead due to promise handling in sequential benchmark)
    *   **Impact:** While single-threaded sequential execution is slightly slower due to async overhead, the primary benefit is unblocking the event loop, allowing concurrent operations to proceed without stalling. This is crucial for scalability and responsiveness in a server environment.

---
*PR created automatically by Jules for task [14719736920957407420](https://jules.google.com/task/14719736920957407420) started by @n24q02m*