### PR TITLE
🔒 Fix Path Traversal Vulnerability in Resources Tool

### DIFF
--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -7,6 +7,7 @@ import { existsSync, readdirSync, readFileSync, statSync, unlinkSync } from 'nod
 import { extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const RESOURCE_EXTENSIONS = new Set([
   '.tres',
@@ -83,7 +84,7 @@ export async function handleResources(action: string, args: Record<string, unkno
     case 'info': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-      const fullPath = projectPath ? resolve(projectPath, resPath) : resolve(resPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), resPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
@@ -111,7 +112,7 @@ export async function handleResources(action: string, args: Record<string, unkno
     case 'delete': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-      const fullPath = projectPath ? resolve(projectPath, resPath) : resolve(resPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), resPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
@@ -127,7 +128,7 @@ export async function handleResources(action: string, args: Record<string, unkno
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
 
-      const importPath = projectPath ? resolve(projectPath, `${resPath}.import`) : resolve(`${resPath}.import`)
+      const importPath = safeResolve(projectPath || process.cwd(), `${resPath}.import`)
 
       if (!existsSync(importPath)) {
         return formatJSON({ path: resPath, imported: false, message: 'No .import file found.' })

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,0 +1,31 @@
+import { resolve, sep } from 'node:path'
+import { GodotMCPError } from './errors.js'
+
+/**
+ * Safely resolves a path relative to a base path, preventing directory traversal.
+ *
+ * @param basePath The trusted base directory (e.g. project root)
+ * @param relativePath The user-provided path to resolve
+ * @returns The absolute resolved path
+ * @throws GodotMCPError if the path traverses outside the base path
+ */
+export function safeResolve(basePath: string, relativePath: string): string {
+  const resolvedBase = resolve(basePath)
+  const resolvedPath = resolve(resolvedBase, relativePath)
+
+  // Ensure the resolved path starts with the base path
+  // We append a separator to ensure we don't match partial folder names (e.g. /var/www vs /var/www-fake)
+  // But we also allow the path to be exactly the base path
+  const baseWithSep = resolvedBase.endsWith(sep) ? resolvedBase : resolvedBase + sep
+  const pathWithSep = resolvedPath.endsWith(sep) ? resolvedPath : resolvedPath + sep
+
+  if (resolvedPath !== resolvedBase && !pathWithSep.startsWith(baseWithSep)) {
+    throw new GodotMCPError(
+      `Path traversal detected: ${relativePath}`,
+      'INVALID_ARGS',
+      'Path must be within project directory.'
+    )
+  }
+
+  return resolvedPath
+}

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -23,7 +23,7 @@ export function safeResolve(basePath: string, relativePath: string): string {
     throw new GodotMCPError(
       `Path traversal detected: ${relativePath}`,
       'INVALID_ARGS',
-      'Path must be within project directory.'
+      'Path must be within project directory.',
     )
   }
 


### PR DESCRIPTION
This PR addresses a critical Path Traversal vulnerability in the resources tool (`src/tools/composite/resources.ts`).

🎯 **What:** The `info`, `delete`, and `import_config` actions in `resources.ts` previously used `resolve` directly on user-provided `resource_path`. This allowed attackers to access files outside the project directory by providing paths like `../../etc/passwd` or absolute paths.

⚠️ **Risk:** Attackers could read sensitive files (`info`), delete arbitrary files (`delete`), or access files (`import_config`) on the system where the MCP server is running, potentially compromising the host machine or exposing secrets.

🛡️ **Solution:**
1.  Created a new utility `safeResolve` in `src/tools/helpers/paths.ts` that safely resolves paths relative to a base directory and throws an error if the resulting path attempts to traverse outside the base directory.
2.  Updated `src/tools/composite/resources.ts` to use `safeResolve` for all `resource_path` resolutions in the affected actions.

**Verification:**
- Verified with a reproduction script (`reproduce_vulnerability.ts`) that the vulnerability is now blocked (throws `Path traversal detected`).
- Ran existing tests (`bun test`) to ensure no regressions. One pre-existing test failure related to `@modelcontextprotocol/sdk` module resolution in the test environment was noted but is unrelated to these changes.

---
*PR created automatically by Jules for task [4257057668730693315](https://jules.google.com/task/4257057668730693315) started by @n24q02m*