### PR TITLE
🔒 Fix path traversal in scenes tool using safeResolve

### DIFF
--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -16,6 +16,7 @@ import {
 import { basename, dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig, SceneInfo, SceneNode } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 import { setSettingInContent } from '../helpers/project-settings.js'
 
 /**
@@ -119,7 +120,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       const rootType = (args.root_type as string) || 'Node2D'
       const rootName = (args.root_name as string) || basename(scenePath, '.tscn')
 
-      const fullPath = resolve(projectPath, scenePath)
+      const fullPath = safeResolve(projectPath, scenePath)
       if (existsSync(fullPath)) {
         throw new GodotMCPError(
           `Scene already exists: ${scenePath}`,
@@ -155,7 +156,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       if (!scenePath) {
         throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path to parse.')
       }
-      const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
       if (!existsSync(fullPath)) {
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path and try again.')
       }
@@ -169,7 +170,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       if (!scenePath) {
         throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path to delete.')
       }
-      const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
       if (!existsSync(fullPath)) {
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
       }
@@ -188,8 +189,8 @@ export async function handleScenes(action: string, args: Record<string, unknown>
           'Provide source and destination paths.',
         )
       }
-      const srcFull = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
-      const dstFull = projectPath ? resolve(projectPath, newPath) : resolve(newPath)
+      const srcFull = safeResolve(projectPath || process.cwd(), scenePath)
+      const dstFull = safeResolve(projectPath || process.cwd(), newPath)
       if (!existsSync(srcFull)) {
         throw new GodotMCPError(`Source scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the source path.')
       }

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -22,16 +22,13 @@ export function safeResolve(basePath: string, ...paths: string[]): string {
   // On Windows, relative can return an absolute path if on a different drive.
   // We also check for '..' at the start to catch traversal.
   // Note: '..foo' is a valid filename, so we check for '..' exact match or '..' followed by separator.
-  const isOutside =
-    rel === '..' ||
-    rel.startsWith(`..${sep}`) ||
-    (process.platform === 'win32' && isAbsolute(rel))
+  const isOutside = rel === '..' || rel.startsWith(`..${sep}`) || (process.platform === 'win32' && isAbsolute(rel))
 
   if (isOutside) {
     throw new GodotMCPError(
       'Access denied: Path traversal detected',
       'INVALID_ARGS',
-      `Path '${paths.join('/')}' resolves to '${resolvedPath}', which is outside the project directory '${absoluteBase}'`
+      `Path '${paths.join('/')}' resolves to '${resolvedPath}', which is outside the project directory '${absoluteBase}'`,
     )
   }
 

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,0 +1,39 @@
+import { isAbsolute, relative, resolve, sep } from 'node:path'
+import { GodotMCPError } from './errors.js'
+
+/**
+ * Safely resolves a path relative to a base directory, preventing path traversal.
+ *
+ * @param basePath - The trusted base directory (absolute or relative to cwd)
+ * @param paths - Path segments to resolve relative to basePath
+ * @returns The resolved absolute path
+ * @throws GodotMCPError if the resolved path is outside the base path
+ */
+export function safeResolve(basePath: string, ...paths: string[]): string {
+  // Ensure we have an absolute base path
+  const absoluteBase = resolve(basePath)
+
+  // Resolve the target path
+  const resolvedPath = resolve(absoluteBase, ...paths)
+
+  // Check if the resolved path is inside the base path
+  const rel = relative(absoluteBase, resolvedPath)
+
+  // On Windows, relative can return an absolute path if on a different drive.
+  // We also check for '..' at the start to catch traversal.
+  // Note: '..foo' is a valid filename, so we check for '..' exact match or '..' followed by separator.
+  const isOutside =
+    rel === '..' ||
+    rel.startsWith(`..${sep}`) ||
+    (process.platform === 'win32' && isAbsolute(rel))
+
+  if (isOutside) {
+    throw new GodotMCPError(
+      'Access denied: Path traversal detected',
+      'INVALID_ARGS',
+      `Path '${paths.join('/')}' resolves to '${resolvedPath}', which is outside the project directory '${absoluteBase}'`
+    )
+  }
+
+  return resolvedPath
+}

--- a/tests/helpers/paths.test.ts
+++ b/tests/helpers/paths.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { join, resolve, sep } from 'node:path'
+import { safeResolve } from '../../src/tools/helpers/paths.js'
+
+describe('safeResolve', () => {
+  const basePath = resolve('test-project')
+
+  it('should resolve simple relative paths', () => {
+    const result = safeResolve(basePath, 'scene.tscn')
+    expect(result).toBe(resolve(basePath, 'scene.tscn'))
+  })
+
+  it('should resolve nested relative paths', () => {
+    const result = safeResolve(basePath, 'scenes/level1/map.tscn')
+    expect(result).toBe(resolve(basePath, 'scenes/level1/map.tscn'))
+  })
+
+  it('should handle parent directory references that stay inside', () => {
+    const result = safeResolve(basePath, 'scenes/../utils.gd')
+    expect(result).toBe(resolve(basePath, 'utils.gd'))
+  })
+
+  it('should throw on parent directory traversal', () => {
+    expect(() => safeResolve(basePath, '../outside.txt')).toThrow('Access denied')
+  })
+
+  it('should throw on multiple parent directory traversal', () => {
+    expect(() => safeResolve(basePath, 'scenes/../../outside.txt')).toThrow('Access denied')
+  })
+
+  it('should throw on absolute path outside base', () => {
+    const outsidePath = resolve(basePath, '..', 'outside.txt')
+    expect(() => safeResolve(basePath, outsidePath)).toThrow('Access denied')
+  })
+
+  it('should allow absolute path inside base', () => {
+    const insidePath = resolve(basePath, 'inside.txt')
+    const result = safeResolve(basePath, insidePath)
+    expect(result).toBe(insidePath)
+  })
+
+  it('should handle empty path (resolves to base)', () => {
+    const result = safeResolve(basePath, '')
+    expect(result).toBe(basePath)
+  })
+
+  it('should handle . path (resolves to base)', () => {
+    const result = safeResolve(basePath, '.')
+    expect(result).toBe(basePath)
+  })
+
+  it('should prevent access to root', () => {
+    expect(() => safeResolve(basePath, '/')).toThrow('Access denied')
+  })
+
+  // Windows specific test (will only run if on Windows or mocked)
+  // Since we are likely on Linux, we can mock process.platform if needed, but vitest runs in strict mode.
+  // We rely on the logic being correct.
+})

--- a/tests/helpers/paths.test.ts
+++ b/tests/helpers/paths.test.ts
@@ -1,5 +1,5 @@
+import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { join, resolve, sep } from 'node:path'
 import { safeResolve } from '../../src/tools/helpers/paths.js'
 
 describe('safeResolve', () => {


### PR DESCRIPTION
🛡️ Fixed path traversal vulnerability in scenes tool

**Issue:**
The `scenes` tool was vulnerable to path traversal attacks because it used `path.resolve` without validating that the resulting path was within the intended project directory. An attacker could potentially access or overwrite files outside the project scope using relative paths (e.g., `../../etc/passwd`).

**Solution:**
- Created a new security utility `safeResolve` in `src/tools/helpers/paths.ts`.
  - This function resolves paths relative to a base directory and throws an error if the result escapes the base.
  - It handles relative paths (`..`), absolute paths on different drives (Windows), and enforces strict boundary checks.
- Updated `src/tools/composite/scenes.ts` to use `safeResolve` for all file operations involving user-supplied paths.
- Added comprehensive unit tests in `tests/helpers/paths.test.ts` to verify `safeResolve` behavior against various attack vectors.
- Verified that existing scene operations still work correctly with regression tests.

**Risk:**
This was a High severity vulnerability as it allowed arbitrary file system access within the context of the running process.

**Verification:**
- `bun test tests/helpers/paths.test.ts` passed (10 tests).
- `bun test tests/composite/scenes.test.ts` passed (14 tests).

---
*PR created automatically by Jules for task [2572052680376665549](https://jules.google.com/task/2572052680376665549) started by @n24q02m*