### PR TITLE
🔒 Fix path traversal in resource deletion

### DIFF
--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -5,9 +5,9 @@
 
 import { existsSync, readdirSync, readFileSync, statSync, unlinkSync } from 'node:fs'
 import { extname, join, relative, resolve } from 'node:path'
-import { safeResolve } from '../helpers/paths.js'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const RESOURCE_EXTENSIONS = new Set([
   '.tres',
@@ -73,7 +73,7 @@ export async function handleResources(action: string, args: Record<string, unkno
 
       const resources = findResourceFiles(resolvedPath, exts)
       const relativePaths = resources.map((r) => ({
-        path: relative(resolvedPath, r).replace(/\\/g, '/'),
+        path: relative(resolvedPath, r).replace(/\\/g, "/"),
         ext: extname(r),
         size: statSync(r).size,
       }))

--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -5,6 +5,7 @@
 
 import { existsSync, readdirSync, readFileSync, statSync, unlinkSync } from 'node:fs'
 import { extname, join, relative, resolve } from 'node:path'
+import { safeResolve } from '../helpers/paths.js'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 
@@ -83,7 +84,8 @@ export async function handleResources(action: string, args: Record<string, unkno
     case 'info': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-      const fullPath = projectPath ? resolve(projectPath, resPath) : resolve(resPath)
+      const basePath = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(basePath, resPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
@@ -111,7 +113,8 @@ export async function handleResources(action: string, args: Record<string, unkno
     case 'delete': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-      const fullPath = projectPath ? resolve(projectPath, resPath) : resolve(resPath)
+      const basePath = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(basePath, resPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
@@ -127,7 +130,8 @@ export async function handleResources(action: string, args: Record<string, unkno
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
 
-      const importPath = projectPath ? resolve(projectPath, `${resPath}.import`) : resolve(`${resPath}.import`)
+      const basePath = projectPath ? resolve(projectPath) : process.cwd()
+      const importPath = safeResolve(basePath, `${resPath}.import`)
 
       if (!existsSync(importPath)) {
         return formatJSON({ path: resPath, imported: false, message: 'No .import file found.' })

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,0 +1,28 @@
+import { isAbsolute, relative, resolve } from 'node:path'
+import { GodotMCPError } from './errors.js'
+
+/**
+ * Safely resolves a path ensuring it stays within the base directory.
+ * Prevents path traversal attacks.
+ *
+ * @param basePath - The base directory to resolve against.
+ * @param relativePath - The relative path to resolve.
+ * @returns The resolved absolute path.
+ * @throws GodotMCPError if the resolved path is outside the base directory.
+ */
+export function safeResolve(basePath: string, relativePath: string): string {
+  const resolvedBase = resolve(basePath)
+  const resolvedPath = resolve(resolvedBase, relativePath)
+
+  const rel = relative(resolvedBase, resolvedPath)
+  const isSafe = !rel.startsWith('..') && !isAbsolute(rel)
+
+  if (!isSafe) {
+    throw new GodotMCPError(
+      `Access denied: Path traversal detected. Resolved path '${resolvedPath}' is outside base directory '${resolvedBase}'`,
+      'INVALID_ARGS',
+      'Ensure resource_path is within the project directory.',
+    )
+  }
+  return resolvedPath
+}

--- a/tests/security/path-traversal.test.ts
+++ b/tests/security/path-traversal.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { handleResources } from '../../src/tools/composite/resources';
+import { createTmpProject, makeConfig } from '../fixtures';
+import { writeFileSync, existsSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+describe('Vulnerability Reproduction: Path Traversal in handleResources delete', () => {
+  it('should PREVENT deleting a file outside the project directory', async () => {
+    // 1. Create a "project" directory
+    const { projectPath, cleanup } = createTmpProject();
+    const config = makeConfig({ projectPath });
+
+    // 2. Create a "victim" directory OUTSIDE the project directory
+    const victimDir = join(tmpdir(), 'godot-mcp-victim-' + Date.now());
+    mkdirSync(victimDir);
+    const victimFile = join(victimDir, 'secret.txt');
+    writeFileSync(victimFile, 'This file should NOT be deleted!', 'utf-8');
+
+    // 3. Construct a malicious path using traversal to reach the victim file
+    const maliciousPath = require('path').relative(projectPath, victimFile);
+
+    // 4. Attempt to delete the victim file via handleResources
+    // We expect this to throw an error now due to safeResolve
+    let errorThrown = false;
+    try {
+      await handleResources('delete', { resource_path: maliciousPath, project_path: projectPath }, config);
+    } catch (error: any) {
+      errorThrown = true;
+      expect(error.message).toContain('Access denied');
+    }
+
+    expect(errorThrown).toBe(true);
+
+    // 5. Assert that the file is STILL THERE
+    const fileExists = existsSync(victimFile);
+
+    // Cleanup first
+    rmSync(victimDir, { recursive: true, force: true });
+    cleanup();
+
+    expect(fileExists).toBe(true);
+  });
+});

--- a/tests/security/path-traversal.test.ts
+++ b/tests/security/path-traversal.test.ts
@@ -1,44 +1,47 @@
-import { describe, it, expect } from 'vitest';
-import { handleResources } from '../../src/tools/composite/resources';
-import { createTmpProject, makeConfig } from '../fixtures';
-import { writeFileSync, existsSync, mkdirSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { relative } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { handleResources } from '../../src/tools/composite/resources.js'
+import { createTmpProject, makeConfig } from '../fixtures.js'
 
 describe('Vulnerability Reproduction: Path Traversal in handleResources delete', () => {
   it('should PREVENT deleting a file outside the project directory', async () => {
     // 1. Create a "project" directory
-    const { projectPath, cleanup } = createTmpProject();
-    const config = makeConfig({ projectPath });
+    const { projectPath, cleanup } = createTmpProject()
+    const config = makeConfig({ projectPath })
 
     // 2. Create a "victim" directory OUTSIDE the project directory
-    const victimDir = join(tmpdir(), 'godot-mcp-victim-' + Date.now());
-    mkdirSync(victimDir);
-    const victimFile = join(victimDir, 'secret.txt');
-    writeFileSync(victimFile, 'This file should NOT be deleted!', 'utf-8');
+    const victimDir = join(tmpdir(), `godot-mcp-victim-${Date.now()}`)
+    mkdirSync(victimDir)
+    const victimFile = join(victimDir, 'secret.txt')
+    writeFileSync(victimFile, 'This file should NOT be deleted!', 'utf-8')
 
     // 3. Construct a malicious path using traversal to reach the victim file
-    const maliciousPath = require('path').relative(projectPath, victimFile);
+    const maliciousPath = relative(projectPath, victimFile)
 
     // 4. Attempt to delete the victim file via handleResources
     // We expect this to throw an error now due to safeResolve
-    let errorThrown = false;
+    let errorThrown = false
     try {
-      await handleResources('delete', { resource_path: maliciousPath, project_path: projectPath }, config);
-    } catch (error: any) {
-      errorThrown = true;
-      expect(error.message).toContain('Access denied');
+      await handleResources('delete', { resource_path: maliciousPath, project_path: projectPath }, config)
+    } catch (error) {
+      errorThrown = true
+      if (error instanceof Error) {
+        expect(error.message).toContain('Access denied')
+      }
     }
 
-    expect(errorThrown).toBe(true);
+    expect(errorThrown).toBe(true)
 
     // 5. Assert that the file is STILL THERE
-    const fileExists = existsSync(victimFile);
+    const fileExists = existsSync(victimFile)
 
     // Cleanup first
-    rmSync(victimDir, { recursive: true, force: true });
-    cleanup();
+    rmSync(victimDir, { recursive: true, force: true })
+    cleanup()
 
-    expect(fileExists).toBe(true);
-  });
-});
+    expect(fileExists).toBe(true)
+  })
+})


### PR DESCRIPTION
**What:**
Fixed a path traversal vulnerability in `src/tools/composite/resources.ts`.

**Risk:**
An attacker could manipulate `resource_path` using `../` sequences to delete or access files outside the intended project directory.

**Solution:**
- Created `src/tools/helpers/paths.ts` with a `safeResolve` function that validates paths stay within the base directory.
- Updated `handleResources` in `src/tools/composite/resources.ts` to use `safeResolve` for `info`, `delete`, and `import_config` actions.
- Added a regression test `tests/security/path-traversal.test.ts` to verify the fix.

---
*PR created automatically by Jules for task [6570053392763251726](https://jules.google.com/task/6570053392763251726) started by @n24q02m*