### PR TITLE
🔒 Fix path traversal vulnerability in scripts tool

### DIFF
--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync,
 import { dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const SCRIPT_TEMPLATES: Record<string, string> = {
   Node: `extends Node
@@ -118,6 +119,7 @@ function findScriptFiles(dir: string): string[] {
 
 export async function handleScripts(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const projectPath = (args.project_path as string) || config.projectPath
+  const base = projectPath ? resolve(projectPath) : process.cwd()
 
   switch (action) {
     case 'create': {
@@ -127,7 +129,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       const extendsType = (args.extends as string) || 'Node'
       const content = (args.content as string) || getTemplate(extendsType)
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const fullPath = safeResolve(base, scriptPath)
       if (existsSync(fullPath)) {
         throw new GodotMCPError(
           `Script already exists: ${scriptPath}`,
@@ -145,7 +147,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       const scriptPath = args.script_path as string
       if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const fullPath = safeResolve(base, scriptPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
 
@@ -160,7 +162,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       if (content === undefined || content === null)
         throw new GodotMCPError('No content specified', 'INVALID_ARGS', 'Provide content to write.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const fullPath = safeResolve(base, scriptPath)
       mkdirSync(dirname(fullPath), { recursive: true })
       writeFileSync(fullPath, content, 'utf-8')
       return formatSuccess(`Written: ${scriptPath} (${content.length} chars)`)
@@ -178,7 +180,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
         )
       }
 
-      const sceneFullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const sceneFullPath = safeResolve(base, scenePath)
       if (!existsSync(sceneFullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
 
@@ -219,7 +221,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       if (!scriptPath)
         throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path to delete.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const fullPath = safeResolve(base, scriptPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
 

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,0 +1,29 @@
+import { resolve, sep } from 'node:path'
+import { GodotMCPError } from './errors.js'
+
+/**
+ * Safely resolves a path relative to a base directory, preventing path traversal.
+ *
+ * @param basePath - The base directory to resolve against.
+ * @param relativePath - The path to resolve.
+ * @returns The resolved absolute path.
+ * @throws {GodotMCPError} If the resolved path is outside the base directory.
+ */
+export function safeResolve(basePath: string, relativePath: string): string {
+  const resolvedBase = resolve(basePath)
+  const resolvedPath = resolve(resolvedBase, relativePath)
+
+  // Ensure the resolved path starts with the base path
+  // Handle case where base path is root or has trailing separator
+  const baseWithSep = resolvedBase.endsWith(sep) ? resolvedBase : resolvedBase + sep
+
+  if (resolvedPath !== resolvedBase && !resolvedPath.startsWith(baseWithSep)) {
+    throw new GodotMCPError(
+      `Path traversal detected: ${relativePath}`,
+      'INVALID_ARGS',
+      'Ensure the path is within the project directory.',
+    )
+  }
+
+  return resolvedPath
+}

--- a/tests/security/path-traversal.test.ts
+++ b/tests/security/path-traversal.test.ts
@@ -1,0 +1,89 @@
+import { writeFileSync, existsSync, rmSync, mkdirSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { handleScripts } from '../../src/tools/composite/scripts.js'
+import { createTmpProject, makeConfig } from '../fixtures.js'
+
+describe('Security: Path Traversal', () => {
+  let projectPath: string
+  let cleanup: () => void
+  let outsideDir: string
+  let outsideFile: string
+
+  beforeEach(() => {
+    const tmp = createTmpProject()
+    projectPath = tmp.projectPath
+    cleanup = tmp.cleanup
+
+    // Create a unique directory outside the project
+    const uniqueId = Math.random().toString(36).substring(7)
+    outsideDir = resolve(projectPath, `../outside_${uniqueId}`)
+
+    if (!existsSync(outsideDir)) {
+      mkdirSync(outsideDir)
+    }
+
+    outsideFile = join(outsideDir, 'secret.txt')
+    writeFileSync(outsideFile, 'secret data')
+  })
+
+  afterEach(() => {
+    cleanup()
+    // Force cleanup of outside dir
+    if (existsSync(outsideDir)) {
+      rmSync(outsideDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should prevent deleting files outside project directory', async () => {
+    const config = makeConfig({ projectPath })
+
+    try {
+      await handleScripts(
+        'delete',
+        {
+          project_path: projectPath,
+          script_path: `../${resolve(outsideDir).split('/').pop()}/secret.txt`
+        },
+        config
+      )
+    } catch (error: any) {
+      if (error.message.includes('Path traversal detected')) {
+        return
+      }
+    }
+
+    expect(existsSync(outsideFile)).toBe(true)
+  })
+
+  it('should prevent reading files outside project directory', async () => {
+    const config = makeConfig({ projectPath })
+    const outsideDirName = resolve(outsideDir).split('/').pop()
+
+    await expect(handleScripts(
+      'read',
+      {
+        project_path: projectPath,
+        script_path: `../${outsideDirName}/secret.txt`
+      },
+      config
+    )).rejects.toThrow(/Path traversal detected/)
+  })
+
+  it('should prevent writing files outside project directory', async () => {
+    const config = makeConfig({ projectPath })
+    const outsideDirName = resolve(outsideDir).split('/').pop()
+
+    await expect(handleScripts(
+      'write',
+      {
+        project_path: projectPath,
+        script_path: `../${outsideDirName}/new_secret.txt`,
+        content: 'hacked'
+      },
+      config
+    )).rejects.toThrow(/Path traversal detected/)
+
+    expect(existsSync(join(outsideDir, 'new_secret.txt'))).toBe(false)
+  })
+})


### PR DESCRIPTION
🔒 Fix path traversal vulnerability in scripts tool

This PR addresses a critical security vulnerability where the `scripts` tool allowed file operations (delete, read, write) outside the project directory via path traversal (e.g., `../../`).

Changes:
- Implemented `safeResolve` utility in `src/tools/helpers/paths.ts` to strictly validate that resolved paths are contained within the base directory.
- Refactored `src/tools/composite/scripts.ts` to use `safeResolve` for all file system operations (`create`, `read`, `write`, `attach`, `delete`).
- Added comprehensive security regression tests in `tests/security/path-traversal.test.ts`.

Verification:
- `tests/security/path-traversal.test.ts` passes (all attempts to access outside files are blocked).
- `tests/composite/scripts.test.ts` passes (existing functionality remains intact).


---
*PR created automatically by Jules for task [6586860851152599703](https://jules.google.com/task/6586860851152599703) started by @n24q02m*