### PR TITLE
Refactor nodes parsing to use centralized scene parser

### DIFF
--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -11,6 +11,7 @@
  * [connection signal="..." from="..." to="..." method="..."]
  */
 
+import type { SceneNode } from '../../godot/types.js'
 import { readFileSync, writeFileSync } from 'node:fs'
 
 export interface TscnHeader {
@@ -311,4 +312,26 @@ export function getNodeProperty(scene: ParsedScene, nodeName: string, property: 
  */
 export function writeScene(filePath: string, content: string): void {
   writeFileSync(filePath, content, 'utf-8')
+}
+
+/**
+ * Map SceneNodeInfo to SceneNode structure
+ */
+export function mapToSceneNode(info: SceneNodeInfo): SceneNode {
+  const properties = { ...info.properties }
+  const script = properties['script'] ?? null
+  if (script) {
+    delete properties['script']
+  }
+
+  // Determine type: explicit type > instance placeholder > generic Node
+  const type = info.type || (info.instance ? 'Instance' : 'Node')
+
+  return {
+    name: info.name,
+    type,
+    parent: info.parent ?? null,
+    properties,
+    script,
+  }
 }

--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -11,8 +11,9 @@
  * [connection signal="..." from="..." to="..." method="..."]
  */
 
-import type { SceneNode } from '../../godot/types.js'
 import { readFileSync, writeFileSync } from 'node:fs'
+import type { SceneNode } from '../../godot/types.js'
+
 
 export interface TscnHeader {
   format: number
@@ -319,9 +320,9 @@ export function writeScene(filePath: string, content: string): void {
  */
 export function mapToSceneNode(info: SceneNodeInfo): SceneNode {
   const properties = { ...info.properties }
-  const script = properties['script'] ?? null
+  const script = properties.script ?? null
   if (script) {
-    delete properties['script']
+    delete properties.script
   }
 
   // Determine type: explicit type > instance placeholder > generic Node

--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -14,7 +14,6 @@
 import { readFileSync, writeFileSync } from 'node:fs'
 import type { SceneNode } from '../../godot/types.js'
 
-
 export interface TscnHeader {
   format: number
   loadSteps: number


### PR DESCRIPTION
This PR refactors `src/tools/composite/nodes.ts` to remove duplicate scene parsing logic. It replaces the local `parseNodes` function with the centralized `parseSceneContent` utility from `src/tools/helpers/scene-parser.ts`. 

Key changes:
- `src/tools/helpers/scene-parser.ts`: exported a new helper function `mapToSceneNode` that maps the internal `SceneNodeInfo` structure to the public `SceneNode` interface.
- `src/tools/composite/nodes.ts`: removed `parseNodes` and updated `handleNodes` to use `parseSceneContent` and `mapToSceneNode`.

This change improves code health by eliminating duplication and fixes a subtle issue where the original regex-based parser ignored instance nodes (nodes without an explicit `type` attribute but with an `instance` attribute). The new implementation correctly identifies these as type 'Instance'.

---
*PR created automatically by Jules for task [884788634177227060](https://jules.google.com/task/884788634177227060) started by @n24q02m*