### PR TITLE
🧪 Add tests for headless Godot execution wrapper

### DIFF
--- a/tests/godot/headless.test.ts
+++ b/tests/godot/headless.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { execSync, spawn } from 'node:child_process'
+import { execGodotScript, execGodotSync, launchGodotEditor, runGodotProject } from '../../src/godot/headless.js'
+
+vi.mock('node:child_process', () => {
+  return {
+    execSync: vi.fn(),
+    spawn: vi.fn(),
+  }
+})
+
+describe('headless', () => {
+  const godotPath = '/usr/bin/godot'
+  const projectPath = '/path/to/project'
+  const scriptPath = 'res://scripts/test.gd'
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  describe('execGodotSync', () => {
+    it('should execute command successfully', () => {
+      vi.mocked(execSync).mockReturnValue('success output')
+
+      const result = execGodotSync(godotPath, ['--version'])
+
+      expect(execSync).toHaveBeenCalledWith(
+        `"${godotPath}" --version`,
+        expect.objectContaining({
+          timeout: 30000,
+          encoding: 'utf-8',
+        })
+      )
+      expect(result).toEqual({
+        success: true,
+        stdout: 'success output',
+        stderr: '',
+        exitCode: 0,
+      })
+    })
+
+    it('should use provided options', () => {
+      vi.mocked(execSync).mockReturnValue('')
+
+      execGodotSync(godotPath, ['--version'], { timeout: 5000, cwd: '/tmp' })
+
+      expect(execSync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          timeout: 5000,
+          cwd: '/tmp',
+        })
+      )
+    })
+
+    it('should handle execution error', () => {
+      const error = new Error('Command failed')
+      Object.assign(error, {
+        status: 1,
+        stdout: 'partial stdout',
+        stderr: 'error stderr',
+      })
+      vi.mocked(execSync).mockImplementation(() => {
+        throw error
+      })
+
+      const result = execGodotSync(godotPath, ['--version'])
+
+      expect(result).toEqual({
+        success: false,
+        stdout: 'partial stdout',
+        stderr: 'error stderr',
+        exitCode: 1,
+      })
+    })
+
+    it('should handle generic error', () => {
+        const error = new Error('Generic error')
+        vi.mocked(execSync).mockImplementation(() => {
+            throw error
+        })
+
+        const result = execGodotSync(godotPath, ['--version'])
+
+        expect(result).toEqual({
+            success: false,
+            stdout: '',
+            stderr: 'Generic error',
+            exitCode: 1
+        })
+    })
+  })
+
+  describe('execGodotScript', () => {
+    it('should verify argument construction', () => {
+        vi.mocked(execSync).mockReturnValue('{}')
+
+        execGodotScript(godotPath, scriptPath, projectPath, ['arg1', 'arg2'])
+
+        expect(execSync).toHaveBeenCalledWith(
+            `"${godotPath}" --headless --path ${projectPath} --script ${scriptPath} -- arg1 arg2`,
+            expect.any(Object)
+        )
+    })
+
+    it('should handle no args', () => {
+        vi.mocked(execSync).mockReturnValue('{}')
+
+        execGodotScript(godotPath, scriptPath, projectPath)
+
+        expect(execSync).toHaveBeenCalledWith(
+            `"${godotPath}" --headless --path ${projectPath} --script ${scriptPath}`,
+            expect.any(Object)
+        )
+    })
+  })
+
+  describe('runGodotProject', () => {
+    it('should spawn process and unref', () => {
+      const mockChild = {
+        unref: vi.fn(),
+        pid: 12345,
+      }
+      vi.mocked(spawn).mockReturnValue(mockChild as any)
+
+      const result = runGodotProject(godotPath, projectPath)
+
+      expect(spawn).toHaveBeenCalledWith(
+        godotPath,
+        ['--path', projectPath],
+        expect.objectContaining({
+          detached: true,
+          stdio: 'ignore',
+        })
+      )
+      expect(mockChild.unref).toHaveBeenCalled()
+      expect(result).toEqual({ pid: 12345 })
+    })
+  })
+
+  describe('launchGodotEditor', () => {
+    it('should spawn editor process and unref', () => {
+      const mockChild = {
+        unref: vi.fn(),
+        pid: 67890,
+      }
+      vi.mocked(spawn).mockReturnValue(mockChild as any)
+
+      const result = launchGodotEditor(godotPath, projectPath)
+
+      expect(spawn).toHaveBeenCalledWith(
+        godotPath,
+        ['--editor', '--path', projectPath],
+        expect.objectContaining({
+          detached: true,
+          stdio: 'ignore',
+        })
+      )
+      expect(mockChild.unref).toHaveBeenCalled()
+      expect(result).toEqual({ pid: 67890 })
+    })
+  })
+})

--- a/tests/godot/headless.test.ts
+++ b/tests/godot/headless.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { execSync, spawn } from 'node:child_process'
+import { type ChildProcess, execSync, spawn } from 'node:child_process'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { execGodotScript, execGodotSync, launchGodotEditor, runGodotProject } from '../../src/godot/headless.js'
 
 vi.mock('node:child_process', () => {
@@ -29,7 +29,7 @@ describe('headless', () => {
         expect.objectContaining({
           timeout: 30000,
           encoding: 'utf-8',
-        })
+        }),
       )
       expect(result).toEqual({
         success: true,
@@ -49,7 +49,7 @@ describe('headless', () => {
         expect.objectContaining({
           timeout: 5000,
           cwd: '/tmp',
-        })
+        }),
       )
     })
 
@@ -75,43 +75,43 @@ describe('headless', () => {
     })
 
     it('should handle generic error', () => {
-        const error = new Error('Generic error')
-        vi.mocked(execSync).mockImplementation(() => {
-            throw error
-        })
+      const error = new Error('Generic error')
+      vi.mocked(execSync).mockImplementation(() => {
+        throw error
+      })
 
-        const result = execGodotSync(godotPath, ['--version'])
+      const result = execGodotSync(godotPath, ['--version'])
 
-        expect(result).toEqual({
-            success: false,
-            stdout: '',
-            stderr: 'Generic error',
-            exitCode: 1
-        })
+      expect(result).toEqual({
+        success: false,
+        stdout: '',
+        stderr: 'Generic error',
+        exitCode: 1,
+      })
     })
   })
 
   describe('execGodotScript', () => {
     it('should verify argument construction', () => {
-        vi.mocked(execSync).mockReturnValue('{}')
+      vi.mocked(execSync).mockReturnValue('{}')
 
-        execGodotScript(godotPath, scriptPath, projectPath, ['arg1', 'arg2'])
+      execGodotScript(godotPath, scriptPath, projectPath, ['arg1', 'arg2'])
 
-        expect(execSync).toHaveBeenCalledWith(
-            `"${godotPath}" --headless --path ${projectPath} --script ${scriptPath} -- arg1 arg2`,
-            expect.any(Object)
-        )
+      expect(execSync).toHaveBeenCalledWith(
+        `"${godotPath}" --headless --path ${projectPath} --script ${scriptPath} -- arg1 arg2`,
+        expect.any(Object),
+      )
     })
 
     it('should handle no args', () => {
-        vi.mocked(execSync).mockReturnValue('{}')
+      vi.mocked(execSync).mockReturnValue('{}')
 
-        execGodotScript(godotPath, scriptPath, projectPath)
+      execGodotScript(godotPath, scriptPath, projectPath)
 
-        expect(execSync).toHaveBeenCalledWith(
-            `"${godotPath}" --headless --path ${projectPath} --script ${scriptPath}`,
-            expect.any(Object)
-        )
+      expect(execSync).toHaveBeenCalledWith(
+        `"${godotPath}" --headless --path ${projectPath} --script ${scriptPath}`,
+        expect.any(Object),
+      )
     })
   })
 
@@ -121,7 +121,7 @@ describe('headless', () => {
         unref: vi.fn(),
         pid: 12345,
       }
-      vi.mocked(spawn).mockReturnValue(mockChild as any)
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess)
 
       const result = runGodotProject(godotPath, projectPath)
 
@@ -131,7 +131,7 @@ describe('headless', () => {
         expect.objectContaining({
           detached: true,
           stdio: 'ignore',
-        })
+        }),
       )
       expect(mockChild.unref).toHaveBeenCalled()
       expect(result).toEqual({ pid: 12345 })
@@ -144,7 +144,7 @@ describe('headless', () => {
         unref: vi.fn(),
         pid: 67890,
       }
-      vi.mocked(spawn).mockReturnValue(mockChild as any)
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess)
 
       const result = launchGodotEditor(godotPath, projectPath)
 
@@ -154,7 +154,7 @@ describe('headless', () => {
         expect.objectContaining({
           detached: true,
           stdio: 'ignore',
-        })
+        }),
       )
       expect(mockChild.unref).toHaveBeenCalled()
       expect(result).toEqual({ pid: 67890 })


### PR DESCRIPTION
Added comprehensive test coverage for `src/godot/headless.ts`:
- Tested `execGodotSync` with mock `execSync` for success, failure, timeout, and cwd options.
- Tested `execGodotScript` argument construction.
- Tested `runGodotProject` with mock `spawn` for detached process handling.
- Tested `launchGodotEditor` with mock `spawn` for detached process handling.

Verified logic using Bun test runner in restricted environment. The implementation uses standard Vitest syntax compatible with the project's tooling.

---
*PR created automatically by Jules for task [12801242024798374529](https://jules.google.com/task/12801242024798374529) started by @n24q02m*