### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal vulnerability

### DIFF
--- a/src/tools/composite/animation.ts
+++ b/src/tools/composite/animation.ts
@@ -4,12 +4,13 @@
  */
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 function resolveScene(projectPath: string | null | undefined, scenePath: string): string {
-  const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+  const base = projectPath || process.cwd()
+  const fullPath = safeResolve(base, scenePath)
   if (!existsSync(fullPath))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
   return fullPath

--- a/src/tools/composite/navigation.ts
+++ b/src/tools/composite/navigation.ts
@@ -4,12 +4,13 @@
  */
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 function resolveScene(projectPath: string | null | undefined, scenePath: string): string {
-  const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+  const base = projectPath || process.cwd()
+  const fullPath = safeResolve(base, scenePath)
   if (!existsSync(fullPath))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
   return fullPath

--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -4,9 +4,9 @@
  */
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 import type { GodotConfig, SceneNode } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 import {
   getNodeProperty,
   parseSceneContent,
@@ -59,7 +59,8 @@ function parseNodes(content: string): SceneNode[] {
 }
 
 function resolveScenePath(projectPath: string | null | undefined, scenePath: string): string {
-  return projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+  const base = projectPath || process.cwd()
+  return safeResolve(base, scenePath)
 }
 
 export async function handleNodes(action: string, args: Record<string, unknown>, config: GodotConfig) {

--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -4,9 +4,9 @@
  */
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
-import { join, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 import { parseProjectSettings, setSettingInContent } from '../helpers/project-settings.js'
 
 export async function handlePhysics(action: string, args: Record<string, unknown>, config: GodotConfig) {
@@ -15,7 +15,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
   switch (action) {
     case 'layers': {
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
-      const configPath = join(resolve(projectPath), 'project.godot')
+      const configPath = safeResolve(projectPath, 'project.godot')
       if (!existsSync(configPath))
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify project path.')
 
@@ -43,7 +43,8 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       const collisionLayer = args.collision_layer as number
       const collisionMask = args.collision_mask as number
 
-      const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const base = projectPath || process.cwd()
+      const fullPath = safeResolve(base, scenePath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 
@@ -74,7 +75,8 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       const nodeName = args.name as string
       if (!nodeName) throw new GodotMCPError('No node name specified', 'INVALID_ARGS', 'Provide node name.')
 
-      const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const base = projectPath || process.cwd()
+      const fullPath = safeResolve(base, scenePath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 
@@ -106,7 +108,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       const name = args.name as string
       if (!name) throw new GodotMCPError('No name specified', 'INVALID_ARGS', 'Provide layer name.')
 
-      const configPath = join(resolve(projectPath), 'project.godot')
+      const configPath = safeResolve(projectPath, 'project.godot')
       if (!existsSync(configPath))
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify project path.')
 

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -5,10 +5,11 @@
 
 import { execSync } from 'node:child_process'
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
-import { join, resolve } from 'node:path'
+import { resolve } from 'node:path'
 import { execGodotSync, runGodotProject } from '../../godot/headless.js'
 import type { GodotConfig, ProjectInfo } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 import { getSetting, parseProjectSettings, setSettingInContent } from '../helpers/project-settings.js'
 
 function parseProjectGodot(projectPath: string): ProjectInfo {
@@ -113,7 +114,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (!key)
         throw new GodotMCPError('No key specified', 'INVALID_ARGS', 'Provide key (e.g., "application/config/name").')
 
-      const configPath = join(resolve(projectPath), 'project.godot')
+      const configPath = safeResolve(projectPath, 'project.godot')
       if (!existsSync(configPath))
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')
 
@@ -131,7 +132,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (!key || value === undefined)
         throw new GodotMCPError('key and value required', 'INVALID_ARGS', 'Provide key and value.')
 
-      const configPath = join(resolve(projectPath), 'project.godot')
+      const configPath = safeResolve(projectPath, 'project.godot')
       if (!existsSync(configPath))
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')
 
@@ -163,7 +164,7 @@ export async function handleProject(action: string, args: Record<string, unknown
         resolve(projectPath),
         '--export-release',
         preset,
-        resolve(projectPath, outputPath),
+        safeResolve(projectPath, outputPath),
       ])
 
       return formatSuccess(`Export complete: ${outputPath}\n${result.stdout}`)

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -5,7 +5,7 @@
 
 import { execSync } from 'node:child_process'
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { join, resolve } from 'node:path'
 import { execGodotSync, runGodotProject } from '../../godot/headless.js'
 import type { GodotConfig, ProjectInfo } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'

--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -7,6 +7,7 @@ import { existsSync, readdirSync, readFileSync, statSync, unlinkSync } from 'nod
 import { extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const RESOURCE_EXTENSIONS = new Set([
   '.tres',
@@ -83,7 +84,8 @@ export async function handleResources(action: string, args: Record<string, unkno
     case 'info': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-      const fullPath = projectPath ? resolve(projectPath, resPath) : resolve(resPath)
+      const base = projectPath || process.cwd()
+      const fullPath = safeResolve(base, resPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
@@ -111,7 +113,8 @@ export async function handleResources(action: string, args: Record<string, unkno
     case 'delete': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-      const fullPath = projectPath ? resolve(projectPath, resPath) : resolve(resPath)
+      const base = projectPath || process.cwd()
+      const fullPath = safeResolve(base, resPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
@@ -127,7 +130,8 @@ export async function handleResources(action: string, args: Record<string, unkno
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
 
-      const importPath = projectPath ? resolve(projectPath, `${resPath}.import`) : resolve(`${resPath}.import`)
+      const base = projectPath || process.cwd()
+      const importPath = safeResolve(base, `${resPath}.import`)
 
       if (!existsSync(importPath)) {
         return formatJSON({ path: resPath, imported: false, message: 'No .import file found.' })

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -16,6 +16,7 @@ import {
 import { basename, dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig, SceneInfo, SceneNode } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 import { setSettingInContent } from '../helpers/project-settings.js'
 
 /**
@@ -119,7 +120,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       const rootType = (args.root_type as string) || 'Node2D'
       const rootName = (args.root_name as string) || basename(scenePath, '.tscn')
 
-      const fullPath = resolve(projectPath, scenePath)
+      const fullPath = safeResolve(projectPath, scenePath)
       if (existsSync(fullPath)) {
         throw new GodotMCPError(
           `Scene already exists: ${scenePath}`,
@@ -155,7 +156,8 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       if (!scenePath) {
         throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path to parse.')
       }
-      const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const base = projectPath || process.cwd()
+      const fullPath = safeResolve(base, scenePath)
       if (!existsSync(fullPath)) {
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path and try again.')
       }
@@ -169,7 +171,8 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       if (!scenePath) {
         throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path to delete.')
       }
-      const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const base = projectPath || process.cwd()
+      const fullPath = safeResolve(base, scenePath)
       if (!existsSync(fullPath)) {
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
       }
@@ -188,8 +191,9 @@ export async function handleScenes(action: string, args: Record<string, unknown>
           'Provide source and destination paths.',
         )
       }
-      const srcFull = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
-      const dstFull = projectPath ? resolve(projectPath, newPath) : resolve(newPath)
+      const base = projectPath || process.cwd()
+      const srcFull = safeResolve(base, scenePath)
+      const dstFull = safeResolve(base, newPath)
       if (!existsSync(srcFull)) {
         throw new GodotMCPError(`Source scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the source path.')
       }
@@ -215,7 +219,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
         throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path to set as main.')
       }
 
-      const configPath = join(resolve(projectPath), 'project.godot')
+      const configPath = safeResolve(projectPath, 'project.godot')
       if (!existsSync(configPath)) {
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')
       }

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -4,7 +4,7 @@
  */
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs'
-import { dirname, extname, join, relative, resolve } from 'node:path'
+import { dirname, extname, join, relative } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
@@ -212,7 +212,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       if (!projectPath)
         throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
 
-      const resolvedPath = resolve(projectPath)
+      const resolvedPath = safeResolve(projectPath, '.')
       const scripts = findScriptFiles(resolvedPath)
       const relativePaths = scripts.map((s) => relative(resolvedPath, s).replace(/\\/g, '/'))
 

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync,
 import { dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const SCRIPT_TEMPLATES: Record<string, string> = {
   Node: `extends Node
@@ -127,7 +128,8 @@ export async function handleScripts(action: string, args: Record<string, unknown
       const extendsType = (args.extends as string) || 'Node'
       const content = (args.content as string) || getTemplate(extendsType)
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const base = projectPath || process.cwd()
+      const fullPath = safeResolve(base, scriptPath)
       if (existsSync(fullPath)) {
         throw new GodotMCPError(
           `Script already exists: ${scriptPath}`,
@@ -145,7 +147,8 @@ export async function handleScripts(action: string, args: Record<string, unknown
       const scriptPath = args.script_path as string
       if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const base = projectPath || process.cwd()
+      const fullPath = safeResolve(base, scriptPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
 
@@ -160,7 +163,8 @@ export async function handleScripts(action: string, args: Record<string, unknown
       if (content === undefined || content === null)
         throw new GodotMCPError('No content specified', 'INVALID_ARGS', 'Provide content to write.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const base = projectPath || process.cwd()
+      const fullPath = safeResolve(base, scriptPath)
       mkdirSync(dirname(fullPath), { recursive: true })
       writeFileSync(fullPath, content, 'utf-8')
       return formatSuccess(`Written: ${scriptPath} (${content.length} chars)`)
@@ -178,7 +182,8 @@ export async function handleScripts(action: string, args: Record<string, unknown
         )
       }
 
-      const sceneFullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const base = projectPath || process.cwd()
+      const sceneFullPath = safeResolve(base, scenePath)
       if (!existsSync(sceneFullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
 
@@ -219,7 +224,8 @@ export async function handleScripts(action: string, args: Record<string, unknown
       if (!scriptPath)
         throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path to delete.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const base = projectPath || process.cwd()
+      const fullPath = safeResolve(base, scriptPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
 

--- a/src/tools/composite/shader.ts
+++ b/src/tools/composite/shader.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSy
 import { dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const SHADER_TEMPLATES: Record<string, string> = {
   canvas_item: `shader_type canvas_item;
@@ -83,7 +84,8 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderType = (args.shader_type as string) || 'canvas_item'
       const content = (args.content as string) || SHADER_TEMPLATES[shaderType] || SHADER_TEMPLATES.canvas_item
 
-      const fullPath = projectPath ? resolve(projectPath, shaderPath) : resolve(shaderPath)
+      const base = projectPath || process.cwd()
+      const fullPath = safeResolve(base, shaderPath)
       if (existsSync(fullPath))
         throw new GodotMCPError(`Shader already exists: ${shaderPath}`, 'SHADER_ERROR', 'Use write action to modify.')
 
@@ -96,7 +98,8 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderPath = args.shader_path as string
       if (!shaderPath) throw new GodotMCPError('No shader_path specified', 'INVALID_ARGS', 'Provide shader_path.')
 
-      const fullPath = projectPath ? resolve(projectPath, shaderPath) : resolve(shaderPath)
+      const base = projectPath || process.cwd()
+      const fullPath = safeResolve(base, shaderPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Shader not found: ${shaderPath}`, 'SHADER_ERROR', 'Check the file path.')
 
@@ -110,7 +113,8 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const content = args.content as string
       if (!content) throw new GodotMCPError('No content specified', 'INVALID_ARGS', 'Provide shader content.')
 
-      const fullPath = projectPath ? resolve(projectPath, shaderPath) : resolve(shaderPath)
+      const base = projectPath || process.cwd()
+      const fullPath = safeResolve(base, shaderPath)
       mkdirSync(dirname(fullPath), { recursive: true })
       writeFileSync(fullPath, content, 'utf-8')
       return formatSuccess(`Written: ${shaderPath} (${content.length} chars)`)
@@ -120,7 +124,8 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderPath = args.shader_path as string
       if (!shaderPath) throw new GodotMCPError('No shader_path specified', 'INVALID_ARGS', 'Provide shader_path.')
 
-      const fullPath = projectPath ? resolve(projectPath, shaderPath) : resolve(shaderPath)
+      const base = projectPath || process.cwd()
+      const fullPath = safeResolve(base, shaderPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Shader not found: ${shaderPath}`, 'SHADER_ERROR', 'Check the file path.')
 

--- a/src/tools/composite/shader.ts
+++ b/src/tools/composite/shader.ts
@@ -4,7 +4,7 @@
  */
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
-import { dirname, extname, join, relative, resolve } from 'node:path'
+import { dirname, extname, join, relative } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
@@ -153,7 +153,7 @@ export async function handleShader(action: string, args: Record<string, unknown>
     case 'list': {
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
 
-      const resolvedPath = resolve(projectPath)
+      const resolvedPath = safeResolve(projectPath, '.')
       const shaders = findShaderFiles(resolvedPath)
       const relativePaths = shaders.map((s) => relative(resolvedPath, s).replace(/\\/g, '/'))
 

--- a/src/tools/composite/signals.ts
+++ b/src/tools/composite/signals.ts
@@ -4,9 +4,9 @@
  */
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 import { parseSceneContent } from '../helpers/scene-parser.js'
 
 export async function handleSignals(action: string, args: Record<string, unknown>, config: GodotConfig) {
@@ -14,7 +14,8 @@ export async function handleSignals(action: string, args: Record<string, unknown
   const scenePath = args.scene_path as string
 
   if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
-  const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+  const base = projectPath || process.cwd()
+  const fullPath = safeResolve(base, scenePath)
   if (!existsSync(fullPath))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
 

--- a/src/tools/composite/tilemap.ts
+++ b/src/tools/composite/tilemap.ts
@@ -4,7 +4,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
+import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'

--- a/src/tools/composite/tilemap.ts
+++ b/src/tools/composite/tilemap.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 export async function handleTilemap(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const projectPath = (args.project_path as string) || config.projectPath
@@ -22,7 +23,8 @@ export async function handleTilemap(action: string, args: Record<string, unknown
         )
       const tileSize = (args.tile_size as number) || 16
 
-      const fullPath = projectPath ? resolve(projectPath, tilesetPath) : resolve(tilesetPath)
+      const base = projectPath || process.cwd()
+      const fullPath = safeResolve(base, tilesetPath)
       if (existsSync(fullPath)) {
         throw new GodotMCPError(`TileSet already exists: ${tilesetPath}`, 'TILEMAP_ERROR', 'Use a different path.')
       }
@@ -48,7 +50,8 @@ export async function handleTilemap(action: string, args: Record<string, unknown
         throw new GodotMCPError('tileset_path and texture_path required', 'INVALID_ARGS', 'Both are required.')
       }
 
-      const fullPath = projectPath ? resolve(projectPath, tilesetPath) : resolve(tilesetPath)
+      const base = projectPath || process.cwd()
+      const fullPath = safeResolve(base, tilesetPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`TileSet not found: ${tilesetPath}`, 'TILEMAP_ERROR', 'Create the tileset first.')
 
@@ -91,7 +94,8 @@ export async function handleTilemap(action: string, args: Record<string, unknown
       const scenePath = args.scene_path as string
       if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
 
-      const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const base = projectPath || process.cwd()
+      const fullPath = safeResolve(base, scenePath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
 

--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
   Button: { text: '"Click"' },
@@ -30,7 +31,8 @@ const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
 }
 
 function resolveScene(projectPath: string | null | undefined, scenePath: string): string {
-  const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+  const base = projectPath || process.cwd()
+  const fullPath = safeResolve(base, scenePath)
   if (!existsSync(fullPath))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
   return fullPath
@@ -86,7 +88,8 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
           'Provide theme_path (e.g., "themes/main.tres").',
         )
 
-      const fullPath = projectPath ? resolve(projectPath, themePath) : resolve(themePath)
+      const base = projectPath || process.cwd()
+      const fullPath = safeResolve(base, themePath)
 
       const fontSize = (args.font_size as number) || 16
       const _fontColor = (args.font_color as string) || 'Color(1, 1, 1, 1)'

--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -4,7 +4,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
+import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -24,6 +24,7 @@ export type GodotMCPErrorCode =
   | 'AUDIO_ERROR'
   | 'NAVIGATION_ERROR'
   | 'UI_ERROR'
+  | 'ACCESS_DENIED'
 
 export class GodotMCPError extends Error {
   constructor(

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,0 +1,27 @@
+import { isAbsolute, relative, resolve, sep } from 'node:path'
+import { GodotMCPError } from './errors.js'
+
+/**
+ * Safely resolves a path relative to a base directory, ensuring it doesn't escape the base.
+ *
+ * @param basePath The base directory (e.g., project root)
+ * @param targetPath The path to resolve (can be relative or absolute)
+ * @returns The resolved absolute path
+ * @throws GodotMCPError if the path attempts to traverse outside the base directory
+ */
+export function safeResolve(basePath: string, targetPath: string): string {
+  const resolvedBase = resolve(basePath)
+  const resolvedTarget = resolve(resolvedBase, targetPath)
+  const rel = relative(resolvedBase, resolvedTarget)
+
+  // Check if path is outside (starts with ..) or is absolute on different drive (win32)
+  if ((rel.startsWith('..') && (rel === '..' || rel.startsWith(`..${sep}`))) || isAbsolute(rel)) {
+    throw new GodotMCPError(
+      `Access denied: Path '${targetPath}' resolves to '${resolvedTarget}', which is outside the project root '${resolvedBase}'`,
+      'ACCESS_DENIED',
+      'Ensure the path is within the project directory.',
+    )
+  }
+
+  return resolvedTarget
+}

--- a/tests/security/path-traversal.test.ts
+++ b/tests/security/path-traversal.test.ts
@@ -1,0 +1,70 @@
+import { existsSync, unlinkSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleScripts } from '../../src/tools/composite/scripts.js'
+import { createTmpProject, makeConfig } from '../fixtures.js'
+
+describe('Security: Path Traversal', () => {
+  let projectPath: string
+  let cleanup: () => void
+  let config: GodotConfig
+
+  beforeEach(() => {
+    const tmp = createTmpProject()
+    projectPath = tmp.projectPath
+    cleanup = tmp.cleanup
+    config = makeConfig({ projectPath })
+  })
+
+  afterEach(() => cleanup())
+
+  it('should prevent creating a script outside the project directory', async () => {
+    // Attempt to create a script in the parent directory of the project
+    const exploitPath = '../exploit.gd'
+    const fullExploitPath = resolve(projectPath, exploitPath)
+
+    // Clean up if it exists from previous runs
+    if (existsSync(fullExploitPath)) {
+      unlinkSync(fullExploitPath)
+    }
+
+    // This should THROW an error if secure.
+    await expect(
+      handleScripts(
+        'create',
+        {
+          project_path: projectPath,
+          script_path: exploitPath,
+        },
+        config,
+      ),
+    ).rejects.toThrow(/Access denied|outside of project/i)
+
+    // verify file was not created
+    expect(existsSync(fullExploitPath)).toBe(false)
+
+    // Final cleanup just in case
+    if (existsSync(fullExploitPath)) {
+      unlinkSync(fullExploitPath)
+    }
+  })
+
+  it('should prevent reading a script outside the project directory', async () => {
+    // Create a sensitive file outside project root
+    const outsideFile = join(projectPath, '../secret.txt')
+    writeFileSync(outsideFile, 'secret data', 'utf-8')
+
+    // Try to read it
+    await expect(
+      handleScripts(
+        'read',
+        {
+          project_path: projectPath,
+          script_path: '../secret.txt',
+        },
+        config,
+      ),
+    ).rejects.toThrow(/Access denied|outside of project/i)
+  })
+})


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Path traversal in multiple MCP tools allowed file access outside the project directory via `../`.
🎯 Impact: Attackers could read/write arbitrary files on the system if the server process has permissions.
🔧 Fix: Implemented `safeResolve` helper in `src/tools/helpers/paths.ts` and refactored all vulnerable tools (`scenes`, `scripts`, `shader`, etc.) to use it.
✅ Verification: Added `tests/security/path-traversal.test.ts` which confirms the fix.

---
*PR created automatically by Jules for task [1732808882096208555](https://jules.google.com/task/1732808882096208555) started by @n24q02m*