### PR TITLE
🛡️ Sentinel: Fix path traversal vulnerability

### DIFF
--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -16,6 +16,7 @@ import {
 import { basename, dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig, SceneInfo, SceneNode } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 import { setSettingInContent } from '../helpers/project-settings.js'
 
 /**
@@ -119,7 +120,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       const rootType = (args.root_type as string) || 'Node2D'
       const rootName = (args.root_name as string) || basename(scenePath, '.tscn')
 
-      const fullPath = resolve(projectPath, scenePath)
+      const fullPath = safeResolve(resolve(projectPath), scenePath)
       if (existsSync(fullPath)) {
         throw new GodotMCPError(
           `Scene already exists: ${scenePath}`,
@@ -155,7 +156,8 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       if (!scenePath) {
         throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path to parse.')
       }
-      const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const basePath = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(basePath, scenePath)
       if (!existsSync(fullPath)) {
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path and try again.')
       }
@@ -169,7 +171,8 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       if (!scenePath) {
         throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path to delete.')
       }
-      const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const basePath = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(basePath, scenePath)
       if (!existsSync(fullPath)) {
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
       }
@@ -188,8 +191,9 @@ export async function handleScenes(action: string, args: Record<string, unknown>
           'Provide source and destination paths.',
         )
       }
-      const srcFull = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
-      const dstFull = projectPath ? resolve(projectPath, newPath) : resolve(newPath)
+      const basePath = projectPath ? resolve(projectPath) : process.cwd()
+      const srcFull = safeResolve(basePath, scenePath)
+      const dstFull = safeResolve(basePath, newPath)
       if (!existsSync(srcFull)) {
         throw new GodotMCPError(`Source scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the source path.')
       }

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync,
 import { dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const SCRIPT_TEMPLATES: Record<string, string> = {
   Node: `extends Node
@@ -127,7 +128,8 @@ export async function handleScripts(action: string, args: Record<string, unknown
       const extendsType = (args.extends as string) || 'Node'
       const content = (args.content as string) || getTemplate(extendsType)
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const basePath = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(basePath, scriptPath)
       if (existsSync(fullPath)) {
         throw new GodotMCPError(
           `Script already exists: ${scriptPath}`,
@@ -145,7 +147,8 @@ export async function handleScripts(action: string, args: Record<string, unknown
       const scriptPath = args.script_path as string
       if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const basePath = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(basePath, scriptPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
 
@@ -160,7 +163,8 @@ export async function handleScripts(action: string, args: Record<string, unknown
       if (content === undefined || content === null)
         throw new GodotMCPError('No content specified', 'INVALID_ARGS', 'Provide content to write.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const basePath = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(basePath, scriptPath)
       mkdirSync(dirname(fullPath), { recursive: true })
       writeFileSync(fullPath, content, 'utf-8')
       return formatSuccess(`Written: ${scriptPath} (${content.length} chars)`)
@@ -178,7 +182,8 @@ export async function handleScripts(action: string, args: Record<string, unknown
         )
       }
 
-      const sceneFullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const basePath = projectPath ? resolve(projectPath) : process.cwd()
+      const sceneFullPath = safeResolve(basePath, scenePath)
       if (!existsSync(sceneFullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
 
@@ -219,7 +224,8 @@ export async function handleScripts(action: string, args: Record<string, unknown
       if (!scriptPath)
         throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path to delete.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const basePath = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(basePath, scriptPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
 

--- a/src/tools/composite/shader.ts
+++ b/src/tools/composite/shader.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSy
 import { dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const SHADER_TEMPLATES: Record<string, string> = {
   canvas_item: `shader_type canvas_item;
@@ -83,7 +84,8 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderType = (args.shader_type as string) || 'canvas_item'
       const content = (args.content as string) || SHADER_TEMPLATES[shaderType] || SHADER_TEMPLATES.canvas_item
 
-      const fullPath = projectPath ? resolve(projectPath, shaderPath) : resolve(shaderPath)
+      const basePath = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(basePath, shaderPath)
       if (existsSync(fullPath))
         throw new GodotMCPError(`Shader already exists: ${shaderPath}`, 'SHADER_ERROR', 'Use write action to modify.')
 
@@ -96,7 +98,8 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderPath = args.shader_path as string
       if (!shaderPath) throw new GodotMCPError('No shader_path specified', 'INVALID_ARGS', 'Provide shader_path.')
 
-      const fullPath = projectPath ? resolve(projectPath, shaderPath) : resolve(shaderPath)
+      const basePath = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(basePath, shaderPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Shader not found: ${shaderPath}`, 'SHADER_ERROR', 'Check the file path.')
 
@@ -110,7 +113,8 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const content = args.content as string
       if (!content) throw new GodotMCPError('No content specified', 'INVALID_ARGS', 'Provide shader content.')
 
-      const fullPath = projectPath ? resolve(projectPath, shaderPath) : resolve(shaderPath)
+      const basePath = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(basePath, shaderPath)
       mkdirSync(dirname(fullPath), { recursive: true })
       writeFileSync(fullPath, content, 'utf-8')
       return formatSuccess(`Written: ${shaderPath} (${content.length} chars)`)
@@ -120,7 +124,8 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderPath = args.shader_path as string
       if (!shaderPath) throw new GodotMCPError('No shader_path specified', 'INVALID_ARGS', 'Provide shader_path.')
 
-      const fullPath = projectPath ? resolve(projectPath, shaderPath) : resolve(shaderPath)
+      const basePath = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(basePath, shaderPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Shader not found: ${shaderPath}`, 'SHADER_ERROR', 'Check the file path.')
 

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -24,6 +24,7 @@ export type GodotMCPErrorCode =
   | 'AUDIO_ERROR'
   | 'NAVIGATION_ERROR'
   | 'UI_ERROR'
+  | 'ACCESS_DENIED'
 
 export class GodotMCPError extends Error {
   constructor(

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,0 +1,25 @@
+import { isAbsolute, relative, resolve } from 'node:path'
+import { GodotMCPError } from './errors.js'
+
+/**
+ * Safely resolves a path relative to a base directory, preventing directory traversal.
+ * @param basePath The trusted base directory (e.g. project root)
+ * @param relativePath The path provided by the user (potentially malicious)
+ * @returns The resolved absolute path
+ * @throws GodotMCPError if the resolved path is outside the base directory
+ */
+export function safeResolve(basePath: string, relativePath: string): string {
+  const resolved = resolve(basePath, relativePath)
+  const rel = relative(basePath, resolved)
+
+  // Check for path traversal (starts with ..) or absolute path pointing outside
+  if (rel.startsWith('..') || isAbsolute(rel)) {
+    throw new GodotMCPError(
+      `Access denied: Path traversal detected. "${relativePath}" resolves outside the project root.`,
+      'ACCESS_DENIED',
+      'Ensure the path is within the project directory.',
+    )
+  }
+
+  return resolved
+}


### PR DESCRIPTION
This PR addresses a critical path traversal vulnerability where malicious actors could access files outside the project directory using `../` sequences in file paths.

### Changes
1.  **New Utility:** Created `src/tools/helpers/paths.ts` with `safeResolve` function that checks if a resolved path is within the trusted base directory.
2.  **Error Handling:** Added `ACCESS_DENIED` error code to `GodotMCPErrorCode` in `src/tools/helpers/errors.ts`.
3.  **Tool Updates:** Refactored the following tools to use `safeResolve`:
    -   `scripts` (create, read, write, attach, delete)
    -   `scenes` (create, info, delete, duplicate)
    -   `shader` (create, read, write, get_params)

### Verification
-   Created a reproduction script `reproduce_traversal.ts` which confirmed the vulnerability before the fix and confirmed the fix (access denied) after.
-   Ran `bun test` on affected modules (`scripts`, `scenes`, `shader`) and all tests passed.


---
*PR created automatically by Jules for task [3843208836668181715](https://jules.google.com/task/3843208836668181715) started by @n24q02m*