### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal Vulnerability

### DIFF
--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -16,6 +16,7 @@ import {
 import { basename, dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig, SceneInfo, SceneNode } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 import { setSettingInContent } from '../helpers/project-settings.js'
 
 /**
@@ -119,7 +120,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       const rootType = (args.root_type as string) || 'Node2D'
       const rootName = (args.root_name as string) || basename(scenePath, '.tscn')
 
-      const fullPath = resolve(projectPath, scenePath)
+      const fullPath = safeResolve(projectPath, scenePath)
       if (existsSync(fullPath)) {
         throw new GodotMCPError(
           `Scene already exists: ${scenePath}`,
@@ -155,7 +156,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       if (!scenePath) {
         throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path to parse.')
       }
-      const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
       if (!existsSync(fullPath)) {
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path and try again.')
       }
@@ -169,7 +170,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       if (!scenePath) {
         throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path to delete.')
       }
-      const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
       if (!existsSync(fullPath)) {
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
       }
@@ -188,8 +189,8 @@ export async function handleScenes(action: string, args: Record<string, unknown>
           'Provide source and destination paths.',
         )
       }
-      const srcFull = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
-      const dstFull = projectPath ? resolve(projectPath, newPath) : resolve(newPath)
+      const srcFull = safeResolve(projectPath || process.cwd(), scenePath)
+      const dstFull = safeResolve(projectPath || process.cwd(), newPath)
       if (!existsSync(srcFull)) {
         throw new GodotMCPError(`Source scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the source path.')
       }

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync,
 import { dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const SCRIPT_TEMPLATES: Record<string, string> = {
   Node: `extends Node
@@ -127,7 +128,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       const extendsType = (args.extends as string) || 'Node'
       const content = (args.content as string) || getTemplate(extendsType)
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), scriptPath)
       if (existsSync(fullPath)) {
         throw new GodotMCPError(
           `Script already exists: ${scriptPath}`,
@@ -145,7 +146,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       const scriptPath = args.script_path as string
       if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), scriptPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
 
@@ -160,7 +161,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       if (content === undefined || content === null)
         throw new GodotMCPError('No content specified', 'INVALID_ARGS', 'Provide content to write.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), scriptPath)
       mkdirSync(dirname(fullPath), { recursive: true })
       writeFileSync(fullPath, content, 'utf-8')
       return formatSuccess(`Written: ${scriptPath} (${content.length} chars)`)
@@ -178,7 +179,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
         )
       }
 
-      const sceneFullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const sceneFullPath = safeResolve(projectPath || process.cwd(), scenePath)
       if (!existsSync(sceneFullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
 
@@ -219,7 +220,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       if (!scriptPath)
         throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path to delete.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), scriptPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
 

--- a/src/tools/composite/shader.ts
+++ b/src/tools/composite/shader.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSy
 import { dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const SHADER_TEMPLATES: Record<string, string> = {
   canvas_item: `shader_type canvas_item;
@@ -83,7 +84,7 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderType = (args.shader_type as string) || 'canvas_item'
       const content = (args.content as string) || SHADER_TEMPLATES[shaderType] || SHADER_TEMPLATES.canvas_item
 
-      const fullPath = projectPath ? resolve(projectPath, shaderPath) : resolve(shaderPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), shaderPath)
       if (existsSync(fullPath))
         throw new GodotMCPError(`Shader already exists: ${shaderPath}`, 'SHADER_ERROR', 'Use write action to modify.')
 
@@ -96,7 +97,7 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderPath = args.shader_path as string
       if (!shaderPath) throw new GodotMCPError('No shader_path specified', 'INVALID_ARGS', 'Provide shader_path.')
 
-      const fullPath = projectPath ? resolve(projectPath, shaderPath) : resolve(shaderPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), shaderPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Shader not found: ${shaderPath}`, 'SHADER_ERROR', 'Check the file path.')
 
@@ -110,7 +111,7 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const content = args.content as string
       if (!content) throw new GodotMCPError('No content specified', 'INVALID_ARGS', 'Provide shader content.')
 
-      const fullPath = projectPath ? resolve(projectPath, shaderPath) : resolve(shaderPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), shaderPath)
       mkdirSync(dirname(fullPath), { recursive: true })
       writeFileSync(fullPath, content, 'utf-8')
       return formatSuccess(`Written: ${shaderPath} (${content.length} chars)`)
@@ -120,7 +121,7 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderPath = args.shader_path as string
       if (!shaderPath) throw new GodotMCPError('No shader_path specified', 'INVALID_ARGS', 'Provide shader_path.')
 
-      const fullPath = projectPath ? resolve(projectPath, shaderPath) : resolve(shaderPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), shaderPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Shader not found: ${shaderPath}`, 'SHADER_ERROR', 'Check the file path.')
 

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -24,6 +24,7 @@ export type GodotMCPErrorCode =
   | 'AUDIO_ERROR'
   | 'NAVIGATION_ERROR'
   | 'UI_ERROR'
+  | 'ACCESS_DENIED'
 
 export class GodotMCPError extends Error {
   constructor(

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,0 +1,29 @@
+import { isAbsolute, relative, resolve } from 'node:path'
+import { GodotMCPError } from './errors.js'
+
+/**
+ * Safely resolves a path relative to a base directory (project root).
+ * Throws if the resolved path is outside the base directory.
+ *
+ * @param basePath - The root directory to confine access to (e.g., project path)
+ * @param userPath - The path provided by the user (relative or absolute)
+ * @returns The resolved absolute path
+ * @throws GodotMCPError if access is denied
+ */
+export function safeResolve(basePath: string, userPath: string): string {
+  const resolvedBase = resolve(basePath)
+  const resolvedPath = resolve(resolvedBase, userPath)
+  const rel = relative(resolvedBase, resolvedPath)
+
+  // specific check for .. at the start or if it's an absolute path on a different drive (Windows)
+  if (rel.startsWith('..') || isAbsolute(rel)) {
+    throw new GodotMCPError(
+      `Access denied: Path '${userPath}' resolves outside the project directory`,
+      'ACCESS_DENIED',
+      'Ensure all paths are relative to the project root and do not use parent directory references (..).',
+      { resolvedPath, basePath: resolvedBase },
+    )
+  }
+
+  return resolvedPath
+}

--- a/tests/security_path_traversal.test.ts
+++ b/tests/security_path_traversal.test.ts
@@ -1,0 +1,110 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, relative } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { handleScenes } from '../src/tools/composite/scenes.js'
+import { handleScripts } from '../src/tools/composite/scripts.js'
+import { handleShader } from '../src/tools/composite/shader.js'
+import { createTmpProject, makeConfig } from './fixtures.js'
+
+describe('Security: Path Traversal', () => {
+  let projectPath: string
+  let cleanupProject: () => void
+  let outsideDir: string
+  let secretFile: string
+
+  beforeEach(() => {
+    // Create a project directory
+    const project = createTmpProject()
+    projectPath = project.projectPath
+    cleanupProject = project.cleanup
+
+    // Create a directory outside the project
+    outsideDir = join(tmpdir(), `godot-mcp-secret-${Date.now()}`)
+    mkdirSync(outsideDir)
+    secretFile = join(outsideDir, 'secret.txt')
+    writeFileSync(secretFile, 'SUPER_SECRET_DATA')
+  })
+
+  afterEach(() => {
+    cleanupProject()
+    rmSync(outsideDir, { recursive: true, force: true })
+  })
+
+  it('should prevent reading scripts outside project directory', async () => {
+    const _relativePath = join('..', `godot-mcp-secret-${Date.now()}`, 'secret.txt')
+    // We need to calculate the relative path from projectPath to secretFile
+    // secretFile is /tmp/godot-mcp-secret-123/secret.txt
+    // projectPath is /tmp/godot-mcp-test-456
+    // path.relative(projectPath, secretFile) should give us ../godot-mcp-secret-123/secret.txt
+
+    // Actually, let's just use absolute path to be sure, or a constructed relative path.
+    // The tools currently do: resolve(projectPath, scriptPath)
+    // So if we pass a relative path that goes up, it should work if vulnerable.
+
+    const relativeSecretPath = relative(projectPath, secretFile)
+
+    await expect(
+      handleScripts(
+        'read',
+        {
+          project_path: projectPath,
+          script_path: relativeSecretPath,
+        },
+        makeConfig(),
+      ),
+    ).rejects.toThrow(/Access denied|outside project/)
+  })
+
+  it('should prevent writing scripts outside project directory', async () => {
+    const relativeSecretPath = relative(projectPath, secretFile)
+
+    await expect(
+      handleScripts(
+        'write',
+        {
+          project_path: projectPath,
+          script_path: relativeSecretPath,
+          content: 'hacked',
+        },
+        makeConfig(),
+      ),
+    ).rejects.toThrow(/Access denied|outside project/)
+  })
+
+  it('should prevent reading scenes outside project directory', async () => {
+    // Create a dummy scene outside
+    const outsideScene = join(outsideDir, 'secret.tscn')
+    writeFileSync(outsideScene, '[gd_scene format=3]\n[node name="Secret" type="Node"]\n')
+    const relativeSecretPath = relative(projectPath, outsideScene)
+
+    await expect(
+      handleScenes(
+        'info',
+        {
+          project_path: projectPath,
+          scene_path: relativeSecretPath,
+        },
+        makeConfig(),
+      ),
+    ).rejects.toThrow(/Access denied|outside project/)
+  })
+
+  it('should prevent reading shaders outside project directory', async () => {
+    // Create a dummy shader outside
+    const outsideShader = join(outsideDir, 'secret.gdshader')
+    writeFileSync(outsideShader, 'shader_type canvas_item;')
+    const relativeSecretPath = relative(projectPath, outsideShader)
+
+    await expect(
+      handleShader(
+        'read',
+        {
+          project_path: projectPath,
+          shader_path: relativeSecretPath,
+        },
+        makeConfig(),
+      ),
+    ).rejects.toThrow(/Access denied|outside project/)
+  })
+})


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Path Traversal
The `scripts`, `scenes`, and `shader` tools previously used `path.resolve` without verifying that the resulting path was within the project directory. This allowed an attacker (or a confused agent) to read or write files outside the intended project scope using paths like `../../etc/passwd`.

🎯 Impact:
- Arbitrary file read/write access on the host system (limited by the permissions of the user running the MCP server).
- Potential for sensitive data leakage or system compromise.

🔧 Fix:
- Created `src/tools/helpers/paths.ts` with a `safeResolve` function.
- This function resolves the path and explicitly checks if it is contained within the base path (project root or CWD).
- Updated `scripts.ts`, `scenes.ts`, and `shader.ts` to use `safeResolve` instead of `path.resolve`.
- Added `ACCESS_DENIED` to `GodotMCPErrorCode`.

✅ Verification:
- Added `tests/security_path_traversal.test.ts` which attempts to read/write files outside the project directory using the affected tools.
- Verified that these attempts now throw an `ACCESS_DENIED` error.
- Verified that normal operations within the project directory still work using existing tests.

---
*PR created automatically by Jules for task [11891366382224641503](https://jules.google.com/task/11891366382224641503) started by @n24q02m*