### PR TITLE
🛡️ Sentinel: Fix path traversal vulnerability in composite tools

### DIFF
--- a/src/tools/composite/animation.ts
+++ b/src/tools/composite/animation.ts
@@ -7,9 +7,11 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 function resolveScene(projectPath: string | null | undefined, scenePath: string): string {
-  const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+  const base = projectPath ? resolve(projectPath) : process.cwd()
+  const fullPath = safeResolve(base, scenePath)
   if (!existsSync(fullPath))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
   return fullPath

--- a/src/tools/composite/audio.ts
+++ b/src/tools/composite/audio.ts
@@ -7,6 +7,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 export async function handleAudio(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const projectPath = (args.project_path as string) || config.projectPath
@@ -156,7 +157,8 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       const parent = (args.parent as string) || '.'
       const bus = (args.bus as string) || 'Master'
 
-      const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(base, scenePath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 

--- a/src/tools/composite/navigation.ts
+++ b/src/tools/composite/navigation.ts
@@ -7,9 +7,11 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 function resolveScene(projectPath: string | null | undefined, scenePath: string): string {
-  const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+  const base = projectPath ? resolve(projectPath) : process.cwd()
+  const fullPath = safeResolve(base, scenePath)
   if (!existsSync(fullPath))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
   return fullPath

--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -7,6 +7,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import type { GodotConfig, SceneNode } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 import {
   getNodeProperty,
   parseSceneContent,
@@ -59,7 +60,8 @@ function parseNodes(content: string): SceneNode[] {
 }
 
 function resolveScenePath(projectPath: string | null | undefined, scenePath: string): string {
-  return projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+  const base = projectPath ? resolve(projectPath) : process.cwd()
+  return safeResolve(base, scenePath)
 }
 
 export async function handleNodes(action: string, args: Record<string, unknown>, config: GodotConfig) {

--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -7,6 +7,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 import { parseProjectSettings, setSettingInContent } from '../helpers/project-settings.js'
 
 export async function handlePhysics(action: string, args: Record<string, unknown>, config: GodotConfig) {
@@ -43,7 +44,8 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       const collisionLayer = args.collision_layer as number
       const collisionMask = args.collision_mask as number
 
-      const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(base, scenePath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 
@@ -74,7 +76,8 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       const nodeName = args.name as string
       if (!nodeName) throw new GodotMCPError('No node name specified', 'INVALID_ARGS', 'Provide node name.')
 
-      const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(base, scenePath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -9,6 +9,7 @@ import { join, resolve } from 'node:path'
 import { execGodotSync, runGodotProject } from '../../godot/headless.js'
 import type { GodotConfig, ProjectInfo } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 import { getSetting, parseProjectSettings, setSettingInContent } from '../helpers/project-settings.js'
 
 function parseProjectGodot(projectPath: string): ProjectInfo {
@@ -157,13 +158,16 @@ export async function handleProject(action: string, args: Record<string, unknown
         )
       }
 
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const exportPath = safeResolve(base, outputPath)
+
       const result = execGodotSync(config.godotPath, [
         '--headless',
         '--path',
-        resolve(projectPath),
+        base,
         '--export-release',
         preset,
-        resolve(projectPath, outputPath),
+        exportPath,
       ])
 
       return formatSuccess(`Export complete: ${outputPath}\n${result.stdout}`)

--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -7,6 +7,7 @@ import { existsSync, readdirSync, readFileSync, statSync, unlinkSync } from 'nod
 import { extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const RESOURCE_EXTENSIONS = new Set([
   '.tres',
@@ -83,7 +84,8 @@ export async function handleResources(action: string, args: Record<string, unkno
     case 'info': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-      const fullPath = projectPath ? resolve(projectPath, resPath) : resolve(resPath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(base, resPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
@@ -111,7 +113,8 @@ export async function handleResources(action: string, args: Record<string, unkno
     case 'delete': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-      const fullPath = projectPath ? resolve(projectPath, resPath) : resolve(resPath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(base, resPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
@@ -127,7 +130,8 @@ export async function handleResources(action: string, args: Record<string, unkno
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
 
-      const importPath = projectPath ? resolve(projectPath, `${resPath}.import`) : resolve(`${resPath}.import`)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const importPath = safeResolve(base, `${resPath}.import`)
 
       if (!existsSync(importPath)) {
         return formatJSON({ path: resPath, imported: false, message: 'No .import file found.' })

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -16,6 +16,7 @@ import {
 import { basename, dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig, SceneInfo, SceneNode } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 import { setSettingInContent } from '../helpers/project-settings.js'
 
 /**
@@ -119,7 +120,8 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       const rootType = (args.root_type as string) || 'Node2D'
       const rootName = (args.root_name as string) || basename(scenePath, '.tscn')
 
-      const fullPath = resolve(projectPath, scenePath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(base, scenePath)
       if (existsSync(fullPath)) {
         throw new GodotMCPError(
           `Scene already exists: ${scenePath}`,
@@ -155,7 +157,8 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       if (!scenePath) {
         throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path to parse.')
       }
-      const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(base, scenePath)
       if (!existsSync(fullPath)) {
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path and try again.')
       }
@@ -169,7 +172,8 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       if (!scenePath) {
         throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path to delete.')
       }
-      const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(base, scenePath)
       if (!existsSync(fullPath)) {
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
       }
@@ -188,8 +192,9 @@ export async function handleScenes(action: string, args: Record<string, unknown>
           'Provide source and destination paths.',
         )
       }
-      const srcFull = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
-      const dstFull = projectPath ? resolve(projectPath, newPath) : resolve(newPath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const srcFull = safeResolve(base, scenePath)
+      const dstFull = safeResolve(base, newPath)
       if (!existsSync(srcFull)) {
         throw new GodotMCPError(`Source scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the source path.')
       }

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync,
 import { dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const SCRIPT_TEMPLATES: Record<string, string> = {
   Node: `extends Node
@@ -127,7 +128,8 @@ export async function handleScripts(action: string, args: Record<string, unknown
       const extendsType = (args.extends as string) || 'Node'
       const content = (args.content as string) || getTemplate(extendsType)
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(base, scriptPath)
       if (existsSync(fullPath)) {
         throw new GodotMCPError(
           `Script already exists: ${scriptPath}`,
@@ -145,7 +147,8 @@ export async function handleScripts(action: string, args: Record<string, unknown
       const scriptPath = args.script_path as string
       if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(base, scriptPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
 
@@ -160,7 +163,8 @@ export async function handleScripts(action: string, args: Record<string, unknown
       if (content === undefined || content === null)
         throw new GodotMCPError('No content specified', 'INVALID_ARGS', 'Provide content to write.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(base, scriptPath)
       mkdirSync(dirname(fullPath), { recursive: true })
       writeFileSync(fullPath, content, 'utf-8')
       return formatSuccess(`Written: ${scriptPath} (${content.length} chars)`)
@@ -178,7 +182,8 @@ export async function handleScripts(action: string, args: Record<string, unknown
         )
       }
 
-      const sceneFullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const sceneFullPath = safeResolve(base, scenePath)
       if (!existsSync(sceneFullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
 
@@ -219,7 +224,8 @@ export async function handleScripts(action: string, args: Record<string, unknown
       if (!scriptPath)
         throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path to delete.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(base, scriptPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
 

--- a/src/tools/composite/shader.ts
+++ b/src/tools/composite/shader.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSy
 import { dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const SHADER_TEMPLATES: Record<string, string> = {
   canvas_item: `shader_type canvas_item;
@@ -83,7 +84,8 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderType = (args.shader_type as string) || 'canvas_item'
       const content = (args.content as string) || SHADER_TEMPLATES[shaderType] || SHADER_TEMPLATES.canvas_item
 
-      const fullPath = projectPath ? resolve(projectPath, shaderPath) : resolve(shaderPath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(base, shaderPath)
       if (existsSync(fullPath))
         throw new GodotMCPError(`Shader already exists: ${shaderPath}`, 'SHADER_ERROR', 'Use write action to modify.')
 
@@ -96,7 +98,8 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderPath = args.shader_path as string
       if (!shaderPath) throw new GodotMCPError('No shader_path specified', 'INVALID_ARGS', 'Provide shader_path.')
 
-      const fullPath = projectPath ? resolve(projectPath, shaderPath) : resolve(shaderPath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(base, shaderPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Shader not found: ${shaderPath}`, 'SHADER_ERROR', 'Check the file path.')
 
@@ -110,7 +113,8 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const content = args.content as string
       if (!content) throw new GodotMCPError('No content specified', 'INVALID_ARGS', 'Provide shader content.')
 
-      const fullPath = projectPath ? resolve(projectPath, shaderPath) : resolve(shaderPath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(base, shaderPath)
       mkdirSync(dirname(fullPath), { recursive: true })
       writeFileSync(fullPath, content, 'utf-8')
       return formatSuccess(`Written: ${shaderPath} (${content.length} chars)`)
@@ -120,7 +124,8 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderPath = args.shader_path as string
       if (!shaderPath) throw new GodotMCPError('No shader_path specified', 'INVALID_ARGS', 'Provide shader_path.')
 
-      const fullPath = projectPath ? resolve(projectPath, shaderPath) : resolve(shaderPath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(base, shaderPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Shader not found: ${shaderPath}`, 'SHADER_ERROR', 'Check the file path.')
 

--- a/src/tools/composite/signals.ts
+++ b/src/tools/composite/signals.ts
@@ -7,6 +7,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 import { parseSceneContent } from '../helpers/scene-parser.js'
 
 export async function handleSignals(action: string, args: Record<string, unknown>, config: GodotConfig) {
@@ -14,7 +15,8 @@ export async function handleSignals(action: string, args: Record<string, unknown
   const scenePath = args.scene_path as string
 
   if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
-  const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+  const base = projectPath ? resolve(projectPath) : process.cwd()
+  const fullPath = safeResolve(base, scenePath)
   if (!existsSync(fullPath))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
 

--- a/src/tools/composite/tilemap.ts
+++ b/src/tools/composite/tilemap.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 export async function handleTilemap(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const projectPath = (args.project_path as string) || config.projectPath
@@ -22,7 +23,8 @@ export async function handleTilemap(action: string, args: Record<string, unknown
         )
       const tileSize = (args.tile_size as number) || 16
 
-      const fullPath = projectPath ? resolve(projectPath, tilesetPath) : resolve(tilesetPath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(base, tilesetPath)
       if (existsSync(fullPath)) {
         throw new GodotMCPError(`TileSet already exists: ${tilesetPath}`, 'TILEMAP_ERROR', 'Use a different path.')
       }
@@ -48,7 +50,8 @@ export async function handleTilemap(action: string, args: Record<string, unknown
         throw new GodotMCPError('tileset_path and texture_path required', 'INVALID_ARGS', 'Both are required.')
       }
 
-      const fullPath = projectPath ? resolve(projectPath, tilesetPath) : resolve(tilesetPath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(base, tilesetPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`TileSet not found: ${tilesetPath}`, 'TILEMAP_ERROR', 'Create the tileset first.')
 
@@ -91,7 +94,8 @@ export async function handleTilemap(action: string, args: Record<string, unknown
       const scenePath = args.scene_path as string
       if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
 
-      const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(base, scenePath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
 

--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
   Button: { text: '"Click"' },
@@ -30,7 +31,8 @@ const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
 }
 
 function resolveScene(projectPath: string | null | undefined, scenePath: string): string {
-  const fullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+  const base = projectPath ? resolve(projectPath) : process.cwd()
+  const fullPath = safeResolve(base, scenePath)
   if (!existsSync(fullPath))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
   return fullPath
@@ -86,7 +88,8 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
           'Provide theme_path (e.g., "themes/main.tres").',
         )
 
-      const fullPath = projectPath ? resolve(projectPath, themePath) : resolve(themePath)
+      const base = projectPath ? resolve(projectPath) : process.cwd()
+      const fullPath = safeResolve(base, themePath)
 
       const fontSize = (args.font_size as number) || 16
       const _fontColor = (args.font_color as string) || 'Color(1, 1, 1, 1)'

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -24,6 +24,7 @@ export type GodotMCPErrorCode =
   | 'AUDIO_ERROR'
   | 'NAVIGATION_ERROR'
   | 'UI_ERROR'
+  | 'ACCESS_DENIED'
 
 export class GodotMCPError extends Error {
   constructor(

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,0 +1,34 @@
+import { isAbsolute, relative, resolve } from 'node:path'
+import { GodotMCPError } from './errors.js'
+
+/**
+ * Safely resolve a path relative to a base directory.
+ * Throws ACCESS_DENIED if the resolved path is outside the base directory.
+ *
+ * @param base The base directory (trusted)
+ * @param target The target path (untrusted, potentially relative)
+ * @returns The resolved absolute path
+ */
+export function safeResolve(base: string, target: string): string {
+  const resolvedBase = resolve(base)
+  const resolvedTarget = resolve(resolvedBase, target)
+
+  const rel = relative(resolvedBase, resolvedTarget)
+
+  // Check if the relative path starts with '..' (outside)
+  // Also check if it's absolute but on a different drive (Windows) or completely unrelated
+  // The 'relative' check covers most cases:
+  // - inside: "foo/bar"
+  // - outside: "../foo"
+  // - same: ""
+
+  if (rel.startsWith('..') || isAbsolute(rel)) {
+    throw new GodotMCPError(
+      `Access denied: Path "${target}" is outside the project directory.`,
+      'ACCESS_DENIED',
+      'Ensure the path is within the project structure.',
+    )
+  }
+
+  return resolvedTarget
+}

--- a/tests/security_path_traversal.test.ts
+++ b/tests/security_path_traversal.test.ts
@@ -1,0 +1,67 @@
+import { existsSync, unlinkSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { GodotConfig } from '../src/godot/types.js'
+import { handleScripts } from '../src/tools/composite/scripts.js'
+import { createTmpProject, makeConfig } from './fixtures.js'
+
+describe('Security: Path Traversal', () => {
+  let projectPath: string
+  let cleanup: () => void
+  let config: GodotConfig
+  let secretFile: string
+  let outsideDir: string
+
+  beforeEach(() => {
+    const tmp = createTmpProject()
+    projectPath = tmp.projectPath
+    cleanup = tmp.cleanup
+    config = makeConfig({ projectPath })
+
+    // Create a file outside the project directory
+    outsideDir = resolve(projectPath, '..')
+    secretFile = join(outsideDir, `secret_${Date.now()}.txt`)
+    writeFileSync(secretFile, 'secret content', 'utf-8')
+  })
+
+  afterEach(() => {
+    try {
+      if (existsSync(secretFile)) unlinkSync(secretFile)
+    } catch {}
+    cleanup()
+  })
+
+  it('should prevent reading files outside project directory', async () => {
+    // Attempt to read the file using path traversal
+    // This should fail with ACCESS_DENIED
+    await expect(
+      handleScripts(
+        'read',
+        {
+          project_path: projectPath,
+          script_path: `../${secretFile.split(/[/\\]/).pop()}`,
+        },
+        config,
+      ),
+    ).rejects.toThrow(/ACCESS_DENIED|Access denied/)
+  })
+
+  it('should prevent writing files outside project directory', async () => {
+    const pwnedFile = join(outsideDir, `pwned_${Date.now()}.gd`)
+
+    // Attempt to write outside
+    await expect(
+      handleScripts(
+        'write',
+        {
+          project_path: projectPath,
+          script_path: `../${pwnedFile.split(/[/\\]/).pop()}`,
+          content: 'extends Node',
+        },
+        config,
+      ),
+    ).rejects.toThrow(/ACCESS_DENIED|Access denied/)
+
+    expect(existsSync(pwnedFile)).toBe(false)
+  })
+})


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix path traversal vulnerability

🚨 Severity: CRITICAL
💡 Vulnerability: Path Traversal
🎯 Impact: Attackers could read/write arbitrary files on the system by providing relative paths (e.g., `../../etc/passwd`) to tool handlers like `scripts`, `scenes`, `resources`, etc.
🔧 Fix: Implemented `safeResolve` helper that ensures resolved paths are within the project directory. Applied this helper across all 13 composite tools that handle file paths.
✅ Verification: Added `tests/security_path_traversal.test.ts` which confirms that attempts to access files outside the project directory now fail with `ACCESS_DENIED`. Ran full test suite to ensure no regressions.

---
*PR created automatically by Jules for task [15121839978522703311](https://jules.google.com/task/15121839978522703311) started by @n24q02m*