### PR TITLE
⚡ Bolt: Async I/O for project/physics tools

### DIFF
--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -3,11 +3,16 @@
  * Actions: layers | collision_setup | body_config | set_layer_name
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
+import { readFile, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
-import { parseProjectSettings, setSettingInContent } from '../helpers/project-settings.js'
+import {
+  parseProjectSettingsAsync,
+  setSettingInContent,
+  writeProjectSettingsAsync,
+} from '../helpers/project-settings.js'
 
 export async function handlePhysics(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const projectPath = (args.project_path as string) || config.projectPath
@@ -19,7 +24,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       if (!existsSync(configPath))
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify project path.')
 
-      const settings = parseProjectSettings(configPath)
+      const settings = await parseProjectSettingsAsync(configPath)
       const layers2d: Record<string, string> = {}
       const layers3d: Record<string, string> = {}
 
@@ -47,7 +52,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 
-      let content = readFileSync(fullPath, 'utf-8')
+      let content = await readFile(fullPath, 'utf-8')
       const nodeRegex = new RegExp(`(\\[node name="${nodeName}"[^\\]]*\\])`)
       const match = content.match(nodeRegex)
       if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
@@ -61,7 +66,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       if (collisionMask !== undefined) props += `\ncollision_mask = ${collisionMask}`
 
       content = `${content.slice(0, insertPoint)}${props}${content.slice(insertPoint)}`
-      writeFileSync(fullPath, content, 'utf-8')
+      await writeFile(fullPath, content, 'utf-8')
 
       return formatSuccess(
         `Set collision on ${nodeName}: layer=${collisionLayer ?? 'unchanged'}, mask=${collisionMask ?? 'unchanged'}`,
@@ -78,7 +83,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 
-      let content = readFileSync(fullPath, 'utf-8')
+      let content = await readFile(fullPath, 'utf-8')
       const nodeRegex = new RegExp(`(\\[node name="${nodeName}"[^\\]]*\\])`)
       const match = content.match(nodeRegex)
       if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
@@ -94,7 +99,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
         throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
       const insertPoint = match.index + match[0].length
       content = `${content.slice(0, insertPoint)}${props}${content.slice(insertPoint)}`
-      writeFileSync(fullPath, content, 'utf-8')
+      await writeFile(fullPath, content, 'utf-8')
 
       return formatSuccess(`Configured physics body: ${nodeName}`)
     }
@@ -110,10 +115,10 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       if (!existsSync(configPath))
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify project path.')
 
-      const content = readFileSync(configPath, 'utf-8')
+      const content = await readFile(configPath, 'utf-8')
       const key = `layer_names/${dimension}_physics/layer_${layerNum}`
       const updated = setSettingInContent(content, key, `"${name}"`)
-      writeFileSync(configPath, updated, 'utf-8')
+      await writeProjectSettingsAsync(configPath, updated)
 
       return formatSuccess(`Set ${dimension} physics layer ${layerNum}: "${name}"`)
     }

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -4,24 +4,35 @@
  */
 
 import { execSync } from 'node:child_process'
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import { execGodotSync, runGodotProject } from '../../godot/headless.js'
 import type { GodotConfig, ProjectInfo } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
-import { getSetting, parseProjectSettings, setSettingInContent } from '../helpers/project-settings.js'
+import {
+  getSetting,
+  parseProjectSettingsAsync,
+  setSettingInContent,
+  writeProjectSettingsAsync,
+} from '../helpers/project-settings.js'
 
-function parseProjectGodot(projectPath: string): ProjectInfo {
+async function parseProjectGodotAsync(projectPath: string): Promise<ProjectInfo> {
   const configPath = join(projectPath, 'project.godot')
-  if (!existsSync(configPath)) {
-    throw new GodotMCPError(
-      `No project.godot found at ${projectPath}`,
-      'PROJECT_NOT_FOUND',
-      'Verify the project path contains a valid Godot project.',
-    )
+  let content: string
+  try {
+    content = await readFile(configPath, 'utf-8')
+  } catch (error: unknown) {
+    if ((error as { code?: string }).code === 'ENOENT') {
+      throw new GodotMCPError(
+        `No project.godot found at ${projectPath}`,
+        'PROJECT_NOT_FOUND',
+        'Verify the project path contains a valid Godot project.',
+      )
+    }
+    throw error
   }
 
-  const content = readFileSync(configPath, 'utf-8')
   const lines = content.split('\n')
 
   const info: ProjectInfo = { name: 'Unknown', configVersion: 5, mainScene: null, features: [], settings: {} }
@@ -71,7 +82,7 @@ export async function handleProject(action: string, args: Record<string, unknown
           'Provide project_path argument or set it via config.set action.',
         )
       }
-      const info = parseProjectGodot(resolve(projectPath))
+      const info = await parseProjectGodotAsync(resolve(projectPath))
       return formatJSON(info)
     }
 
@@ -117,7 +128,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (!existsSync(configPath))
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')
 
-      const settings = parseProjectSettings(configPath)
+      const settings = await parseProjectSettingsAsync(configPath)
       const value = getSetting(settings, key)
 
       return formatJSON({ key, value: value ?? null })
@@ -135,9 +146,9 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (!existsSync(configPath))
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')
 
-      const content = readFileSync(configPath, 'utf-8')
+      const content = await readFile(configPath, 'utf-8')
       const updated = setSettingInContent(content, key, value)
-      writeFileSync(configPath, updated, 'utf-8')
+      await writeProjectSettingsAsync(configPath, updated)
 
       return formatSuccess(`Set ${key} = ${value}`)
     }

--- a/src/tools/helpers/project-settings.ts
+++ b/src/tools/helpers/project-settings.ts
@@ -8,6 +8,7 @@
  */
 
 import { readFileSync, writeFileSync } from 'node:fs'
+import { readFile, writeFile } from 'node:fs/promises'
 
 export interface ProjectSettings {
   sections: Map<string, Map<string, string>>
@@ -19,6 +20,14 @@ export interface ProjectSettings {
  */
 export function parseProjectSettings(filePath: string): ProjectSettings {
   const raw = readFileSync(filePath, 'utf-8')
+  return parseProjectSettingsContent(raw)
+}
+
+/**
+ * Parse project.godot file asynchronously
+ */
+export async function parseProjectSettingsAsync(filePath: string): Promise<ProjectSettings> {
+  const raw = await readFile(filePath, 'utf-8')
   return parseProjectSettingsContent(raw)
 }
 
@@ -131,6 +140,13 @@ export function setSettingInContent(content: string, path: string, value: string
  */
 export function writeProjectSettings(filePath: string, content: string): void {
   writeFileSync(filePath, content, 'utf-8')
+}
+
+/**
+ * Write project settings back to file asynchronously
+ */
+export async function writeProjectSettingsAsync(filePath: string, content: string): Promise<void> {
+  await writeFile(filePath, content, 'utf-8')
 }
 
 /**

--- a/tests/composite/physics.test.ts
+++ b/tests/composite/physics.test.ts
@@ -1,0 +1,49 @@
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { handlePhysics } from '../../src/tools/composite/physics.js'
+import { createTmpProject, makeConfig } from '../fixtures.js'
+
+describe('physics tool', () => {
+  it('should list physics layers', async () => {
+    const { projectPath, cleanup } = createTmpProject()
+    try {
+      // Add physics layers to project.godot
+      const configPath = join(projectPath, 'project.godot')
+      // Note: parser expects key=value format
+      const content = `[application]\n\n[layer_names]\n2d_physics/layer_1="Player"\n`
+      writeFileSync(configPath, content, 'utf-8')
+
+      const config = makeConfig({ projectPath })
+      const result = await handlePhysics('layers', { project_path: projectPath }, config)
+      const data = JSON.parse(result.content[0].text)
+      // The key inside layer_names section is 2d_physics/layer_1
+      expect(data.layers2d['2d_physics/layer_1']).toBe('Player')
+    } finally {
+      cleanup()
+    }
+  })
+
+  it('should set layer name', async () => {
+    const { projectPath, cleanup } = createTmpProject()
+    try {
+      const config = makeConfig({ projectPath })
+      await handlePhysics(
+        'set_layer_name',
+        {
+          project_path: projectPath,
+          layer_number: 1,
+          dimension: '2d',
+          name: 'Enemy',
+        },
+        config,
+      )
+
+      const result = await handlePhysics('layers', { project_path: projectPath }, config)
+      const data = JSON.parse(result.content[0].text)
+      expect(data.layers2d['2d_physics/layer_1']).toBe('Enemy')
+    } finally {
+      cleanup()
+    }
+  })
+})

--- a/tests/composite/project.test.ts
+++ b/tests/composite/project.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { handleProject } from '../../src/tools/composite/project.js'
+import { createTmpProject, makeConfig } from '../fixtures.js'
+
+describe('project tool', () => {
+  it('should get project info', async () => {
+    const { projectPath, cleanup } = createTmpProject()
+    try {
+      const config = makeConfig({ projectPath })
+      const result = await handleProject('info', { project_path: projectPath }, config)
+      const info = JSON.parse(result.content[0].text)
+      expect(info.name).toBe('TestProject')
+    } finally {
+      cleanup()
+    }
+  })
+
+  it('should get setting', async () => {
+    const { projectPath, cleanup } = createTmpProject()
+    try {
+      const config = makeConfig({ projectPath })
+      const result = await handleProject(
+        'settings_get',
+        { project_path: projectPath, key: 'application/config/name' },
+        config,
+      )
+      const data = JSON.parse(result.content[0].text)
+      expect(data.value).toBe('"TestProject"')
+    } finally {
+      cleanup()
+    }
+  })
+
+  it('should set setting', async () => {
+    const { projectPath, cleanup } = createTmpProject()
+    try {
+      const config = makeConfig({ projectPath })
+      await handleProject(
+        'settings_set',
+        { project_path: projectPath, key: 'application/config/name', value: '"NewName"' },
+        config,
+      )
+
+      const result = await handleProject(
+        'settings_get',
+        { project_path: projectPath, key: 'application/config/name' },
+        config,
+      )
+      const data = JSON.parse(result.content[0].text)
+      expect(data.value).toBe('"NewName"')
+    } finally {
+      cleanup()
+    }
+  })
+})

--- a/tests/helpers/project-settings-async.test.ts
+++ b/tests/helpers/project-settings-async.test.ts
@@ -1,0 +1,28 @@
+import * as fsPromises from 'node:fs/promises'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { parseProjectSettingsAsync, writeProjectSettingsAsync } from '../../src/tools/helpers/project-settings.js'
+
+vi.mock('node:fs/promises')
+
+describe('project-settings-async', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should parse project settings asynchronously', async () => {
+    const mockContent = '[application]\nconfig/name="AsyncTest"\n'
+    vi.mocked(fsPromises.readFile).mockResolvedValue(mockContent)
+
+    const settings = await parseProjectSettingsAsync('project.godot')
+    expect(fsPromises.readFile).toHaveBeenCalledWith('project.godot', 'utf-8')
+    expect(settings.sections.get('application')?.get('config/name')).toBe('"AsyncTest"')
+  })
+
+  it('should write project settings asynchronously', async () => {
+    const mockContent = '[application]\nconfig/name="AsyncTest"\n'
+    vi.mocked(fsPromises.writeFile).mockResolvedValue(undefined)
+
+    await writeProjectSettingsAsync('project.godot', mockContent)
+    expect(fsPromises.writeFile).toHaveBeenCalledWith('project.godot', mockContent, 'utf-8')
+  })
+})


### PR DESCRIPTION
⚡ Bolt: Use async I/O for project settings and physics tools

💡 What: Refactored `src/tools/composite/project.ts` and `src/tools/composite/physics.ts` to use asynchronous file I/O operations (`readFile`, `writeFile` from `node:fs/promises`). Added `parseProjectSettingsAsync` and `writeProjectSettingsAsync` to `src/tools/helpers/project-settings.ts`.
🎯 Why: Synchronous I/O blocks the Node.js event loop, which can degrade performance and responsiveness of the MCP server, especially when handling multiple requests or large files.
📊 Impact: Non-blocking I/O allows concurrent handling of other tasks.
🔬 Measurement: Verified with new unit tests `tests/helpers/project-settings-async.test.ts`, `tests/composite/project.test.ts`, and `tests/composite/physics.test.ts`. All existing tests passed (except unrelated core test failure).

---
*PR created automatically by Jules for task [275499578555995943](https://jules.google.com/task/275499578555995943) started by @n24q02m*