### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in Godot execution

### DIFF
--- a/src/godot/headless.ts
+++ b/src/godot/headless.ts
@@ -2,7 +2,7 @@
  * Run Godot in headless mode for CLI operations
  */
 
-import { execSync, spawn } from 'node:child_process'
+import { execFileSync, spawn } from 'node:child_process'
 import type { HeadlessResult } from './types.js'
 
 const DEFAULT_TIMEOUT_MS = 30_000
@@ -18,7 +18,7 @@ export function execGodotSync(
   const timeout = options?.timeout ?? DEFAULT_TIMEOUT_MS
 
   try {
-    const stdout = execSync(`"${godotPath}" ${args.join(' ')}`, {
+    const stdout = execFileSync(godotPath, args, {
       timeout,
       cwd: options?.cwd,
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/tests/godot/headless-security.test.ts
+++ b/tests/godot/headless-security.test.ts
@@ -1,33 +1,33 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import * as child_process from 'node:child_process';
-import { execGodotSync } from '../../src/godot/headless.js';
+import * as child_process from 'node:child_process'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { execGodotSync } from '../../src/godot/headless.js'
 
 vi.mock('node:child_process', () => ({
   execSync: vi.fn(() => 'success'),
   execFileSync: vi.fn(() => 'success'), // We expect this to be used after fix
   spawn: vi.fn(() => ({ unref: vi.fn(), pid: 123 })),
-}));
+}))
 
 describe('execGodotSync Security', () => {
   afterEach(() => {
-    vi.clearAllMocks();
-  });
+    vi.clearAllMocks()
+  })
 
   it('should use execFileSync instead of execSync to prevent command injection', () => {
-    const godotPath = '/usr/bin/godot';
-    const maliciousArg = '"; echo injected; "';
-    const args = [maliciousArg];
+    const godotPath = '/usr/bin/godot'
+    const maliciousArg = '"; echo injected; "'
+    const args = [maliciousArg]
 
-    execGodotSync(godotPath, args);
+    execGodotSync(godotPath, args)
 
     // After the fix, execFileSync should be called with the array of arguments
     expect(child_process.execFileSync).toHaveBeenCalledWith(
       godotPath,
       args,
-      expect.objectContaining({ encoding: 'utf-8' })
-    );
+      expect.objectContaining({ encoding: 'utf-8' }),
+    )
 
     // And execSync should NOT be called
-    expect(child_process.execSync).not.toHaveBeenCalled();
-  });
-});
+    expect(child_process.execSync).not.toHaveBeenCalled()
+  })
+})

--- a/tests/godot/headless-security.test.ts
+++ b/tests/godot/headless-security.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as child_process from 'node:child_process';
+import { execGodotSync } from '../../src/godot/headless.js';
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(() => 'success'),
+  execFileSync: vi.fn(() => 'success'), // We expect this to be used after fix
+  spawn: vi.fn(() => ({ unref: vi.fn(), pid: 123 })),
+}));
+
+describe('execGodotSync Security', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should use execFileSync instead of execSync to prevent command injection', () => {
+    const godotPath = '/usr/bin/godot';
+    const maliciousArg = '"; echo injected; "';
+    const args = [maliciousArg];
+
+    execGodotSync(godotPath, args);
+
+    // After the fix, execFileSync should be called with the array of arguments
+    expect(child_process.execFileSync).toHaveBeenCalledWith(
+      godotPath,
+      args,
+      expect.objectContaining({ encoding: 'utf-8' })
+    );
+
+    // And execSync should NOT be called
+    expect(child_process.execSync).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
**Vulnerability Fix:**
Identified and fixed a command injection vulnerability in `src/godot/headless.ts` where `execSync` was used with concatenated string arguments. This allowed attackers to inject shell commands via crafted arguments.

**Resolution:**
Replaced `execSync` with `execFileSync`, which passes arguments directly to the process without shell interpretation.

**Verification:**
Added `tests/godot/headless-security.test.ts` to verify that `execFileSync` is used and `execSync` is not. Run `pnpm test` to verify.

---
*PR created automatically by Jules for task [9329971233062019221](https://jules.google.com/task/9329971233062019221) started by @n24q02m*