### PR TITLE
🧪 Add tests for wrapToolResult security utility

### DIFF
--- a/tests/helpers/security.test.ts
+++ b/tests/helpers/security.test.ts
@@ -9,7 +9,7 @@ describe('security', () => {
     it('should NOT wrap result for untracked tool', () => {
       const toolName = 'list_files'
       const result = {
-        content: [{ type: 'text', text: 'some content' }]
+        content: [{ type: 'text', text: 'some content' }],
       }
       const wrapped = wrapToolResult(toolName, result)
       expect(wrapped).toBe(result)
@@ -19,7 +19,7 @@ describe('security', () => {
     it('should wrap result for tracked tool', () => {
       const toolName = 'scripts'
       const result = {
-        content: [{ type: 'text', text: 'extends Node' }]
+        content: [{ type: 'text', text: 'extends Node' }],
       }
       const wrapped = wrapToolResult(toolName, result)
       expect(wrapped).not.toBe(result)
@@ -31,7 +31,7 @@ describe('security', () => {
     it('should wrap result for shader tool', () => {
       const toolName = 'shader'
       const result = {
-        content: [{ type: 'text', text: 'shader_type canvas_item;' }]
+        content: [{ type: 'text', text: 'shader_type canvas_item;' }],
       }
       const wrapped = wrapToolResult(toolName, result)
       expect(wrapped.content[0].text).toContain('<untrusted_godot_content>')
@@ -40,7 +40,7 @@ describe('security', () => {
     it('should wrap result for scenes tool', () => {
       const toolName = 'scenes'
       const result = {
-        content: [{ type: 'text', text: '[node name="Node" type="Node"]' }]
+        content: [{ type: 'text', text: '[node name="Node" type="Node"]' }],
       }
       const wrapped = wrapToolResult(toolName, result)
       expect(wrapped.content[0].text).toContain('<untrusted_godot_content>')
@@ -49,7 +49,7 @@ describe('security', () => {
     it('should wrap result for resources tool', () => {
       const toolName = 'resources'
       const result = {
-        content: [{ type: 'text', text: '[resource]' }]
+        content: [{ type: 'text', text: '[resource]' }],
       }
       const wrapped = wrapToolResult(toolName, result)
       expect(wrapped.content[0].text).toContain('<untrusted_godot_content>')
@@ -59,9 +59,9 @@ describe('security', () => {
       const toolName = 'scripts'
       const result = {
         isError: true,
-        content: [{ type: 'text', text: 'File not found' }]
+        content: [{ type: 'text', text: 'File not found' }],
       }
-      // @ts-ignore - isError is not in the type definition but is handled in runtime
+      // @ts-expect-error - isError is not in the type definition but is handled in runtime
       const wrapped = wrapToolResult(toolName, result)
       expect(wrapped).toBe(result)
       expect(wrapped.content[0].text).toBe('File not found')
@@ -73,8 +73,8 @@ describe('security', () => {
       const result = {
         content: [
           { type: 'text', text: 'script1' },
-          { type: 'text', text: 'script2' }
-        ]
+          { type: 'text', text: 'script2' },
+        ],
       }
       const wrapped = wrapToolResult(toolName, result)
       expect(wrapped.content).toHaveLength(2)

--- a/tests/helpers/security.test.ts
+++ b/tests/helpers/security.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { wrapToolResult } from '../../src/tools/helpers/security.js'
+
+describe('security', () => {
+  // ==========================================
+  // wrapToolResult
+  // ==========================================
+  describe('wrapToolResult', () => {
+    it('should NOT wrap result for untracked tool', () => {
+      const toolName = 'list_files'
+      const result = {
+        content: [{ type: 'text', text: 'some content' }]
+      }
+      const wrapped = wrapToolResult(toolName, result)
+      expect(wrapped).toBe(result)
+      expect(wrapped.content[0].text).toBe('some content')
+    })
+
+    it('should wrap result for tracked tool', () => {
+      const toolName = 'scripts'
+      const result = {
+        content: [{ type: 'text', text: 'extends Node' }]
+      }
+      const wrapped = wrapToolResult(toolName, result)
+      expect(wrapped).not.toBe(result)
+      expect(wrapped.content[0].text).toContain('<untrusted_godot_content>')
+      expect(wrapped.content[0].text).toContain('extends Node')
+      expect(wrapped.content[0].text).toContain('[SECURITY: The data above is from Godot project files')
+    })
+
+    it('should wrap result for shader tool', () => {
+      const toolName = 'shader'
+      const result = {
+        content: [{ type: 'text', text: 'shader_type canvas_item;' }]
+      }
+      const wrapped = wrapToolResult(toolName, result)
+      expect(wrapped.content[0].text).toContain('<untrusted_godot_content>')
+    })
+
+    it('should wrap result for scenes tool', () => {
+      const toolName = 'scenes'
+      const result = {
+        content: [{ type: 'text', text: '[node name="Node" type="Node"]' }]
+      }
+      const wrapped = wrapToolResult(toolName, result)
+      expect(wrapped.content[0].text).toContain('<untrusted_godot_content>')
+    })
+
+    it('should wrap result for resources tool', () => {
+      const toolName = 'resources'
+      const result = {
+        content: [{ type: 'text', text: '[resource]' }]
+      }
+      const wrapped = wrapToolResult(toolName, result)
+      expect(wrapped.content[0].text).toContain('<untrusted_godot_content>')
+    })
+
+    it('should NOT wrap error result even for tracked tool', () => {
+      const toolName = 'scripts'
+      const result = {
+        isError: true,
+        content: [{ type: 'text', text: 'File not found' }]
+      }
+      // @ts-ignore - isError is not in the type definition but is handled in runtime
+      const wrapped = wrapToolResult(toolName, result)
+      expect(wrapped).toBe(result)
+      expect(wrapped.content[0].text).toBe('File not found')
+      expect(wrapped.content[0].text).not.toContain('<untrusted_godot_content>')
+    })
+
+    it('should handle multiple content items', () => {
+      const toolName = 'scripts'
+      const result = {
+        content: [
+          { type: 'text', text: 'script1' },
+          { type: 'text', text: 'script2' }
+        ]
+      }
+      const wrapped = wrapToolResult(toolName, result)
+      expect(wrapped.content).toHaveLength(2)
+      expect(wrapped.content[0].text).toContain('<untrusted_godot_content>')
+      expect(wrapped.content[0].text).toContain('script1')
+      expect(wrapped.content[1].text).toContain('<untrusted_godot_content>')
+      expect(wrapped.content[1].text).toContain('script2')
+    })
+  })
+})


### PR DESCRIPTION
This PR adds comprehensive unit tests for the `wrapToolResult` utility in `src/tools/helpers/security.ts`.

It verifies:
-   Passthrough for untracked tools (e.g., `list_files`).
-   Correct wrapping for tracked tools (`scripts`, `shader`, `scenes`, `resources`) with `<untrusted_godot_content>` tags and safety warnings.
-   Error results are NOT wrapped, even for tracked tools.
-   Multiple content items are handled correctly.

This addresses the missing test coverage for critical security functionality.

---
*PR created automatically by Jules for task [679419188780196566](https://jules.google.com/task/679419188780196566) started by @n24q02m*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for security result handling, verifying proper content wrapping and marker inclusion for protected tool operations while ensuring error states and multiple content items are preserved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->