### PR TITLE
Add tests for handleUI tool

### DIFF
--- a/tests/composite/ui.test.ts
+++ b/tests/composite/ui.test.ts
@@ -1,0 +1,280 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleUI } from '../../src/tools/composite/ui.js'
+import { createTmpProject, createTmpScene, makeConfig, MINIMAL_TSCN } from '../fixtures.js'
+
+describe('ui', () => {
+  let projectPath: string
+  let cleanup: () => void
+  let config: GodotConfig
+
+  beforeEach(() => {
+    const tmp = createTmpProject()
+    projectPath = tmp.projectPath
+    cleanup = tmp.cleanup
+    config = makeConfig({ projectPath })
+  })
+
+  afterEach(() => cleanup())
+
+  // ==========================================
+  // create_control
+  // ==========================================
+  describe('create_control', () => {
+    it('should create a control with default properties', async () => {
+      createTmpScene(projectPath, 'ui.tscn', MINIMAL_TSCN)
+
+      const result = await handleUI(
+        'create_control',
+        {
+          project_path: projectPath,
+          scene_path: 'ui.tscn',
+          name: 'MyButton',
+          type: 'Button',
+        },
+        config,
+      )
+
+      expect(result.content[0].text).toContain('Created UI control: MyButton')
+      const content = readFileSync(join(projectPath, 'ui.tscn'), 'utf-8')
+      expect(content).toContain('name="MyButton"')
+      expect(content).toContain('type="Button"')
+      expect(content).toContain('text = "Click"')
+    })
+
+    it('should create a control with custom properties', async () => {
+      createTmpScene(projectPath, 'ui.tscn', MINIMAL_TSCN)
+
+      const result = await handleUI(
+        'create_control',
+        {
+          project_path: projectPath,
+          scene_path: 'ui.tscn',
+          name: 'MyLabel',
+          type: 'Label',
+          properties: {
+            text: '"Hello World"',
+            custom_minimum_size: 'Vector2(100, 50)',
+          },
+        },
+        config,
+      )
+
+      const content = readFileSync(join(projectPath, 'ui.tscn'), 'utf-8')
+      expect(content).toContain('text = "Hello World"')
+      expect(content).toContain('custom_minimum_size = Vector2(100, 50)')
+    })
+
+    it('should create a control with parent', async () => {
+      // Create scene with a container
+      const sceneContent = `[gd_scene format=3]
+
+[node name="Root" type="Control"]
+
+[node name="Container" type="VBoxContainer" parent="."]
+`
+      createTmpScene(projectPath, 'ui.tscn', sceneContent)
+
+      await handleUI(
+        'create_control',
+        {
+          project_path: projectPath,
+          scene_path: 'ui.tscn',
+          name: 'ChildButton',
+          type: 'Button',
+          parent: 'Container',
+        },
+        config,
+      )
+
+      const content = readFileSync(join(projectPath, 'ui.tscn'), 'utf-8')
+      expect(content).toContain('name="ChildButton"')
+      expect(content).toContain('parent="Container"')
+    })
+
+    it('should throw if scene_path is missing', async () => {
+      await expect(
+        handleUI(
+          'create_control',
+          {
+            project_path: projectPath,
+            name: 'Button',
+          },
+          config,
+        ),
+      ).rejects.toThrow('No scene_path specified')
+    })
+
+    it('should throw if name is missing', async () => {
+      await expect(
+        handleUI(
+          'create_control',
+          {
+            project_path: projectPath,
+            scene_path: 'ui.tscn',
+            type: 'Button',
+          },
+          config,
+        ),
+      ).rejects.toThrow('No name specified')
+    })
+  })
+
+  // ==========================================
+  // set_theme
+  // ==========================================
+  describe('set_theme', () => {
+    it('should create a theme resource', async () => {
+      const result = await handleUI(
+        'set_theme',
+        {
+          project_path: projectPath,
+          theme_path: 'themes/main.tres',
+          font_size: 20,
+        },
+        config,
+      )
+
+      expect(result.content[0].text).toContain('Created theme: themes/main.tres')
+      const content = readFileSync(join(projectPath, 'themes/main.tres'), 'utf-8')
+      expect(content).toContain('[gd_resource type="Theme" format=3]')
+      expect(content).toContain('default_font_size = 20')
+    })
+
+    it('should throw if theme_path is missing', async () => {
+      await expect(
+        handleUI(
+          'set_theme',
+          {
+            project_path: projectPath,
+            font_size: 16,
+          },
+          config,
+        ),
+      ).rejects.toThrow('No theme_path specified')
+    })
+  })
+
+  // ==========================================
+  // layout
+  // ==========================================
+  describe('layout', () => {
+    it('should set layout preset', async () => {
+      const sceneContent = `[gd_scene format=3]
+
+[node name="Root" type="Control"]
+
+[node name="MyPanel" type="Panel" parent="."]
+`
+      createTmpScene(projectPath, 'ui.tscn', sceneContent)
+
+      const result = await handleUI(
+        'layout',
+        {
+          project_path: projectPath,
+          scene_path: 'ui.tscn',
+          name: 'MyPanel',
+          preset: 'full_rect',
+        },
+        config,
+      )
+
+      expect(result.content[0].text).toContain('Set layout preset "full_rect"')
+      const content = readFileSync(join(projectPath, 'ui.tscn'), 'utf-8')
+      expect(content).toContain('anchors_preset = 15')
+      expect(content).toContain('anchor_right = 1.0')
+      expect(content).toContain('anchor_bottom = 1.0')
+    })
+
+    it('should throw for unknown preset', async () => {
+      createTmpScene(projectPath, 'ui.tscn', MINIMAL_TSCN)
+
+      await expect(
+        handleUI(
+          'layout',
+          {
+            project_path: projectPath,
+            scene_path: 'ui.tscn',
+            name: 'Root',
+            preset: 'invalid_preset',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Unknown layout preset')
+    })
+
+    it('should throw if node not found', async () => {
+      createTmpScene(projectPath, 'ui.tscn', MINIMAL_TSCN)
+
+      await expect(
+        handleUI(
+          'layout',
+          {
+            project_path: projectPath,
+            scene_path: 'ui.tscn',
+            name: 'NonExistentNode',
+            preset: 'full_rect',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Node "NonExistentNode" not found')
+    })
+  })
+
+  // ==========================================
+  // list_controls
+  // ==========================================
+  describe('list_controls', () => {
+    it('should list only UI controls', async () => {
+      const sceneContent = `[gd_scene format=3]
+
+[node name="Root" type="Control"]
+
+[node name="Button" type="Button" parent="."]
+
+[node name="Timer" type="Timer" parent="."]
+
+[node name="Sprite" type="Sprite2D" parent="."]
+`
+      createTmpScene(projectPath, 'ui.tscn', sceneContent)
+
+      const result = await handleUI(
+        'list_controls',
+        {
+          project_path: projectPath,
+          scene_path: 'ui.tscn',
+        },
+        config,
+      )
+
+      const data = JSON.parse(result.content[0].text)
+      expect(data.count).toBe(2) // Root (Control) and Button
+      expect(data.controls).toHaveLength(2)
+      expect(data.controls.map((c: any) => c.name)).toContain('Root')
+      expect(data.controls.map((c: any) => c.name)).toContain('Button')
+      expect(data.controls.map((c: any) => c.name)).not.toContain('Timer')
+      expect(data.controls.map((c: any) => c.name)).not.toContain('Sprite')
+    })
+
+    it('should throw if scene_path is missing', async () => {
+      await expect(
+        handleUI(
+          'list_controls',
+          {
+            project_path: projectPath,
+          },
+          config,
+        ),
+      ).rejects.toThrow('No scene_path specified')
+    })
+  })
+
+  // ==========================================
+  // Invalid Action
+  // ==========================================
+  it('should throw for unknown action', async () => {
+    await expect(handleUI('invalid_action', {}, config)).rejects.toThrow('Unknown action')
+  })
+})

--- a/tests/composite/ui.test.ts
+++ b/tests/composite/ui.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { GodotConfig } from '../../src/godot/types.js'
 import { handleUI } from '../../src/tools/composite/ui.js'
-import { createTmpProject, createTmpScene, makeConfig, MINIMAL_TSCN } from '../fixtures.js'
+import { createTmpProject, createTmpScene, MINIMAL_TSCN, makeConfig } from '../fixtures.js'
 
 describe('ui', () => {
   let projectPath: string
@@ -47,7 +47,7 @@ describe('ui', () => {
     it('should create a control with custom properties', async () => {
       createTmpScene(projectPath, 'ui.tscn', MINIMAL_TSCN)
 
-      const result = await handleUI(
+      await handleUI(
         'create_control',
         {
           project_path: projectPath,
@@ -252,10 +252,12 @@ describe('ui', () => {
       const data = JSON.parse(result.content[0].text)
       expect(data.count).toBe(2) // Root (Control) and Button
       expect(data.controls).toHaveLength(2)
-      expect(data.controls.map((c: any) => c.name)).toContain('Root')
-      expect(data.controls.map((c: any) => c.name)).toContain('Button')
-      expect(data.controls.map((c: any) => c.name)).not.toContain('Timer')
-      expect(data.controls.map((c: any) => c.name)).not.toContain('Sprite')
+
+      const controlNames = data.controls.map((c: { name: string }) => c.name)
+      expect(controlNames).toContain('Root')
+      expect(controlNames).toContain('Button')
+      expect(controlNames).not.toContain('Timer')
+      expect(controlNames).not.toContain('Sprite')
     })
 
     it('should throw if scene_path is missing', async () => {


### PR DESCRIPTION
Added `tests/composite/ui.test.ts` to cover the `handleUI` tool functionality.
The tests cover:
- `create_control`: Creating controls with default and custom properties, and parenting.
- `set_theme`: Creating theme resources.
- `layout`: Applying layout presets to nodes.
- `list_controls`: Listing UI controls in a scene.
- Error handling for missing arguments, unknown actions, and invalid inputs.

Verified with `npx vitest tests/composite/ui.test.ts` and `npx vitest run`.

---
*PR created automatically by Jules for task [6875681298970317853](https://jules.google.com/task/6875681298970317853) started by @n24q02m*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for UI functionality including control creation, theme configuration, layout management, and control listing.
  * Includes validation of error handling for missing or invalid parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->