### PR TITLE
🧹 Use shared scene-parser in ui.ts

### DIFF
--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { parseScene } from '../helpers/scene-parser.js'
 
 const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
   Button: { text: '"Click"' },
@@ -166,7 +167,7 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
       if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
 
       const fullPath = resolveScene(projectPath, scenePath)
-      const content = readFileSync(fullPath, 'utf-8')
+      const scene = parseScene(fullPath)
 
       const controlTypes = new Set([
         'Control',
@@ -204,10 +205,10 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
       ])
 
       const controls: { name: string; type: string; parent: string }[] = []
-      const nodeRegex = /\[node name="([^"]+)" type="([^"]+)"(?:\s+parent="([^"]*)")?/g
-      for (const match of content.matchAll(nodeRegex)) {
-        if (controlTypes.has(match[2])) {
-          controls.push({ name: match[1], type: match[2], parent: match[3] || '(root)' })
+
+      for (const node of scene.nodes) {
+        if (node.type && controlTypes.has(node.type)) {
+          controls.push({ name: node.name, type: node.type, parent: node.parent || '(root)' })
         }
       }
 

--- a/tests/composite/ui.test.ts
+++ b/tests/composite/ui.test.ts
@@ -2,8 +2,6 @@
  * Integration tests for UI tool
  */
 
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { GodotConfig } from '../../src/godot/types.js'
 import { handleUI } from '../../src/tools/composite/ui.js'
@@ -49,6 +47,12 @@ position = Vector2(100, 100)
 texture = ExtResource("1_xxxxx")
 `
 
+interface ControlInfo {
+  name: string
+  type: string
+  parent: string
+}
+
 describe('ui', () => {
   let projectPath: string
   let cleanup: () => void
@@ -83,7 +87,7 @@ describe('ui', () => {
       expect(data.count).toBe(5)
       expect(data.controls).toHaveLength(5)
 
-      const names = data.controls.map((c: any) => c.name)
+      const names = data.controls.map((c: ControlInfo) => c.name)
       expect(names).toContain('Root')
       expect(names).toContain('Button')
       expect(names).toContain('Label')
@@ -93,14 +97,17 @@ describe('ui', () => {
       expect(names).not.toContain('Sprite')
 
       // Check parent pointers
-      const innerLabel = data.controls.find((c: any) => c.name === 'InnerLabel')
-      expect(innerLabel.parent).toBe('Container')
+      const innerLabel = data.controls.find((c: ControlInfo) => c.name === 'InnerLabel')
+      expect(innerLabel).toBeDefined()
+      expect(innerLabel?.parent).toBe('Container')
 
-      const button = data.controls.find((c: any) => c.name === 'Button')
-      expect(button.parent).toBe('.')
+      const button = data.controls.find((c: ControlInfo) => c.name === 'Button')
+      expect(button).toBeDefined()
+      expect(button?.parent).toBe('.')
 
-      const root = data.controls.find((c: any) => c.name === 'Root')
-      expect(root.parent).toBe('(root)')
+      const root = data.controls.find((c: ControlInfo) => c.name === 'Root')
+      expect(root).toBeDefined()
+      expect(root?.parent).toBe('(root)')
     })
   })
 })

--- a/tests/composite/ui.test.ts
+++ b/tests/composite/ui.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Integration tests for UI tool
+ */
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleUI } from '../../src/tools/composite/ui.js'
+import { createTmpProject, createTmpScene, makeConfig } from '../fixtures.js'
+
+const UI_SCENE = `[gd_scene load_steps=1 format=3 uid="uid://test"]
+
+[node name="Root" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Button" type="Button" parent="."]
+layout_mode = 0
+offset_right = 8.0
+offset_bottom = 8.0
+text = "Click me"
+
+[node name="Label" type="Label" parent="."]
+layout_mode = 0
+offset_top = 20.0
+offset_right = 40.0
+offset_bottom = 43.0
+text = "Hello"
+
+[node name="Container" type="VBoxContainer" parent="."]
+layout_mode = 0
+offset_top = 50.0
+offset_right = 100.0
+offset_bottom = 100.0
+
+[node name="InnerLabel" type="Label" parent="Container"]
+layout_mode = 2
+text = "Inner"
+
+[node name="Node2D" type="Node2D" parent="."]
+position = Vector2(100, 100)
+
+[node name="Sprite" type="Sprite2D" parent="Node2D"]
+texture = ExtResource("1_xxxxx")
+`
+
+describe('ui', () => {
+  let projectPath: string
+  let cleanup: () => void
+  let config: GodotConfig
+
+  beforeEach(() => {
+    const tmp = createTmpProject()
+    projectPath = tmp.projectPath
+    cleanup = tmp.cleanup
+    config = makeConfig({ projectPath })
+  })
+
+  afterEach(() => cleanup())
+
+  // ==========================================
+  // list_controls
+  // ==========================================
+  describe('list_controls', () => {
+    it('should list only control nodes', async () => {
+      createTmpScene(projectPath, 'ui_test.tscn', UI_SCENE)
+
+      const result = await handleUI(
+        'list_controls',
+        {
+          project_path: projectPath,
+          scene_path: 'ui_test.tscn',
+        },
+        config,
+      )
+
+      const data = JSON.parse(result.content[0].text)
+      expect(data.count).toBe(5)
+      expect(data.controls).toHaveLength(5)
+
+      const names = data.controls.map((c: any) => c.name)
+      expect(names).toContain('Root')
+      expect(names).toContain('Button')
+      expect(names).toContain('Label')
+      expect(names).toContain('Container')
+      expect(names).toContain('InnerLabel')
+      expect(names).not.toContain('Node2D')
+      expect(names).not.toContain('Sprite')
+
+      // Check parent pointers
+      const innerLabel = data.controls.find((c: any) => c.name === 'InnerLabel')
+      expect(innerLabel.parent).toBe('Container')
+
+      const button = data.controls.find((c: any) => c.name === 'Button')
+      expect(button.parent).toBe('.')
+
+      const root = data.controls.find((c: any) => c.name === 'Root')
+      expect(root.parent).toBe('(root)')
+    })
+  })
+})


### PR DESCRIPTION
Refactored `src/tools/composite/ui.ts` to use `scene-parser.ts` for parsing scene files in `list_controls` action.

🎯 **What:** Replaced ad-hoc regex parsing in `ui.ts` with the shared `parseScene` function from `src/tools/helpers/scene-parser.ts`.
💡 **Why:** To improve maintainability, reduce code duplication, and increase reliability of scene parsing by using a robust, centralized parser.
✅ **Verification:** Added `tests/composite/ui.test.ts` to verify `list_controls` functionality. The test passes and covers various node structures (root, children, nested). Verified no regression in behavior.
✨ **Result:** Cleaner code in `ui.ts` and consistent parsing logic across tools.

---
*PR created automatically by Jules for task [7214480804844939598](https://jules.google.com/task/7214480804844939598) started by @n24q02m*