### PR TITLE
Enhance project-settings parser for multiline values

### DIFF
--- a/src/tools/helpers/project-settings.ts
+++ b/src/tools/helpers/project-settings.ts
@@ -15,6 +15,47 @@ export interface ProjectSettings {
 }
 
 /**
+ * Check if a value string is syntactically complete (balanced brackets/quotes)
+ */
+export function isValueComplete(value: string): boolean {
+  let inQuote = false
+  let escaped = false
+  let brackets = 0 // []
+  let braces = 0 // {}
+  let parens = 0 // ()
+
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i]
+
+    if (escaped) {
+      escaped = false
+      continue
+    }
+
+    if (char === '\\') {
+      escaped = true
+      continue
+    }
+
+    if (char === '"') {
+      inQuote = !inQuote
+      continue
+    }
+
+    if (inQuote) continue
+
+    if (char === '[') brackets++
+    else if (char === ']') brackets--
+    else if (char === '{') braces++
+    else if (char === '}') braces--
+    else if (char === '(') parens++
+    else if (char === ')') parens--
+  }
+
+  return !inQuote && brackets === 0 && braces === 0 && parens === 0
+}
+
+/**
  * Parse project.godot file
  */
 export function parseProjectSettings(filePath: string): ProjectSettings {
@@ -29,7 +70,21 @@ export function parseProjectSettingsContent(content: string): ProjectSettings {
   const sections = new Map<string, Map<string, string>>()
   let currentSection = ''
 
+  let currentKey: string | null = null
+  let currentValue = ''
+
   for (const rawLine of content.split('\n')) {
+    // If we are accumulating a multiline value
+    if (currentKey !== null) {
+      currentValue += `\n${rawLine}`
+      if (isValueComplete(currentValue)) {
+        sections.get(currentSection)?.set(currentKey, currentValue)
+        currentKey = null
+        currentValue = ''
+      }
+      continue
+    }
+
     const line = rawLine.trim()
     if (!line || line.startsWith(';')) continue
 
@@ -48,7 +103,13 @@ export function parseProjectSettingsContent(content: string): ProjectSettings {
     if (kvMatch && currentSection) {
       const key = kvMatch[1].trim()
       const value = kvMatch[2].trim()
-      sections.get(currentSection)?.set(key, value)
+
+      if (isValueComplete(value)) {
+        sections.get(currentSection)?.set(key, value)
+      } else {
+        currentKey = key
+        currentValue = value
+      }
     }
   }
 
@@ -86,8 +147,22 @@ export function setSettingInContent(content: string, path: string, value: string
   let keySet = false
   let sectionFound = false
 
+  let skippingValue = false
+  let skippedBuffer = ''
+
   for (let i = 0; i < lines.length; i++) {
-    const trimmed = lines[i].trim()
+    const rawLine = lines[i]
+
+    if (skippingValue) {
+      skippedBuffer += `\n${rawLine}`
+      if (isValueComplete(skippedBuffer)) {
+        skippingValue = false
+        skippedBuffer = ''
+      }
+      continue
+    }
+
+    const trimmed = rawLine.trim()
 
     // Check for section header
     if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
@@ -104,10 +179,17 @@ export function setSettingInContent(content: string, path: string, value: string
     if (inSection && trimmed.startsWith(`${key}=`)) {
       result.push(`${key}=${value}`)
       keySet = true
+
+      // Check if we need to skip lines (if old value was multiline)
+      const oldValueStart = trimmed.substring(key.length + 1).trim()
+      if (!isValueComplete(oldValueStart)) {
+        skippingValue = true
+        skippedBuffer = oldValueStart
+      }
       continue
     }
 
-    result.push(lines[i])
+    result.push(rawLine)
   }
 
   // Handle last section

--- a/tests/helpers/project-settings-multiline.test.ts
+++ b/tests/helpers/project-settings-multiline.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isValueComplete, // We will export this for testing
+  parseProjectSettingsContent,
+  setSettingInContent,
+} from '../../src/tools/helpers/project-settings.js'
+
+describe('project-settings multiline support', () => {
+  describe('isValueComplete', () => {
+    // We expect this function to be exported, even if just for testing.
+    // If it's not exported, we can skip these unit tests and rely on integration tests.
+    // But for TDD, it's better to export it.
+
+    // Placeholder - will enable after implementation
+    it('should identify complete values', () => {
+      expect(isValueComplete('"hello"')).toBe(true)
+      expect(isValueComplete('123')).toBe(true)
+      expect(isValueComplete('[]')).toBe(true)
+      expect(isValueComplete('{}')).toBe(true)
+      expect(isValueComplete('{"a": 1}')).toBe(true)
+      expect(isValueComplete('[1, 2]')).toBe(true)
+    })
+
+    it('should identify incomplete values', () => {
+      expect(isValueComplete('"hello')).toBe(false)
+      expect(isValueComplete('[')).toBe(false)
+      expect(isValueComplete('{')).toBe(false)
+      expect(isValueComplete('{"a":')).toBe(false)
+      expect(isValueComplete('(')).toBe(false)
+    })
+
+    it('should handle nested structures', () => {
+      expect(isValueComplete('{"a": [1, 2]}')).toBe(true)
+      expect(isValueComplete('{"a": [1,')).toBe(false)
+    })
+
+    it('should ignore brackets in strings', () => {
+      expect(isValueComplete('"["')).toBe(true)
+      expect(isValueComplete('"{')).toBe(false) // Wait, "{ is incomplete string
+      expect(isValueComplete('"{"')).toBe(true)
+    })
+
+    it('should handle escaped quotes', () => {
+      expect(isValueComplete('"\\""')).toBe(true)
+      expect(isValueComplete('"\\"')).toBe(false)
+    })
+  })
+
+  describe('parseProjectSettingsContent', () => {
+    it('should parse multiline array', () => {
+      const content = `[application]
+config/features=PackedStringArray("4.4",
+"GL Compatibility")`
+
+      const settings = parseProjectSettingsContent(content)
+      const app = settings.sections.get('application')
+      // Expect newline preservation or at least content capture
+      expect(app?.get('config/features')).toContain('"4.4"')
+      expect(app?.get('config/features')).toContain('"GL Compatibility"')
+    })
+
+    it('should parse multiline dictionary', () => {
+      const content = `[input]
+move_left={
+"deadzone": 0.5,
+"events": []
+}`
+
+      const settings = parseProjectSettingsContent(content)
+      const input = settings.sections.get('input')
+      const value = input?.get('move_left')
+      expect(value).toContain('"deadzone": 0.5')
+      expect(value).toContain('"events": []')
+    })
+
+    it('should parse deeply nested multiline structure', () => {
+      const content = `[section]
+key={
+    "a": [
+        1,
+        2
+    ],
+    "b": {
+        "c": 3
+    }
+}`
+      const settings = parseProjectSettingsContent(content)
+      const val = settings.sections.get('section')?.get('key')
+      expect(val).toContain('"a": [')
+      expect(val).toContain('1,')
+      expect(val).toContain('2')
+      expect(val).toContain('],')
+      expect(val).toContain('"b": {')
+      expect(val).toContain('"c": 3')
+      expect(val).toContain('}')
+    })
+  })
+
+  describe('setSettingInContent', () => {
+    it('should replace single-line with multiline', () => {
+      const content = `[section]
+key=1
+other=2`
+      const newValue = `[
+  1,
+  2
+]`
+      const result = setSettingInContent(content, 'section/key', newValue)
+      expect(result).toContain(`key=${newValue}`)
+      expect(result).toContain('other=2')
+    })
+
+    it('should replace multiline with single-line', () => {
+      const content = `[section]
+key=[
+  1,
+  2
+]
+other=2`
+      const result = setSettingInContent(content, 'section/key', '3')
+      expect(result).toContain('key=3')
+      expect(result).toContain('other=2')
+      expect(result).not.toContain('[\n  1,\n  2\n]')
+    })
+
+    it('should replace multiline with multiline', () => {
+      const content = `[section]
+key=[
+  1,
+  2
+]
+other=2`
+      const newValue = `{
+  "a": 1
+}`
+      const result = setSettingInContent(content, 'section/key', newValue)
+      expect(result).toContain(`key=${newValue}`)
+      expect(result).toContain('other=2')
+      expect(result).not.toContain('key=[')
+    })
+  })
+})


### PR DESCRIPTION
🎯 **What:** Enhanced `project-settings` parser to support multiline values.
💡 **Why:** Godot's `project.godot` file format supports multiline values for arrays, dictionaries, and strings. The previous line-based parser would fail to parse these correctly, leading to data loss or corruption when reading or modifying settings.
✅ **Verification:**
- Added `tests/helpers/project-settings-multiline.test.ts` with comprehensive test cases for parsing and modifying multiline arrays, dictionaries, and nested structures.
- Verified that `setSettingInContent` correctly replaces single-line values with multiline values and vice-versa, ensuring no artifact lines remain.
- Ran existing tests `tests/helpers/project-settings.test.ts` to ensure no regressions.
✨ **Result:** The parser now robustly handles multiline values, improving the reliability of project settings manipulation.

---
*PR created automatically by Jules for task [11844681106123706510](https://jules.google.com/task/11844681106123706510) started by @n24q02m*