### PR TITLE
Fix path traversal in resources tool

### DIFF
--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -7,6 +7,7 @@ import { existsSync, readdirSync, readFileSync, statSync, unlinkSync } from 'nod
 import { extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const RESOURCE_EXTENSIONS = new Set([
   '.tres',
@@ -51,6 +52,7 @@ function findResourceFiles(dir: string, extensions?: Set<string>): string[] {
 
 export async function handleResources(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const projectPath = (args.project_path as string) || config.projectPath
+  const base = projectPath ? resolve(projectPath) : resolve()
 
   switch (action) {
     case 'list': {
@@ -83,7 +85,8 @@ export async function handleResources(action: string, args: Record<string, unkno
     case 'info': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-      const fullPath = projectPath ? resolve(projectPath, resPath) : resolve(resPath)
+      const fullPath = safeResolve(base, resPath)
+
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
@@ -111,7 +114,8 @@ export async function handleResources(action: string, args: Record<string, unkno
     case 'delete': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-      const fullPath = projectPath ? resolve(projectPath, resPath) : resolve(resPath)
+      const fullPath = safeResolve(base, resPath)
+
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
@@ -127,7 +131,7 @@ export async function handleResources(action: string, args: Record<string, unkno
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
 
-      const importPath = projectPath ? resolve(projectPath, `${resPath}.import`) : resolve(`${resPath}.import`)
+      const importPath = safeResolve(base, `${resPath}.import`)
 
       if (!existsSync(importPath)) {
         return formatJSON({ path: resPath, imported: false, message: 'No .import file found.' })

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -24,6 +24,7 @@ export type GodotMCPErrorCode =
   | 'AUDIO_ERROR'
   | 'NAVIGATION_ERROR'
   | 'UI_ERROR'
+  | 'ACCESS_DENIED'
 
 export class GodotMCPError extends Error {
   constructor(

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,0 +1,29 @@
+import { isAbsolute, relative, resolve } from 'node:path'
+import { GodotMCPError } from './errors.js'
+
+/**
+ * Safely resolves a path ensuring it remains within the project root.
+ * Throws ACCESS_DENIED if the path attempts to traverse outside.
+ *
+ * @param basePath - The root directory (e.g., project path)
+ * @param relativePath - The path to resolve relative to root
+ * @returns The absolute resolved path
+ */
+export function safeResolve(basePath: string, relativePath: string): string {
+  const resolvedBase = resolve(basePath)
+  const resolvedPath = resolve(resolvedBase, relativePath)
+
+  // Ensure the path is within the base path
+  // We use relative() to check if it starts with '..'
+  const rel = relative(resolvedBase, resolvedPath)
+
+  if (rel.startsWith('..') || isAbsolute(rel)) {
+    throw new GodotMCPError(
+      `Access denied: Path '${relativePath}' is outside the project root.`,
+      'ACCESS_DENIED',
+      'Ensure all paths are within the project directory.',
+    )
+  }
+
+  return resolvedPath
+}

--- a/tests/composite/resources_security.test.ts
+++ b/tests/composite/resources_security.test.ts
@@ -1,0 +1,63 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { handleResources } from '../../src/tools/composite/resources.js'
+import { GodotMCPError } from '../../src/tools/helpers/errors.js'
+import { makeConfig } from '../fixtures.js'
+
+describe('resources security', () => {
+  const tmpDir = resolve(`temp_security_test_${Date.now()}`)
+  const projectPath = join(tmpDir, 'project')
+  const sensitiveFile = join(tmpDir, 'sensitive.txt')
+
+  beforeAll(() => {
+    mkdirSync(projectPath, { recursive: true })
+    writeFileSync(sensitiveFile, 'secret data')
+    // Create a valid resource inside project to ensure tool works
+    writeFileSync(join(projectPath, 'valid.tres'), 'resource')
+  })
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('should prevent path traversal in info action', async () => {
+    const config = makeConfig({ projectPath })
+
+    // Attempt to access file outside project
+    try {
+      await handleResources(
+        'info',
+        {
+          project_path: projectPath,
+          resource_path: '../sensitive.txt',
+        },
+        config,
+      )
+
+      throw new Error('Should have thrown access denied')
+    } catch (error) {
+      expect(error).toBeInstanceOf(GodotMCPError)
+      if (error instanceof GodotMCPError) {
+        expect(error.code).toBe('ACCESS_DENIED')
+        expect(error.message).toContain('outside the project root')
+      }
+    }
+  })
+
+  it('should allow accessing valid resources inside project', async () => {
+    const config = makeConfig({ projectPath })
+
+    const result = await handleResources(
+      'info',
+      {
+        project_path: projectPath,
+        resource_path: 'valid.tres',
+      },
+      config,
+    )
+
+    const data = JSON.parse(result.content[0].text)
+    expect(data.path).toBe('valid.tres')
+  })
+})


### PR DESCRIPTION
Fixed a path traversal vulnerability in the resources tool by adding a `safeResolve` utility and updating the tool to use it. Added regression tests to verify the fix.

---
*PR created automatically by Jules for task [13525186338439930623](https://jules.google.com/task/13525186338439930623) started by @n24q02m*