### PR TITLE
Refactor project tool to use shared project-settings parser

### DIFF
--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -21,40 +21,34 @@ function parseProjectGodot(projectPath: string): ProjectInfo {
     )
   }
 
-  const content = readFileSync(configPath, 'utf-8')
-  const lines = content.split('\n')
-
+  const settings = parseProjectSettings(configPath)
   const info: ProjectInfo = { name: 'Unknown', configVersion: 5, mainScene: null, features: [], settings: {} }
-  let currentSection = ''
 
-  for (const line of lines) {
-    const trimmed = line.trim()
+  for (const [section, params] of settings.sections) {
+    for (const [key, rawValue] of params) {
+      // Strip surrounding quotes if present
+      const value = rawValue.replace(/^"(.*)"$/, '$1')
+      const fullKey = section ? `${section}/${key}` : key
 
-    const sectionMatch = trimmed.match(/^\[(.+)\]$/)
-    if (sectionMatch) {
-      currentSection = sectionMatch[1]
-      continue
-    }
+      info.settings[fullKey] = value
 
-    const kvMatch = trimmed.match(/^(\S+)\s*=\s*(.+)$/)
-    if (!kvMatch) continue
-
-    const [, key, rawValue] = kvMatch
-    const value = rawValue.replace(/^"(.*)"$/, '$1')
-
-    if (currentSection === '' || currentSection === 'application') {
-      if (key === 'config/name') info.name = value
-      if (key === 'run/main_scene') info.mainScene = value
-      if (key === 'config/features') {
-        const featMatch = rawValue.match(/PackedStringArray\((.+)\)/)
-        if (featMatch) {
-          info.features = featMatch[1].split(',').map((f) => f.trim().replace(/"/g, ''))
+      // Check for standard properties
+      // These are typically in [application] section, but we check global too just in case (legacy support)
+      if (section === 'application' || section === '') {
+        if (key === 'config/name') info.name = value
+        if (key === 'run/main_scene') info.mainScene = value
+        if (key === 'config/features') {
+          const featMatch = rawValue.match(/PackedStringArray\((.+)\)/)
+          if (featMatch) {
+            info.features = featMatch[1].split(',').map((f) => f.trim().replace(/"/g, ''))
+          }
         }
       }
-    }
 
-    if (key === 'config_version') info.configVersion = Number.parseInt(value, 10)
-    info.settings[`${currentSection ? `${currentSection}/` : ''}${key}`] = value
+      if (key === 'config_version' && section === '') {
+        info.configVersion = Number.parseInt(value, 10)
+      }
+    }
   }
 
   return info

--- a/src/tools/helpers/project-settings.ts
+++ b/src/tools/helpers/project-settings.ts
@@ -29,6 +29,9 @@ export function parseProjectSettingsContent(content: string): ProjectSettings {
   const sections = new Map<string, Map<string, string>>()
   let currentSection = ''
 
+  // Initialize global section
+  sections.set('', new Map())
+
   for (const rawLine of content.split('\n')) {
     const line = rawLine.trim()
     if (!line || line.startsWith(';')) continue
@@ -45,7 +48,7 @@ export function parseProjectSettingsContent(content: string): ProjectSettings {
 
     // Key=value
     const kvMatch = line.match(/^([^=]+)=(.*)$/)
-    if (kvMatch && currentSection) {
+    if (kvMatch) {
       const key = kvMatch[1].trim()
       const value = kvMatch[2].trim()
       sections.get(currentSection)?.set(key, value)
@@ -60,13 +63,20 @@ export function parseProjectSettingsContent(content: string): ProjectSettings {
  * Example: getSetting(settings, "application/config/name")
  */
 export function getSetting(settings: ProjectSettings, path: string): string | undefined {
-  // Try direct section/key lookup
   const parts = path.split('/')
+
+  // Handle global keys (e.g. "config_version")
+  if (parts.length === 1) {
+    return settings.sections.get('')?.get(path)
+  }
+
+  // Handle section/key lookup
   if (parts.length >= 2) {
     const section = parts[0]
     const key = parts.slice(1).join('/')
     return settings.sections.get(section)?.get(key)
   }
+
   return undefined
 }
 
@@ -75,6 +85,42 @@ export function getSetting(settings: ProjectSettings, path: string): string | un
  */
 export function setSettingInContent(content: string, path: string, value: string): string {
   const parts = path.split('/')
+
+  // Handle global keys
+  if (parts.length === 1) {
+    const key = parts[0]
+    const lines = content.split('\n')
+    let keySet = false
+    const result: string[] = []
+
+    // Global keys usually appear at the top, before any section
+    let firstSectionIndex = -1
+
+    for (let i = 0; i < lines.length; i++) {
+      const trimmed = lines[i].trim()
+
+      if (firstSectionIndex === -1 && trimmed.startsWith('[') && trimmed.endsWith(']')) {
+        firstSectionIndex = i
+      }
+
+      // Replace existing global key (before any section)
+      if (firstSectionIndex === -1 && trimmed.startsWith(`${key}=`)) {
+        result.push(`${key}=${value}`)
+        keySet = true
+        continue
+      }
+
+      result.push(lines[i])
+    }
+
+    if (!keySet) {
+      // Insert at top if not found
+      result.unshift(`${key}=${value}`)
+    }
+
+    return result.join('\n')
+  }
+
   if (parts.length < 2) return content
 
   const section = parts[0]

--- a/tests/composite/project.test.ts
+++ b/tests/composite/project.test.ts
@@ -2,7 +2,7 @@
  * Integration tests for Project tool
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { GodotConfig } from '../../src/godot/types.js'
@@ -78,8 +78,7 @@ window/size/viewport_height=1080
 
     it('should throw if project.godot not found', async () => {
       const emptyDir = join(projectPath, 'empty')
-      const fs = await import('node:fs')
-      if (!fs.existsSync(emptyDir)) fs.mkdirSync(emptyDir)
+      if (!existsSync(emptyDir)) mkdirSync(emptyDir)
 
       await expect(
         handleProject(

--- a/tests/composite/project.test.ts
+++ b/tests/composite/project.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Integration tests for Project tool
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleProject } from '../../src/tools/composite/project.js'
+import { createTmpProject, makeConfig } from '../fixtures.js'
+
+// Mock headless execution
+vi.mock('../../src/godot/headless.js', () => ({
+  execGodotSync: vi.fn().mockReturnValue({ stdout: '4.2.1.stable', stderr: '', exitCode: 0, success: true }),
+  runGodotProject: vi.fn().mockReturnValue({ pid: 1234 }),
+}))
+
+// Mock child_process for stop action
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}))
+
+describe('project', () => {
+  let projectPath: string
+  let cleanup: () => void
+  let config: GodotConfig
+
+  beforeEach(() => {
+    const tmp = createTmpProject()
+    projectPath = tmp.projectPath
+    cleanup = tmp.cleanup
+    // Provide a dummy godot path so version/run checks pass
+    config = makeConfig({ projectPath, godotPath: '/bin/godot' })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  // ==========================================
+  // info
+  // ==========================================
+  describe('info', () => {
+    it('should return project info', async () => {
+      const content = `config_version=5
+
+[application]
+
+config/name="Test Project"
+run/main_scene="res://main.tscn"
+config/features=PackedStringArray("4.2", "Forward Plus")
+config/icon="res://icon.svg"
+
+[display]
+
+window/size/viewport_width=1920
+window/size/viewport_height=1080
+`
+      writeFileSync(join(projectPath, 'project.godot'), content)
+
+      const result = await handleProject(
+        'info',
+        {
+          project_path: projectPath,
+        },
+        config,
+      )
+
+      const data = JSON.parse(result.content[0].text)
+      expect(data.name).toBe('Test Project')
+      expect(data.configVersion).toBe(5)
+      expect(data.mainScene).toBe('res://main.tscn')
+      expect(data.features).toContain('4.2')
+      expect(data.features).toContain('Forward Plus')
+      expect(data.settings['display/window/size/viewport_width']).toBe('1920')
+    })
+
+    it('should throw if project.godot not found', async () => {
+      const emptyDir = join(projectPath, 'empty')
+      const fs = await import('node:fs')
+      if (!fs.existsSync(emptyDir)) fs.mkdirSync(emptyDir)
+
+      await expect(
+        handleProject(
+          'info',
+          {
+            project_path: emptyDir,
+          },
+          config,
+        ),
+      ).rejects.toThrow('No project.godot found')
+    })
+  })
+
+  // ==========================================
+  // version
+  // ==========================================
+  describe('version', () => {
+    it('should return godot version', async () => {
+      const result = await handleProject('version', {}, config)
+      expect(result.content[0].text).toContain('Godot version: 4.2.1.stable')
+    })
+
+    it('should throw if godotPath is not set', async () => {
+      await expect(handleProject('version', {}, makeConfig())).rejects.toThrow('Godot not found')
+    })
+  })
+
+  // ==========================================
+  // settings_get
+  // ==========================================
+  describe('settings_get', () => {
+    it('should get specific setting', async () => {
+      const content = `[application]
+config/name="My Game"`
+      writeFileSync(join(projectPath, 'project.godot'), content)
+
+      const result = await handleProject(
+        'settings_get',
+        {
+          project_path: projectPath,
+          key: 'application/config/name',
+        },
+        config,
+      )
+
+      const data = JSON.parse(result.content[0].text)
+      expect(data.key).toBe('application/config/name')
+      expect(data.value).toBe('"My Game"')
+    })
+
+    it('should return null for missing setting', async () => {
+      const result = await handleProject(
+        'settings_get',
+        {
+          project_path: projectPath,
+          key: 'application/missing/key',
+        },
+        config,
+      )
+
+      const data = JSON.parse(result.content[0].text)
+      expect(data.value).toBeNull()
+    })
+  })
+
+  // ==========================================
+  // settings_set
+  // ==========================================
+  describe('settings_set', () => {
+    it('should set specific setting', async () => {
+      const result = await handleProject(
+        'settings_set',
+        {
+          project_path: projectPath,
+          key: 'application/config/name',
+          value: '"New Name"',
+        },
+        config,
+      )
+
+      expect(result.content[0].text).toContain('Set application/config/name')
+
+      const content = readFileSync(join(projectPath, 'project.godot'), 'utf-8')
+      expect(content).toContain('config/name="New Name"')
+    })
+  })
+})

--- a/tests/helpers/project-settings.test.ts
+++ b/tests/helpers/project-settings.test.ts
@@ -52,7 +52,8 @@ config/name="Test"`
       const settings = parseProjectSettingsContent(SAMPLE_PROJECT_GODOT)
       // No section should be named starting with ";"
       for (const key of settings.sections.keys()) {
-        if (key !== '') { // Ignore global section
+        if (key !== '') {
+          // Ignore global section
           expect(key.startsWith(';')).toBe(false)
         }
       }

--- a/tests/helpers/project-settings.test.ts
+++ b/tests/helpers/project-settings.test.ts
@@ -38,22 +38,35 @@ describe('project-settings', () => {
       expect(display?.get('window/size/viewport_height')).toBe('720')
     })
 
+    it('should parse global keys', () => {
+      const content = `config_version=5
+[application]
+config/name="Test"`
+      const settings = parseProjectSettingsContent(content)
+      const global = settings.sections.get('')
+      expect(global).toBeDefined()
+      expect(global?.get('config_version')).toBe('5')
+    })
+
     it('should skip comments', () => {
       const settings = parseProjectSettingsContent(SAMPLE_PROJECT_GODOT)
       // No section should be named starting with ";"
       for (const key of settings.sections.keys()) {
-        expect(key.startsWith(';')).toBe(false)
+        if (key !== '') { // Ignore global section
+          expect(key.startsWith(';')).toBe(false)
+        }
       }
     })
 
     it('should handle empty content', () => {
       const settings = parseProjectSettingsContent('')
-      expect(settings.sections.size).toBe(0)
+      expect(settings.sections.size).toBe(1) // Should contain empty global section
+      expect(settings.sections.has('')).toBe(true)
     })
 
     it('should handle content with only comments', () => {
       const settings = parseProjectSettingsContent('; just a comment\n; another one\n')
-      expect(settings.sections.size).toBe(0)
+      expect(settings.sections.size).toBe(1)
     })
 
     it('should preserve raw content', () => {
@@ -76,6 +89,11 @@ describe('project-settings', () => {
       expect(getSetting(settings, 'display/window/size/viewport_width')).toBe('1280')
     })
 
+    it('should get global setting', () => {
+      const settings = parseProjectSettingsContent('config_version=5\n[application]')
+      expect(getSetting(settings, 'config_version')).toBe('5')
+    })
+
     it('should return undefined for missing section', () => {
       const settings = parseProjectSettingsContent(SAMPLE_PROJECT_GODOT)
       expect(getSetting(settings, 'nonexistent/key')).toBeUndefined()
@@ -86,7 +104,7 @@ describe('project-settings', () => {
       expect(getSetting(settings, 'application/nonexistent')).toBeUndefined()
     })
 
-    it('should return undefined for single-segment path', () => {
+    it('should return undefined for single-segment path if not in global', () => {
       const settings = parseProjectSettingsContent(SAMPLE_PROJECT_GODOT)
       expect(getSetting(settings, 'application')).toBeUndefined()
     })
@@ -120,10 +138,19 @@ describe('project-settings', () => {
       expect(result).toContain('custom_key=value')
     })
 
-    it('should reject single-segment path (no-op)', () => {
-      const original = SAMPLE_PROJECT_GODOT
-      const result = setSettingInContent(original, 'noslash', 'value')
-      expect(result).toBe(original)
+    it('should set global key', () => {
+      const content = `[application]
+config/name="Test"`
+      const result = setSettingInContent(content, 'config_version', '5')
+      expect(result).toMatch(/^config_version=5/)
+    })
+
+    it('should replace global key', () => {
+      const content = `config_version=4
+[application]`
+      const result = setSettingInContent(content, 'config_version', '5')
+      expect(result).toContain('config_version=5')
+      expect(result).not.toContain('config_version=4')
     })
   })
 


### PR DESCRIPTION
Refactored `src/tools/composite/project.ts` to use the shared project settings parser (`src/tools/helpers/project-settings.ts`).

🎯 **What:**
- Updated `src/tools/helpers/project-settings.ts` to support global configuration keys (e.g. `config_version`) by mapping them to an empty string section.
- Refactored `src/tools/composite/project.ts` to replace manual file parsing with `parseProjectSettings`.
- Created `tests/composite/project.test.ts` to verify `project` tool functionality.
- Updated `tests/helpers/project-settings.test.ts` to test global key support.

💡 **Why:**
- Improves code maintainability by centralized parsing logic.
- Ensures consistency in how `project.godot` is handled across different tools.
- Removes duplicated and potentially fragile parsing code in `project.ts`.

✅ **Verification:**
- Ran `vitest tests/helpers/project-settings.test.ts` -> Passed.
- Ran `vitest tests/composite/project.test.ts` -> Passed.
- Verified that global keys like `config_version` and section keys like `application/config/name` are correctly parsed.

✨ **Result:**
- Cleaner `project.ts` implementation.
- Robust, tested project settings parser.

---
*PR created automatically by Jules for task [12790796517402904640](https://jules.google.com/task/12790796517402904640) started by @n24q02m*