### PR TITLE
🔒 Fix path traversal vulnerability in scripts tool

### DIFF
--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync,
 import { dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const SCRIPT_TEMPLATES: Record<string, string> = {
   Node: `extends Node
@@ -127,7 +128,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       const extendsType = (args.extends as string) || 'Node'
       const content = (args.content as string) || getTemplate(extendsType)
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), scriptPath)
       if (existsSync(fullPath)) {
         throw new GodotMCPError(
           `Script already exists: ${scriptPath}`,
@@ -145,7 +146,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       const scriptPath = args.script_path as string
       if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), scriptPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
 
@@ -160,7 +161,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       if (content === undefined || content === null)
         throw new GodotMCPError('No content specified', 'INVALID_ARGS', 'Provide content to write.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), scriptPath)
       mkdirSync(dirname(fullPath), { recursive: true })
       writeFileSync(fullPath, content, 'utf-8')
       return formatSuccess(`Written: ${scriptPath} (${content.length} chars)`)
@@ -178,7 +179,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
         )
       }
 
-      const sceneFullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const sceneFullPath = safeResolve(projectPath || process.cwd(), scenePath)
       if (!existsSync(sceneFullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
 
@@ -219,7 +220,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       if (!scriptPath)
         throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path to delete.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), scriptPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
 

--- a/src/tools/helpers/errors.ts.orig
+++ b/src/tools/helpers/errors.ts.orig
@@ -24,7 +24,6 @@ export type GodotMCPErrorCode =
   | 'AUDIO_ERROR'
   | 'NAVIGATION_ERROR'
   | 'UI_ERROR'
-  | 'ACCESS_DENIED'
 
 export class GodotMCPError extends Error {
   constructor(

--- a/src/tools/helpers/errors.ts.rej
+++ b/src/tools/helpers/errors.ts.rej
@@ -1,0 +1,7 @@
+--- /dev/null
++++ /dev/null
+@@ -21,3 +21,4 @@
+   | 'AUDIO_ERROR'
+   | 'NAVIGATION_ERROR'
+   | 'UI_ERROR'
++  | 'ACCESS_DENIED'

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -19,7 +19,7 @@ export function safeResolve(base: string, target: string): string {
     throw new GodotMCPError(
       `Access denied: Path '${target}' resolves to '${resolvedTarget}' which is outside the project root '${resolvedBase}'`,
       'ACCESS_DENIED',
-      'Ensure all paths are within the project directory.'
+      'Ensure all paths are within the project directory.',
     )
   }
 

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,0 +1,27 @@
+import { isAbsolute, relative, resolve } from 'node:path'
+import { GodotMCPError } from './errors.js'
+
+/**
+ * Safely resolves a path relative to a base directory.
+ * Throws an ACCESS_DENIED error if the resolved path is outside the base directory.
+ *
+ * @param base - The base directory (e.g., project root)
+ * @param target - The target path relative to the base
+ * @returns The resolved absolute path
+ */
+export function safeResolve(base: string, target: string): string {
+  const resolvedBase = resolve(base)
+  const resolvedTarget = resolve(resolvedBase, target)
+  const rel = relative(resolvedBase, resolvedTarget)
+
+  // Check if path traverses up (starts with ..) or is absolute (different drive on Windows)
+  if (rel.startsWith('..') || isAbsolute(rel)) {
+    throw new GodotMCPError(
+      `Access denied: Path '${target}' resolves to '${resolvedTarget}' which is outside the project root '${resolvedBase}'`,
+      'ACCESS_DENIED',
+      'Ensure all paths are within the project directory.'
+    )
+  }
+
+  return resolvedTarget
+}

--- a/tests/composite/scripts.test.ts
+++ b/tests/composite/scripts.test.ts
@@ -246,6 +246,25 @@ describe('scripts', () => {
   })
 
   // ==========================================
+  // security
+  // ==========================================
+  describe('security', () => {
+    it('should prevent path traversal', async () => {
+      await expect(
+        handleScripts(
+          'write',
+          {
+            project_path: projectPath,
+            script_path: '../outside.gd',
+            content: 'extends Node',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Access denied')
+    })
+  })
+
+  // ==========================================
   // invalid action
   // ==========================================
   it('should throw for unknown action', async () => {

--- a/tests/helpers/paths.test.ts
+++ b/tests/helpers/paths.test.ts
@@ -1,0 +1,27 @@
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { safeResolve } from '../../src/tools/helpers/paths.js'
+
+describe('safeResolve', () => {
+  const base = resolve('/tmp/project')
+
+  it('should resolve valid relative paths', () => {
+    expect(safeResolve(base, 'file.txt')).toBe(join(base, 'file.txt'))
+    expect(safeResolve(base, 'subdir/file.txt')).toBe(join(base, 'subdir/file.txt'))
+  })
+
+  it('should resolve valid absolute paths inside base', () => {
+    const absPath = join(base, 'file.txt')
+    expect(safeResolve(base, absPath)).toBe(absPath)
+  })
+
+  it('should throw for path traversal', () => {
+    expect(() => safeResolve(base, '../outside.txt')).toThrow('Access denied')
+    expect(() => safeResolve(base, 'subdir/../../outside.txt')).toThrow('Access denied')
+  })
+
+  it('should throw for absolute paths outside base', () => {
+    const outside = resolve('/tmp/outside.txt')
+    expect(() => safeResolve(base, outside)).toThrow('Access denied')
+  })
+})


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
A path traversal vulnerability in the `scripts` tool allowed attackers to write files outside the project directory by supplying malicious paths (e.g., `../../etc/passwd`).

⚠️ **Risk:** The potential impact if left unfixed
An attacker could overwrite critical system files or exfiltrate sensitive data if the tool is run with elevated privileges or in a sensitive environment.

🛡️ **Solution:** How the fix addresses the vulnerability
- Implemented a `safeResolve` helper function in `src/tools/helpers/paths.ts` that resolves paths and verifies they remain within the base directory.
- Updated `src/tools/composite/scripts.ts` to use `safeResolve` for all file operations (`create`, `read`, `write`, `attach`, `delete`).
- Added comprehensive unit tests for `safeResolve` and integration tests for the `scripts` tool to verify the fix and prevent regression.

---
*PR created automatically by Jules for task [956375917638310888](https://jules.google.com/task/956375917638310888) started by @n24q02m*