### PR TITLE
🧹 Refactor input-map to use enhanced project-settings

### DIFF
--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -1,19 +1,20 @@
-/**
- * Input Map tool - Input action management via project.godot
- * Actions: list | add_action | remove_action | add_event
- */
-
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import {
+  getInputActions,
+  getSetting,
+  parseProjectSettingsContent,
+  removeSettingInContent,
+  setSettingInContent,
+} from '../helpers/project-settings.js'
 
 /**
- * Godot 4.x Key enum numeric values (@GlobalScope.Key)
- * Letters are ASCII codes, special keys use 4194xxx range
+ * Godot 4.x KeyCode enum numeric values (partial list)
  */
 const GODOT_KEY_CODES: Record<string, number> = {
-  // Letters (ASCII)
+  // Letters
   KEY_A: 65,
   KEY_B: 66,
   KEY_C: 67,
@@ -142,69 +143,16 @@ function getProjectGodotPath(projectPath: string | null | undefined): string {
 }
 
 /**
- * Parse input actions from project.godot
+ * Extract event strings from a Godot input action value string
  */
-function parseInputActions(content: string): Map<string, string[]> {
-  const actions = new Map<string, string[]>()
-  let inInputSection = false
-
-  for (const line of content.split('\n')) {
-    const trimmed = line.trim()
-
-    if (trimmed === '[input]') {
-      inInputSection = true
-      continue
-    }
-    if (trimmed.startsWith('[') && inInputSection) {
-      break
-    }
-
-    if (inInputSection) {
-      // Single-line format: action_name={...}
-      const match = trimmed.match(/^(\w+)=\{(.+)\}$/)
-      if (match) {
-        const actionName = match[1]
-        const eventsMatch = match[2].match(/"events":\s*\[([^\]]*)\]/)
-        const events = eventsMatch
-          ? eventsMatch[1]
-              .split(',')
-              .map((e) => e.trim())
-              .filter(Boolean)
-          : []
-        actions.set(actionName, events)
-      } else {
-        // Multi-line format: action_name={
-        //   "deadzone": 0.2,
-        //   "events": [...]
-        // }
-        const startMatch = trimmed.match(/^(\w+)=\{(.*)$/)
-        if (startMatch) {
-          const actionName = startMatch[1]
-          let accumulated = startMatch[2]
-          // Read subsequent lines until closing }
-          const lines = content.split('\n')
-          const currentIdx = lines.findIndex((l) => l.trim() === trimmed)
-          if (currentIdx >= 0) {
-            for (let j = currentIdx + 1; j < lines.length; j++) {
-              const nextLine = lines[j].trim()
-              accumulated += nextLine
-              if (nextLine.endsWith('}')) break
-            }
-          }
-          const eventsMatch = accumulated.match(/"events":\s*\[([^\]]*)\]/)
-          const events = eventsMatch
-            ? eventsMatch[1]
-                .split(',')
-                .map((e) => e.trim())
-                .filter(Boolean)
-            : []
-          actions.set(actionName, events)
-        }
-      }
-    }
-  }
-
-  return actions
+function extractEventsFromValue(value: string): string[] {
+  const eventsMatch = value.match(/"events":\s*\[([^\]]*)\]/)
+  return eventsMatch
+    ? eventsMatch[1]
+        .split(',')
+        .map((e) => e.trim())
+        .filter(Boolean)
+    : []
 }
 
 export async function handleInputMap(action: string, args: Record<string, unknown>, config: GodotConfig) {
@@ -214,11 +162,12 @@ export async function handleInputMap(action: string, args: Record<string, unknow
     case 'list': {
       const configPath = getProjectGodotPath(projectPath)
       const content = readFileSync(configPath, 'utf-8')
-      const actions = parseInputActions(content)
+      const settings = parseProjectSettingsContent(content)
+      const actionsMap = getInputActions(settings)
 
-      const actionList = Array.from(actions.entries()).map(([name, events]) => ({
+      const actionList = Array.from(actionsMap.entries()).map(([name, value]) => ({
         name,
-        eventCount: events.length,
+        eventCount: extractEventsFromValue(value).length,
       }))
 
       return formatJSON({ count: actionList.length, actions: actionList })
@@ -230,23 +179,18 @@ export async function handleInputMap(action: string, args: Record<string, unknow
       if (!actionName) throw new GodotMCPError('No action_name specified', 'INVALID_ARGS', 'Provide action_name.')
       const deadzone = (args.deadzone as number) || 0.5
 
-      let content = readFileSync(configPath, 'utf-8')
-
-      // Check if [input] section exists
-      if (!content.includes('[input]')) {
-        content += `\n[input]\n`
-      }
+      const content = readFileSync(configPath, 'utf-8')
+      const settings = parseProjectSettingsContent(content)
 
       // Check if action already exists
-      if (content.includes(`${actionName}={`)) {
+      if (getSetting(settings, `input/${actionName}`)) {
         throw new GodotMCPError(`Action "${actionName}" already exists`, 'INPUT_ERROR', 'Remove it first to recreate.')
       }
 
-      // Add action after [input] section header
-      const actionLine = `${actionName}={\n"deadzone": ${deadzone},\n"events": []\n}`
-      content = content.replace('[input]', `[input]\n${actionLine}`)
+      const actionValue = `{\n"deadzone": ${deadzone},\n"events": []\n}`
+      const updated = setSettingInContent(content, `input/${actionName}`, actionValue)
 
-      writeFileSync(configPath, content, 'utf-8')
+      writeFileSync(configPath, updated, 'utf-8')
       return formatSuccess(`Added input action: ${actionName} (deadzone: ${deadzone})`)
     }
 
@@ -256,14 +200,13 @@ export async function handleInputMap(action: string, args: Record<string, unknow
       if (!actionName) throw new GodotMCPError('No action_name specified', 'INVALID_ARGS', 'Provide action_name.')
 
       const content = readFileSync(configPath, 'utf-8')
-      // Remove the action line(s) - handles multi-line format
-      const pattern = new RegExp(`${actionName}=\\{[^}]*\\}\\n?`, 'g')
-      const updated = content.replace(pattern, '')
+      const settings = parseProjectSettingsContent(content)
 
-      if (updated === content) {
+      if (!getSetting(settings, `input/${actionName}`)) {
         throw new GodotMCPError(`Action "${actionName}" not found`, 'INPUT_ERROR', 'Check action name with list.')
       }
 
+      const updated = removeSettingInContent(content, `input/${actionName}`)
       writeFileSync(configPath, updated, 'utf-8')
       return formatSuccess(`Removed input action: ${actionName}`)
     }
@@ -282,6 +225,16 @@ export async function handleInputMap(action: string, args: Record<string, unknow
       }
 
       const content = readFileSync(configPath, 'utf-8')
+      const settings = parseProjectSettingsContent(content)
+      const currentValue = getSetting(settings, `input/${actionName}`)
+
+      if (!currentValue) {
+        throw new GodotMCPError(
+          `Action "${actionName}" not found`,
+          'INPUT_ERROR',
+          'Add the action first with add_action.',
+        )
+      }
 
       // Build event object based on type
       let eventObj: string
@@ -308,20 +261,17 @@ export async function handleInputMap(action: string, args: Record<string, unknow
       }
 
       // Find existing events array and append
-      const actionRegex = new RegExp(`(${actionName}=\\{[^}]*"events":\\s*\\[)([^\\]]*)\\]`)
-      const match = content.match(actionRegex)
-      if (!match) {
-        throw new GodotMCPError(
-          `Action "${actionName}" not found`,
-          'INPUT_ERROR',
-          'Add the action first with add_action.',
-        )
+      const eventsMatch = currentValue.match(/"events":\s*\[([^\]]*)\]/)
+      if (!eventsMatch) {
+        // Should usually not happen for valid action
+        throw new GodotMCPError(`Action "${actionName}" has invalid format`, 'INPUT_ERROR', 'Events array not found.')
       }
 
-      const existingEvents = match[2].trim()
+      const existingEvents = eventsMatch[1].trim()
       const newEvents = existingEvents ? `${existingEvents}, ${eventObj}` : eventObj
-      const updated = content.replace(actionRegex, `$1${newEvents}]`)
+      const updatedValue = currentValue.replace(/"events":\s*\[[^\]]*\]/, `"events": [${newEvents}]`)
 
+      const updated = setSettingInContent(content, `input/${actionName}`, updatedValue)
       writeFileSync(configPath, updated, 'utf-8')
       return formatSuccess(`Added ${eventType} event to action: ${actionName}`)
     }

--- a/src/tools/helpers/project-settings.ts
+++ b/src/tools/helpers/project-settings.ts
@@ -29,7 +29,9 @@ export function parseProjectSettingsContent(content: string): ProjectSettings {
   const sections = new Map<string, Map<string, string>>()
   let currentSection = ''
 
-  for (const rawLine of content.split('\n')) {
+  const lines = content.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const rawLine = lines[i]
     const line = rawLine.trim()
     if (!line || line.startsWith(';')) continue
 
@@ -47,7 +49,25 @@ export function parseProjectSettingsContent(content: string): ProjectSettings {
     const kvMatch = line.match(/^([^=]+)=(.*)$/)
     if (kvMatch && currentSection) {
       const key = kvMatch[1].trim()
-      const value = kvMatch[2].trim()
+      let value = kvMatch[2].trim()
+
+      // Handle multi-line values (e.g. dictionaries/arrays starting with { and not ending with })
+      // Godot format usually puts } on a new line for complex structures
+      if (value.startsWith('{') && !value.endsWith('}')) {
+        // Accumulate subsequent lines until closing brace
+        while (i + 1 < lines.length) {
+          const nextLine = lines[i + 1]
+          const trimmedNext = nextLine.trim()
+
+          value += `\n${nextLine}` // Preserve indentation in value
+          i++
+
+          if (trimmedNext.endsWith('}')) {
+            break
+          }
+        }
+      }
+
       sections.get(currentSection)?.set(key, value)
     }
   }
@@ -104,6 +124,19 @@ export function setSettingInContent(content: string, path: string, value: string
     if (inSection && trimmed.startsWith(`${key}=`)) {
       result.push(`${key}=${value}`)
       keySet = true
+
+      // Check if existing value was multi-line and skip its lines
+      const existingValueStart = trimmed.substring(key.length + 1).trim()
+      if (existingValueStart.startsWith('{') && !existingValueStart.endsWith('}')) {
+        while (i + 1 < lines.length) {
+          const nextLine = lines[i + 1].trim()
+          if (nextLine.endsWith('}')) {
+            i++ // Skip the closing brace line too
+            break
+          }
+          i++
+        }
+      }
       continue
     }
 
@@ -118,9 +151,57 @@ export function setSettingInContent(content: string, path: string, value: string
 
   // Section doesn't exist yet - add it
   if (!sectionFound) {
-    result.push('')
+    if (result.length > 0 && result[result.length - 1] !== '') {
+      result.push('')
+    }
     result.push(sectionHeader)
     result.push(`${key}=${value}`)
+  }
+
+  return result.join('\n')
+}
+
+/**
+ * Remove a setting from project.godot content
+ */
+export function removeSettingInContent(content: string, path: string): string {
+  const parts = path.split('/')
+  if (parts.length < 2) return content
+
+  const section = parts[0]
+  const key = parts.slice(1).join('/')
+  const sectionHeader = `[${section}]`
+  const lines = content.split('\n')
+  const result: string[] = []
+  let inSection = false
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim()
+
+    // Check for section header
+    if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+      inSection = trimmed === sectionHeader
+    }
+
+    // Remove existing key in current section
+    if (inSection && trimmed.startsWith(`${key}=`)) {
+      // Check if existing value was multi-line and skip its lines
+      const existingValueStart = trimmed.substring(key.length + 1).trim()
+      if (existingValueStart.startsWith('{') && !existingValueStart.endsWith('}')) {
+        while (i + 1 < lines.length) {
+          const nextLine = lines[i + 1].trim()
+          if (nextLine.endsWith('}')) {
+            i++ // Skip the closing brace line too
+            break
+          }
+          i++
+        }
+      }
+      // Do not push the line(s) to result
+      continue
+    }
+
+    result.push(lines[i])
   }
 
   return result.join('\n')

--- a/tests/helpers/project-settings.test.ts
+++ b/tests/helpers/project-settings.test.ts
@@ -210,16 +210,16 @@ describe('project-settings', () => {
   })
 })
 
-  describe('setSettingInContent extra', () => {
-    it('should add key to middle section', () => {
-      // display is between application and input
-      const result = setSettingInContent(SAMPLE_PROJECT_GODOT, 'display/window/vsync/vsync_mode', '1')
-      expect(result).toContain('window/vsync/vsync_mode=1')
-      // Ensure it's in the right place (after [display] and before [input])
-      const displayIdx = result.indexOf('[display]')
-      const inputIdx = result.indexOf('[input]')
-      const keyIdx = result.indexOf('window/vsync/vsync_mode=1')
-      expect(keyIdx).toBeGreaterThan(displayIdx)
-      expect(keyIdx).toBeLessThan(inputIdx)
-    })
+describe('setSettingInContent extra', () => {
+  it('should add key to middle section', () => {
+    // display is between application and input
+    const result = setSettingInContent(SAMPLE_PROJECT_GODOT, 'display/window/vsync/vsync_mode', '1')
+    expect(result).toContain('window/vsync/vsync_mode=1')
+    // Ensure it's in the right place (after [display] and before [input])
+    const displayIdx = result.indexOf('[display]')
+    const inputIdx = result.indexOf('[input]')
+    const keyIdx = result.indexOf('window/vsync/vsync_mode=1')
+    expect(keyIdx).toBeGreaterThan(displayIdx)
+    expect(keyIdx).toBeLessThan(inputIdx)
   })
+})

--- a/tests/helpers/project-settings.test.ts
+++ b/tests/helpers/project-settings.test.ts
@@ -7,9 +7,21 @@ import {
   getInputActions,
   getSetting,
   parseProjectSettingsContent,
+  removeSettingInContent,
   setSettingInContent,
 } from '../../src/tools/helpers/project-settings.js'
 import { SAMPLE_PROJECT_GODOT } from '../fixtures.js'
+
+const MULTILINE_PROJECT = `; Engine configuration file.
+
+[input]
+
+jump={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"keycode":32)]
+}
+move_left={ "deadzone": 0.5, "events": [] }
+`
 
 describe('project-settings', () => {
   // ==========================================
@@ -59,6 +71,18 @@ describe('project-settings', () => {
     it('should preserve raw content', () => {
       const settings = parseProjectSettingsContent(SAMPLE_PROJECT_GODOT)
       expect(settings.raw).toBe(SAMPLE_PROJECT_GODOT)
+    })
+
+    it('should parse multi-line input action', () => {
+      const settings = parseProjectSettingsContent(MULTILINE_PROJECT)
+      const input = settings.sections.get('input')
+
+      expect(input?.has('jump')).toBe(true)
+      const jumpValue = input?.get('jump')
+      expect(jumpValue).toContain('"deadzone": 0.5')
+      expect(jumpValue).toContain('InputEventKey')
+      // It should capture the full value including newlines
+      expect(jumpValue).toContain('\n')
     })
   })
 
@@ -125,6 +149,47 @@ describe('project-settings', () => {
       const result = setSettingInContent(original, 'noslash', 'value')
       expect(result).toBe(original)
     })
+
+    it('should replace multi-line input action', () => {
+      const newValue = '{ "deadzone": 0.2, "events": [] }'
+      const updated = setSettingInContent(MULTILINE_PROJECT, 'input/jump', newValue)
+
+      expect(updated).toContain(`jump=${newValue}`)
+      // Should remove the old multi-line value
+      expect(updated).not.toContain('InputEventKey')
+      // Should preserve other keys
+      expect(updated).toContain('move_left={ "deadzone": 0.5, "events": [] }')
+    })
+  })
+
+  // ==========================================
+  // removeSettingInContent
+  // ==========================================
+  describe('removeSettingInContent', () => {
+    it('should remove existing setting', () => {
+      const result = removeSettingInContent(SAMPLE_PROJECT_GODOT, 'display/window/size/viewport_width')
+      expect(result).not.toContain('window/size/viewport_width')
+      // Should keep other settings
+      expect(result).toContain('window/size/viewport_height')
+    })
+
+    it('should remove multi-line setting', () => {
+      const result = removeSettingInContent(MULTILINE_PROJECT, 'input/jump')
+      expect(result).not.toContain('jump={')
+      expect(result).not.toContain('InputEventKey')
+      // Should keep other settings
+      expect(result).toContain('move_left')
+    })
+
+    it('should do nothing if setting not found', () => {
+      const result = removeSettingInContent(SAMPLE_PROJECT_GODOT, 'input/nonexistent')
+      expect(result).toBe(SAMPLE_PROJECT_GODOT)
+    })
+
+    it('should do nothing if section not found', () => {
+      const result = removeSettingInContent(SAMPLE_PROJECT_GODOT, 'nonexistent/key')
+      expect(result).toBe(SAMPLE_PROJECT_GODOT)
+    })
   })
 
   // ==========================================
@@ -144,3 +209,17 @@ describe('project-settings', () => {
     })
   })
 })
+
+  describe('setSettingInContent extra', () => {
+    it('should add key to middle section', () => {
+      // display is between application and input
+      const result = setSettingInContent(SAMPLE_PROJECT_GODOT, 'display/window/vsync/vsync_mode', '1')
+      expect(result).toContain('window/vsync/vsync_mode=1')
+      // Ensure it's in the right place (after [display] and before [input])
+      const displayIdx = result.indexOf('[display]')
+      const inputIdx = result.indexOf('[input]')
+      const keyIdx = result.indexOf('window/vsync/vsync_mode=1')
+      expect(keyIdx).toBeGreaterThan(displayIdx)
+      expect(keyIdx).toBeLessThan(inputIdx)
+    })
+  })


### PR DESCRIPTION
Refactor input-map to use enhanced project-settings

🎯 **What:**
- Enhanced `src/tools/helpers/project-settings.ts` to support multi-line values (e.g., Godot dictionaries/arrays) and added `removeSettingInContent`.
- Refactored `src/tools/composite/input-map.ts` to remove custom parsing logic and use the shared `project-settings.ts` utilities.
- Added comprehensive tests for multi-line support and setting removal in `tests/helpers/project-settings.test.ts`.

💡 **Why:**
- Reduces code duplication by centralizing project file parsing logic.
- Improves maintainability by using a single robust parser for `project.godot`.
- Adds missing functionality (setting removal, multi-line support) to the shared helper, benefiting other tools that might need it.

✅ **Verification:**
- Verified `input-map` functionality (list, add_action, remove_action, add_event) using `tests/composite/input-map.test.ts`.
- Verified new `project-settings` capabilities using `tests/helpers/project-settings.test.ts`.
- Confirmed `setSettingInContent` correctly handles adding keys to existing sections (upsert).

✨ **Result:**
- `input-map.ts` is cleaner and relies on shared infrastructure.
- `project-settings.ts` is more robust and feature-complete.

---
*PR created automatically by Jules for task [5389674163579900646](https://jules.google.com/task/5389674163579900646) started by @n24q02m*