### PR TITLE
🔒 Fix command injection vulnerability in godotPath

### DIFF
--- a/src/godot/headless.ts
+++ b/src/godot/headless.ts
@@ -2,7 +2,7 @@
  * Run Godot in headless mode for CLI operations
  */
 
-import { execSync, spawn } from 'node:child_process'
+import { execFileSync, spawn } from 'node:child_process'
 import type { HeadlessResult } from './types.js'
 
 const DEFAULT_TIMEOUT_MS = 30_000
@@ -18,7 +18,7 @@ export function execGodotSync(
   const timeout = options?.timeout ?? DEFAULT_TIMEOUT_MS
 
   try {
-    const stdout = execSync(`"${godotPath}" ${args.join(' ')}`, {
+    const stdout = execFileSync(godotPath, args, {
       timeout,
       cwd: options?.cwd,
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -36,6 +36,15 @@ export async function handleConfig(action: string, args: Record<string, unknown>
         throw new GodotMCPError(`Invalid config key: ${key}`, 'INVALID_ARGS', `Valid keys: ${validKeys.join(', ')}`)
       }
 
+      // Validate before state change
+      if (key === 'godot_path' && /[;&|`]/.test(value)) {
+        throw new GodotMCPError(
+          'Invalid characters in godot_path',
+          'INVALID_ARGS',
+          'Path cannot contain shell metacharacters.',
+        )
+      }
+
       runtimeConfig[key] = value
 
       // Apply to active config

--- a/tests/composite/config.test.ts
+++ b/tests/composite/config.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleConfig } from '../../src/tools/composite/config.js'
+
+describe('Config Tool', () => {
+  it('should prevent setting godot_path with shell metacharacters', async () => {
+    const config: GodotConfig = {
+      godotPath: '',
+      godotVersion: null,
+      projectPath: '',
+    }
+
+    await expect(handleConfig('set', { key: 'godot_path', value: '; echo malicious' }, config)).rejects.toThrow(
+      'Invalid characters in godot_path',
+    )
+
+    expect(config.godotPath).toBe('')
+  })
+
+  it('should allow setting valid godot_path', async () => {
+    const config: GodotConfig = {
+      godotPath: '',
+      godotVersion: null,
+      projectPath: '',
+    }
+
+    const result = await handleConfig('set', { key: 'godot_path', value: '/usr/bin/godot' }, config)
+    expect(config.godotPath).toBe('/usr/bin/godot')
+    expect(result.content[0].text).toContain('Config updated')
+  })
+})

--- a/tests/godot/headless-security.test.ts
+++ b/tests/godot/headless-security.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { execGodotSync } from '../../src/godot/headless.js'
+
+describe('Godot Headless Security', () => {
+  it('should prevent command injection in godotPath', () => {
+    // Malicious path that tries to execute 'echo INJECTED'
+    // If vulnerable (using execSync), this runs and output contains INJECTED.
+    // If secure (using execFileSync), this fails as ENOENT or similar.
+
+    // Construct a path that would be valid in shell but not as a file
+    const maliciousPath = '"; echo INJECTED; echo "'
+
+    // We expect this to execute safely (i.e., try to find a file with that name)
+    // rather than executing the shell command.
+
+    const result = execGodotSync(maliciousPath, ['--version'])
+
+    // Verification:
+    // 1. stdout should NOT contain 'INJECTED'
+    expect(result.stdout).not.toContain('INJECTED')
+
+    // 2. Ideally, it should fail because the file named `"; echo INJECTED; echo "` likely doesn't exist
+    // However, if the vulnerability exists, result.success might be true (because echo succeeds)
+
+    if (result.stdout.includes('INJECTED')) {
+      throw new Error('VULNERABILITY DETECTED: Command injection successful')
+    }
+  })
+})


### PR DESCRIPTION
🎯 **What:** Fixed a command injection vulnerability in `godotPath` configuration.
⚠️ **Risk:** A malicious user could set `godotPath` to a string containing shell metacharacters (e.g., `; rm -rf /`), which would be executed by `execSync` when running Godot commands.
🛡️ **Solution:**
1.  Replaced `execSync` with `execFileSync` in `src/godot/headless.ts` to execute the binary directly without shell interpretation.
2.  Added input validation in `src/tools/composite/config.ts` to reject `godot_path` values containing shell metacharacters.
3.  Added regression tests in `tests/godot/headless-security.test.ts` and `tests/composite/config.test.ts`.

---
*PR created automatically by Jules for task [15543787496768450249](https://jules.google.com/task/15543787496768450249) started by @n24q02m*