### PR TITLE
🔒 Fix Regular Expression Injection in Scene Parser

### DIFF
--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -237,19 +237,28 @@ export function removeNodeFromContent(content: string, nodeName: string): string
 }
 
 /**
+ * Escape special characters in a string for use in a regular expression
+ */
+function escapeRegExp(string: string): string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
  * Rename a node in scene content
  */
 export function renameNodeInContent(content: string, oldName: string, newName: string): string {
+  const escapedOldName = escapeRegExp(oldName)
+
   // Replace in node declarations
-  let result = content.replace(new RegExp(`name="${oldName}"`, 'g'), `name="${newName}"`)
+  let result = content.replace(new RegExp(`name="${escapedOldName}"`, 'g'), `name="${newName}"`)
   // Replace in parent references
-  result = result.replace(new RegExp(`parent="${oldName}"`, 'g'), `parent="${newName}"`)
+  result = result.replace(new RegExp(`parent="${escapedOldName}"`, 'g'), `parent="${newName}"`)
   // Replace in parent paths containing the old name
-  result = result.replace(new RegExp(`parent="([^"]*/)${oldName}(/[^"]*)"`, 'g'), `parent="$1${newName}$2"`)
-  result = result.replace(new RegExp(`parent="([^"]*/)${oldName}"`, 'g'), `parent="$1${newName}"`)
+  result = result.replace(new RegExp(`parent="([^"]*/)${escapedOldName}(/[^"]*)"`, 'g'), `parent="$1${newName}$2"`)
+  result = result.replace(new RegExp(`parent="([^"]*/)${escapedOldName}"`, 'g'), `parent="$1${newName}"`)
   // Replace in connection references
-  result = result.replace(new RegExp(`from="${oldName}"`, 'g'), `from="${newName}"`)
-  result = result.replace(new RegExp(`to="${oldName}"`, 'g'), `to="${newName}"`)
+  result = result.replace(new RegExp(`from="${escapedOldName}"`, 'g'), `from="${newName}"`)
+  result = result.replace(new RegExp(`to="${escapedOldName}"`, 'g'), `to="${newName}"`)
   return result
 }
 

--- a/tests/helpers/scene-parser-security.test.ts
+++ b/tests/helpers/scene-parser-security.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { renameNodeInContent } from '../../src/tools/helpers/scene-parser.js'
+
+describe('scene-parser security', () => {
+  it('should not allow regex injection in node renaming', () => {
+    const content = `
+[node name="TargetNode" type="Node"]
+[node name="OtherNode" type="Node"]
+`
+    // Attempt to use a regex pattern that matches "TargetNode" (and potentially "OtherNode" if not anchored correctly, but here we just want to prove it treats it as regex)
+    // "Target.*" matches "TargetNode"
+    // If we try to rename "Target.*" to "Renamed", it should NOT match "TargetNode" unless the node is literally named "Target.*"
+
+    // In this case, there is NO node named "Target.*".
+    // So if the function is secure, nothing should change.
+    // If it is vulnerable, "TargetNode" will be renamed.
+
+    const result = renameNodeInContent(content, 'Target.*', 'Hacked')
+
+    // Vulnerable behavior: "TargetNode" becomes "Hacked"
+    // Secure behavior: "TargetNode" remains "TargetNode"
+
+    expect(result).toContain('name="TargetNode"')
+    expect(result).not.toContain('name="Hacked"')
+  })
+
+  it('should handle special characters in node names correctly', () => {
+    const content = `
+[node name="Node(1)" type="Node"]
+`
+    // specific test for parentheses which are regex special chars
+    const result = renameNodeInContent(content, 'Node(1)', 'NodeRenamed')
+
+    expect(result).toContain('name="NodeRenamed"')
+    expect(result).not.toContain('name="Node(1)"')
+  })
+})


### PR DESCRIPTION
🎯 **What:** Fixed a Regular Expression Injection vulnerability in `renameNodeInContent` within `src/tools/helpers/scene-parser.ts`.

⚠️ **Risk:** The vulnerability allowed untrusted input (node names) to be passed directly to the `RegExp` constructor without escaping. This could lead to incorrect replacements (if the name contained regex control characters like `.` or `*`) or potentially Regular Expression Denial of Service (ReDoS) if a malicious pattern was provided.

🛡️ **Solution:**
1.  Implemented an `escapeRegExp` helper function to escape special regex characters (`.*+?^${}()|[\]\`).
2.  Updated `renameNodeInContent` to escape the `oldName` before using it in regex patterns.
3.  Added a new test file `tests/helpers/scene-parser-security.test.ts` with reproduction cases for regex injection and special character handling.
4.  Verified the fix with the new tests and ensured no regressions with existing tests.

---
*PR created automatically by Jules for task [16965916897277440133](https://jules.google.com/task/16965916897277440133) started by @n24q02m*