### PR TITLE
🛡️ Sentinel: Fix path traversal in scripts tool

### DIFF
--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync,
 import { dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const SCRIPT_TEMPLATES: Record<string, string> = {
   Node: `extends Node
@@ -119,6 +120,21 @@ function findScriptFiles(dir: string): string[] {
 export async function handleScripts(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const projectPath = (args.project_path as string) || config.projectPath
 
+  if (!projectPath && action !== 'list') {
+    // List handles missing projectPath internally, but others need it for safeResolve base
+    // Though list also throws if missing. Let's rely on standard checks inside but ensure projectPath is available for resolution.
+    // Actually, all actions check projectPath. We can resolve it early.
+  }
+
+  // Helper to resolve path securely
+  const resolvePath = (path: string) => {
+    if (!projectPath) {
+      // Should be caught by action-specific checks, but fallback for safety
+      throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
+    }
+    return safeResolve(projectPath, path)
+  }
+
   switch (action) {
     case 'create': {
       const scriptPath = args.script_path as string
@@ -127,7 +143,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       const extendsType = (args.extends as string) || 'Node'
       const content = (args.content as string) || getTemplate(extendsType)
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const fullPath = resolvePath(scriptPath)
       if (existsSync(fullPath)) {
         throw new GodotMCPError(
           `Script already exists: ${scriptPath}`,
@@ -145,7 +161,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       const scriptPath = args.script_path as string
       if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const fullPath = resolvePath(scriptPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
 
@@ -160,7 +176,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       if (content === undefined || content === null)
         throw new GodotMCPError('No content specified', 'INVALID_ARGS', 'Provide content to write.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const fullPath = resolvePath(scriptPath)
       mkdirSync(dirname(fullPath), { recursive: true })
       writeFileSync(fullPath, content, 'utf-8')
       return formatSuccess(`Written: ${scriptPath} (${content.length} chars)`)
@@ -178,7 +194,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
         )
       }
 
-      const sceneFullPath = projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)
+      const sceneFullPath = resolvePath(scenePath)
       if (!existsSync(sceneFullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
 
@@ -219,7 +235,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       if (!scriptPath)
         throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path to delete.')
 
-      const fullPath = projectPath ? resolve(projectPath, scriptPath) : resolve(scriptPath)
+      const fullPath = resolvePath(scriptPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
 

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,0 +1,33 @@
+import { isAbsolute, relative, resolve } from 'node:path'
+import { GodotMCPError } from './errors.js'
+
+/**
+ * Safely resolves a path relative to a base directory, preventing path traversal.
+ *
+ * @param baseDir The trusted base directory (e.g. project root)
+ * @param targetPath The untrusted path provided by user
+ * @returns The resolved absolute path
+ * @throws GodotMCPError if the path attempts to traverse outside the base directory
+ */
+export function safeResolve(baseDir: string, targetPath: string): string {
+  // Normalize paths to remove .. and .
+  const resolvedBase = resolve(baseDir)
+  const resolvedTarget = resolve(resolvedBase, targetPath)
+
+  // Calculate relative path from base to target
+  const relativePath = relative(resolvedBase, resolvedTarget)
+
+  // Check if path is outside base directory
+  // 1. Starts with .. (parent directory)
+  // 2. Is absolute (on Windows, could be different drive)
+  // 3. relativePath should not be absolute if it's inside base
+  if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+    throw new GodotMCPError(
+      `Access denied: Path '${targetPath}' resolves to '${resolvedTarget}' which is outside the project root '${resolvedBase}'.`,
+      'INVALID_ARGS',
+      'Ensure all file paths are within the project directory.',
+    )
+  }
+
+  return resolvedTarget
+}


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix path traversal in scripts tool

🚨 Severity: CRITICAL
💡 Vulnerability: Path traversal allowing read/write access to files outside the project directory via `script_path` arguments (e.g., `../../secret.txt`).
🎯 Impact: Attackers could read sensitive system files or overwrite critical files on the host machine running the MCP server.
🔧 Fix: Implemented `safeResolve` helper that validates resolved paths are within the `project_path` root. Applied this validation to all file operations in the `scripts` tool.
✅ Verification: Verified with a reproduction test case that confirmed access to external files is now blocked with an "Access denied" error.

---
*PR created automatically by Jules for task [7046096415377690474](https://jules.google.com/task/7046096415377690474) started by @n24q02m*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced security for script file operations by implementing strict path validation to prevent unauthorized access outside project directories and ensure safer file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->