### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in Godot headless runner

### DIFF
--- a/src/godot/headless.ts
+++ b/src/godot/headless.ts
@@ -2,7 +2,7 @@
  * Run Godot in headless mode for CLI operations
  */
 
-import { execSync, spawn } from 'node:child_process'
+import { execFileSync, spawn } from 'node:child_process'
 import type { HeadlessResult } from './types.js'
 
 const DEFAULT_TIMEOUT_MS = 30_000
@@ -18,7 +18,7 @@ export function execGodotSync(
   const timeout = options?.timeout ?? DEFAULT_TIMEOUT_MS
 
   try {
-    const stdout = execSync(`"${godotPath}" ${args.join(' ')}`, {
+    const stdout = execFileSync(godotPath, args, {
       timeout,
       cwd: options?.cwd,
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/tests/godot/headless-security.test.ts
+++ b/tests/godot/headless-security.test.ts
@@ -1,0 +1,19 @@
+import * as cp from 'node:child_process'
+import { describe, expect, it, vi } from 'vitest'
+import { execGodotSync } from '../../src/godot/headless.js'
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn().mockReturnValue('mock output'),
+  spawn: vi.fn(),
+}))
+
+describe('headless-security', () => {
+  it('should prevent command injection in args by using execFileSync', () => {
+    const result = execGodotSync('godot', ['--version', '&&', 'echo', 'injected'])
+
+    // It should use execFileSync which escapes the arguments properly
+    expect(cp.execFileSync).toHaveBeenCalledWith('godot', ['--version', '&&', 'echo', 'injected'], expect.any(Object))
+    expect(result.success).toBe(true)
+    expect(result.stdout).toBe('mock output')
+  })
+})


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix command injection in Godot headless runner

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `execGodotSync` function in `src/godot/headless.ts` previously concatenated `godotPath` and `args` into a single string to execute via `execSync`, which spawns a shell. If user-controlled input ended up in the arguments (e.g. from the composite tool arguments), an attacker could inject arbitrary shell commands.
🎯 **Impact:** An attacker could execute arbitrary OS commands on the user's host machine with the privileges of the running Node.js process.
🔧 **Fix:** Changed `execSync` to `execFileSync`, keeping `args` as an array. `execFileSync` invokes the executable directly without spawning a shell to parse the arguments, thereby neutralizing the risk of command injection metacharacters.
✅ **Verification:** Added a unit test in `tests/godot/headless-security.test.ts` to assert that `execFileSync` is called instead of `execSync`, and all tests pass with `pnpm test`. `pnpm check` output is perfectly clean.

---
*PR created automatically by Jules for task [12458729894941408886](https://jules.google.com/task/12458729894941408886) started by @n24q02m*