### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in execGodotSync

### DIFF
--- a/src/godot/headless.ts
+++ b/src/godot/headless.ts
@@ -2,7 +2,7 @@
  * Run Godot in headless mode for CLI operations
  */
 
-import { execSync, spawn } from 'node:child_process'
+import { execFileSync, spawn } from 'node:child_process'
 import type { HeadlessResult } from './types.js'
 
 const DEFAULT_TIMEOUT_MS = 30_000
@@ -18,7 +18,7 @@ export function execGodotSync(
   const timeout = options?.timeout ?? DEFAULT_TIMEOUT_MS
 
   try {
-    const stdout = execSync(`"${godotPath}" ${args.join(' ')}`, {
+    const stdout = execFileSync(godotPath, args, {
       timeout,
       cwd: options?.cwd,
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/tests/godot/headless-security.test.ts
+++ b/tests/godot/headless-security.test.ts
@@ -1,0 +1,55 @@
+import * as childProcess from 'node:child_process'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { execGodotSync } from '../../src/godot/headless.js'
+
+vi.mock('node:child_process')
+
+describe('execGodotSync Security', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('should use execFileSync instead of execSync to prevent command injection', () => {
+    const godotPath = '/usr/bin/godot'
+    const args = ['--headless', '--script', 'test.gd']
+
+    // Because we use vi.mock('node:child_process'), execFileSync will just be a mocked function
+    // returning what we tell it to. It won't actually try to spawn the file.
+    vi.mocked(childProcess.execFileSync).mockReturnValue('success')
+
+    const result = execGodotSync(godotPath, args)
+
+    expect(result.success).toBe(true)
+    expect(result.stdout).toBe('success')
+
+    // Verify execFileSync is called, not execSync
+    expect(childProcess.execFileSync).toHaveBeenCalledTimes(1)
+    expect(childProcess.execSync).not.toHaveBeenCalled()
+
+    // Verify arguments are passed as array to execFileSync, which prevents command injection
+    expect(childProcess.execFileSync).toHaveBeenCalledWith(godotPath, args, expect.any(Object))
+  })
+
+  it('should safely handle malicious arguments without executing them as shell commands', () => {
+    const godotPath = '/usr/bin/godot'
+    // A malicious payload that would execute `ls` if passed to a shell
+    const maliciousArgs = ['--headless', '--script', 'test.gd', ';', 'ls', '-la']
+
+    vi.mocked(childProcess.execFileSync).mockReturnValue('success')
+
+    execGodotSync(godotPath, maliciousArgs)
+
+    // Verify the malicious arguments are passed exactly as array elements
+    // In execFileSync, these are passed directly to the executable (Godot)
+    // rather than being parsed by a shell like `/bin/sh -c "/usr/bin/godot --headless --script test.gd ; ls -la"`
+    expect(childProcess.execFileSync).toHaveBeenCalledWith(
+      godotPath,
+      ['--headless', '--script', 'test.gd', ';', 'ls', '-la'],
+      expect.any(Object),
+    )
+  })
+})


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `execGodotSync` in `src/godot/headless.ts` was using `execSync(godotPath + ' ' + args.join(' '))`. This passed arguments to a shell context, making it vulnerable to command injection if arguments could be influenced (e.g. `[';', 'ls']`).
🎯 Impact: An attacker could execute arbitrary commands on the system running the server by injecting shell metacharacters in the arguments array.
🔧 Fix: Replaced `execSync` with `execFileSync` and directly passed the `args` array to safely execute the command without shell invocation.
✅ Verification: Ran `vitest` tests confirming the vulnerability is fixed and verified no regressions.

---
*PR created automatically by Jules for task [8494321099413291545](https://jules.google.com/task/8494321099413291545) started by @n24q02m*