### PR TITLE
🧪 Add tests for tilemap tool edge cases

### DIFF
--- a/tests/composite/tilemap.test.ts
+++ b/tests/composite/tilemap.test.ts
@@ -43,6 +43,14 @@ describe('tilemap', () => {
       expect(existsSync(join(projectPath, 'tilesets/main.tres'))).toBe(true)
     })
 
+
+    it('should create .tres file at given path without project_path', async () => {
+      const result = await handleTilemap('create_tileset', { tileset_path: join(projectPath, 'tilesets/no_proj.tres') }, { projectPath: '' } as GodotConfig)
+
+      expect(result.content[0].text).toContain('Created TileSet')
+      expect(existsSync(join(projectPath, 'tilesets/no_proj.tres'))).toBe(true)
+    })
+
     it('should use default tile_size of 16', async () => {
       await handleTilemap('create_tileset', { tileset_path: 'tilesets/tiles16.tres' }, config)
 
@@ -87,6 +95,26 @@ describe('tilemap', () => {
       const content = readFileSync(join(projectPath, 'tilesets/main.tres'), 'utf-8')
       expect(content).toContain('ext_resource')
       expect(content).toContain('tiles.png')
+    })
+
+
+    it('should increment source ID when adding multiple sources', async () => {
+      await handleTilemap('create_tileset', { tileset_path: 'tilesets/main.tres' }, config)
+      await handleTilemap('add_source', { tileset_path: 'tilesets/main.tres', texture_path: 'textures/tiles1.png' }, config)
+      const result = await handleTilemap('add_source', { tileset_path: 'tilesets/main.tres', texture_path: 'textures/tiles2.png' }, config)
+
+      expect(result.content[0].text).toContain('id: source_1')
+      const content = readFileSync(join(projectPath, 'tilesets/main.tres'), 'utf-8')
+      expect(content).toContain('id="source_0"')
+      expect(content).toContain('id="source_1"')
+    })
+
+    it('should convert backslashes in texture_path to forward slashes', async () => {
+      await handleTilemap('create_tileset', { tileset_path: 'tilesets/main.tres' }, config)
+      await handleTilemap('add_source', { tileset_path: 'tilesets/main.tres', texture_path: 'textures\\win_tiles.png' }, config)
+
+      const content = readFileSync(join(projectPath, 'tilesets/main.tres'), 'utf-8')
+      expect(content).toContain('res://textures/win_tiles.png')
     })
 
     it('should throw if tileset not found', async () => {

--- a/tests/composite/tilemap.test.ts
+++ b/tests/composite/tilemap.test.ts
@@ -43,9 +43,12 @@ describe('tilemap', () => {
       expect(existsSync(join(projectPath, 'tilesets/main.tres'))).toBe(true)
     })
 
-
     it('should create .tres file at given path without project_path', async () => {
-      const result = await handleTilemap('create_tileset', { tileset_path: join(projectPath, 'tilesets/no_proj.tres') }, { projectPath: '' } as GodotConfig)
+      const result = await handleTilemap(
+        'create_tileset',
+        { tileset_path: join(projectPath, 'tilesets/no_proj.tres') },
+        { projectPath: '' } as GodotConfig,
+      )
 
       expect(result.content[0].text).toContain('Created TileSet')
       expect(existsSync(join(projectPath, 'tilesets/no_proj.tres'))).toBe(true)
@@ -97,11 +100,18 @@ describe('tilemap', () => {
       expect(content).toContain('tiles.png')
     })
 
-
     it('should increment source ID when adding multiple sources', async () => {
       await handleTilemap('create_tileset', { tileset_path: 'tilesets/main.tres' }, config)
-      await handleTilemap('add_source', { tileset_path: 'tilesets/main.tres', texture_path: 'textures/tiles1.png' }, config)
-      const result = await handleTilemap('add_source', { tileset_path: 'tilesets/main.tres', texture_path: 'textures/tiles2.png' }, config)
+      await handleTilemap(
+        'add_source',
+        { tileset_path: 'tilesets/main.tres', texture_path: 'textures/tiles1.png' },
+        config,
+      )
+      const result = await handleTilemap(
+        'add_source',
+        { tileset_path: 'tilesets/main.tres', texture_path: 'textures/tiles2.png' },
+        config,
+      )
 
       expect(result.content[0].text).toContain('id: source_1')
       const content = readFileSync(join(projectPath, 'tilesets/main.tres'), 'utf-8')
@@ -111,7 +121,11 @@ describe('tilemap', () => {
 
     it('should convert backslashes in texture_path to forward slashes', async () => {
       await handleTilemap('create_tileset', { tileset_path: 'tilesets/main.tres' }, config)
-      await handleTilemap('add_source', { tileset_path: 'tilesets/main.tres', texture_path: 'textures\\win_tiles.png' }, config)
+      await handleTilemap(
+        'add_source',
+        { tileset_path: 'tilesets/main.tres', texture_path: 'textures\\win_tiles.png' },
+        config,
+      )
 
       const content = readFileSync(join(projectPath, 'tilesets/main.tres'), 'utf-8')
       expect(content).toContain('res://textures/win_tiles.png')


### PR DESCRIPTION
🎯 What: The testing gap addressed
The handleTilemap tool in `src/tools/composite/tilemap.ts` lacked complete test coverage for several edge cases:
- Handling the absence of `project_path`.
- Adding multiple sources to a tileset and verifying correct incrementing behavior for the source ID.
- Normalizing backslashes (`\`) to forward slashes (`/`) in `texture_path`.

📊 Coverage: What scenarios are now tested
Tests have been added to `tests/composite/tilemap.test.ts` to cover these exact scenarios within the `create_tileset` and `add_source` actions.

✨ Result: The improvement in test coverage
Increased reliability for file creation and resource reference modification inside `handleTilemap`.

---
*PR created automatically by Jules for task [14522432537781594140](https://jules.google.com/task/14522432537781594140) started by @n24q02m*