### PR TITLE
🧪 [testing improvement] Add exhaustive tests for setup tool check action

### DIFF
--- a/tests/composite/setup.test.ts
+++ b/tests/composite/setup.test.ts
@@ -97,6 +97,42 @@ describe('setup', () => {
       expect(data.project.valid).toBe(true)
     })
 
+    it('should return valid project but missing godot', async () => {
+      // Mock failure detection
+      vi.mocked(detectGodot).mockReturnValue(null)
+
+      const result = await handleSetup('check', {}, { ...config, projectPath: tmpProject.projectPath })
+      const data = JSON.parse(result.content[0].text)
+
+      expect(data.godot.found).toBe(false)
+      expect(data.project.path).toBe(tmpProject.projectPath)
+      expect(data.project.valid).toBe(true)
+    })
+
+    it('should return invalid project but found godot', async () => {
+      // Mock successful detection
+      vi.mocked(detectGodot).mockReturnValue({
+        path: '/opt/godot/godot',
+        version: {
+          major: 4,
+          minor: 3,
+          patch: 0,
+          label: 'stable',
+          raw: '4.3.stable',
+        },
+        source: 'env',
+      })
+
+      const invalidPath = join(tmpProject.projectPath, 'nonexistent')
+      const result = await handleSetup('check', {}, { ...config, projectPath: invalidPath })
+      const data = JSON.parse(result.content[0].text)
+
+      expect(data.godot.found).toBe(true)
+      expect(data.godot.path).toBe('/opt/godot/godot')
+      expect(data.project.path).toBe(invalidPath)
+      expect(data.project.valid).toBe(false)
+    })
+
     it('should return invalid project and missing godot', async () => {
       // Mock failure detection
       vi.mocked(detectGodot).mockReturnValue(null)


### PR DESCRIPTION
🎯 **What:** The check action in the setup tool was missing combinations for partial match scenarios (e.g. valid project but missing Godot).
📊 **Coverage:** The new tests cover scenario where project is valid but Godot is missing, and where project is invalid but Godot is found.
✨ **Result:** handleSetup now has exhausted tests for 'check' action combinations, increasing test reliability.

---
*PR created automatically by Jules for task [8340892865971728591](https://jules.google.com/task/8340892865971728591) started by @n24q02m*