### PR TITLE
🧪 [testing] Add missing edge case test for parseProjectGodot

### DIFF
--- a/tests/composite/project.test.ts
+++ b/tests/composite/project.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { execFileSync } from 'node:child_process'
-import { readFileSync } from 'node:fs'
+import { readFileSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { GodotConfig } from '../../src/godot/types.js'
@@ -58,6 +58,13 @@ describe('project', () => {
       const result = await handleProject('info', {}, config)
       const data = JSON.parse(result.content[0].text)
       expect(data.name).toBe('TestProject')
+    })
+
+    it('should throw PROJECT_NOT_FOUND if project.godot is missing', async () => {
+      rmSync(join(projectPath, 'project.godot'))
+      await expect(handleProject('info', { project_path: projectPath }, config)).rejects.toThrow(
+        'No project.godot found at',
+      )
     })
 
     it('should throw if no project path', async () => {


### PR DESCRIPTION
🎯 **What:** Address the testing gap for the `parseProjectGodot` function in `src/tools/composite/project.ts` when a `project.godot` file is missing. The existing test suite was lacking validation for the `GodotMCPError` edge case thrown during `PROJECT_NOT_FOUND`.

📊 **Coverage:** A new edge case test has been added to `tests/composite/project.test.ts` within the `info` describe block. This scenario properly removes the `project.godot` file in the test environment using `fs.rmSync` and verifies the function effectively throws and returns the `No project.godot found at` error message when `handleProject('info', ...)` is executed.

✨ **Result:** Test coverage for `parseProjectGodot` functionality specifically in error conditions is substantially improved, making edge-case behavior explicit, catching regressions early, and completing the `info` testing scenario requirements.

---
*PR created automatically by Jules for task [12466589563213894041](https://jules.google.com/task/12466589563213894041) started by @n24q02m*