### PR TITLE
⚡ Perf: optimize file finders to reduce array allocations

### DIFF
--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -33,9 +33,9 @@ interface ResourceEntry {
   size: number
 }
 
-function findResourceFiles(dir: string, extensions?: Set<string>): ResourceEntry[] {
+function findResourceFiles(dir: string, extensions?: Set<string>, results: ResourceEntry[] = []): ResourceEntry[] {
   const exts = extensions || RESOURCE_EXTENSIONS
-  const results: ResourceEntry[] = []
+
   try {
     const entries = readdirSync(dir)
     for (const entry of entries) {
@@ -43,7 +43,7 @@ function findResourceFiles(dir: string, extensions?: Set<string>): ResourceEntry
       const fullPath = join(dir, entry)
       const stat = statSync(fullPath)
       if (stat.isDirectory()) {
-        results.push(...findResourceFiles(fullPath, exts))
+        findResourceFiles(fullPath, exts, results)
       } else if (exts.has(extname(entry).toLowerCase())) {
         results.push({ path: fullPath, size: stat.size })
       }

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -73,9 +73,7 @@ async function parseTscnFile(filePath: string): Promise<SceneInfo> {
 /**
  * Recursively find all .tscn files in a directory
  */
-function findSceneFiles(dir: string): string[] {
-  const results: string[] = []
-
+function findSceneFiles(dir: string, results: string[] = []): string[] {
   try {
     const entries = readdirSync(dir)
     for (const entry of entries) {
@@ -85,7 +83,7 @@ function findSceneFiles(dir: string): string[] {
       const stat = statSync(fullPath)
 
       if (stat.isDirectory()) {
-        results.push(...findSceneFiles(fullPath))
+        findSceneFiles(fullPath, results)
       } else if (extname(entry) === '.tscn') {
         results.push(fullPath)
       }


### PR DESCRIPTION
💡 **What:** Modified `findSceneFiles` in `src/tools/composite/scenes.ts` and `findResourceFiles` in `src/tools/composite/resources.ts` to use a shared accumulator array passed recursively, replacing the previous `results.push(...findFiles(fullPath))` pattern.

🎯 **Why:** The spread operator (`...`) combined with array pushing creates unnecessary intermediate arrays and can lead to stack overflows or high memory pressure for directories with many files or deep nesting. Passing the `results` array recursively avoids these allocations entirely, mirroring an optimization already present in `src/tools/composite/scripts.ts`.

📊 **Measured Improvement:** While a specific benchmark suite wasn't established for these individual internal functions, this exact optimization in the `findScriptFiles` function in `scripts.ts` was noted in the memory context as being "~20% faster than spread operators" due to reduced memory allocations. The change applies the same proven pattern to the remaining file finders. Tests pass successfully in ~4.5 seconds.

---
*PR created automatically by Jules for task [8860985516983026526](https://jules.google.com/task/8860985516983026526) started by @n24q02m*