### PR TITLE
🔒 Fix path traversal vulnerability in Scenes tool

### DIFF
--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -17,6 +17,7 @@ import { readFile } from 'node:fs/promises'
 import { basename, dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig, SceneInfo, SceneNode } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 import { setSettingInContent } from '../helpers/project-settings.js'
 
 /**
@@ -106,8 +107,8 @@ function validateSceneArgs(action: string, args: Record<string, unknown>, config
   const scenePath = args.scene_path as string
   const newPath = args.new_path as string
 
-  // project_path required
-  if (['create', 'list', 'set_main'].includes(action) && !projectPath) {
+  // project_path required for all actions to ensure path security
+  if (!projectPath) {
     throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
   }
 
@@ -137,7 +138,14 @@ function validateSceneArgs(action: string, args: Record<string, unknown>, config
 }
 
 function resolvePath(base: string | undefined, relative: string): string {
-  return base ? resolve(base, relative) : resolve(relative)
+  if (!base) {
+    throw new GodotMCPError(
+      'No project path specified',
+      'INVALID_ARGS',
+      'Provide project_path argument to resolve paths securely.',
+    )
+  }
+  return safeResolve(base, relative)
 }
 
 export async function handleScenes(action: string, args: Record<string, unknown>, config: GodotConfig) {
@@ -149,7 +157,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       const rootType = (args.root_type as string) || 'Node2D'
       const rootName = (args.root_name as string) || basename(scenePath, '.tscn')
 
-      const fullPath = resolve(projectPath as string, scenePath)
+      const fullPath = safeResolve(projectPath as string, scenePath)
       if (existsSync(fullPath)) {
         throw new GodotMCPError(
           `Scene already exists: ${scenePath}`,

--- a/tests/composite/scenes.test.ts
+++ b/tests/composite/scenes.test.ts
@@ -151,6 +151,32 @@ describe('scenes', () => {
       expect(data.nodeCount).toBeGreaterThan(0)
     })
 
+    it('should prevent path traversal outside project root', async () => {
+      await expect(
+        handleScenes(
+          'info',
+          {
+            project_path: projectPath,
+            scene_path: '../../../etc/passwd',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Access denied')
+    })
+
+    it('should prevent absolute paths outside project root', async () => {
+      await expect(
+        handleScenes(
+          'info',
+          {
+            project_path: projectPath,
+            scene_path: '/etc/passwd',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Access denied')
+    })
+
     it('should throw for missing scene', async () => {
       await expect(
         handleScenes(


### PR DESCRIPTION
🎯 **What:** The `handleScenes` tool (`src/tools/composite/scenes.ts`) was vulnerable to path traversal (CWE-22). The tool improperly used Node.js's `path.resolve` to combine the `project_path` and `scene_path` arguments without ensuring the resulting path remained within the Godot project root.

⚠️ **Risk:** A malicious actor or compromised prompt interacting with this MCP server could potentially read, overwrite, or delete arbitrary files on the local filesystem by providing a manipulated `scene_path` like `../../../etc/passwd` or an absolute path `/etc/passwd`. The impact would be limited to the privileges of the user running the MCP process, but could lead to information disclosure or destructive operations.

🛡️ **Solution:**
- Swapped `resolve` for the existing `safeResolve` utility from `src/tools/helpers/paths.ts` inside `resolvePath` and `handleScenes`.
- Modified `validateSceneArgs` to mandate `project_path` for all operations in the `scenes` tool, providing a bounded directory for `safeResolve`.
- Added automated path traversal test coverage to `tests/composite/scenes.test.ts`.

---
*PR created automatically by Jules for task [4200706584916335204](https://jules.google.com/task/4200706584916335204) started by @n24q02m*