### PR TITLE
🧪 Add missing test coverage for handleAnimation tool

### DIFF
--- a/tests/composite/animation.test.ts
+++ b/tests/composite/animation.test.ts
@@ -125,6 +125,26 @@ describe('animation', () => {
       expect(content).toContain('length = 2.5')
       expect(content).toContain('loop_mode = 0')
     })
+
+    it('should append the animation at the end if there are no [node] tags', async () => {
+      createTmpScene(projectPath, 'test_no_nodes.tscn', '[gd_scene format=3 uid="uid://test"]\n')
+
+      const result = await handleAnimation(
+        'add_animation',
+        {
+          project_path: projectPath,
+          scene_path: 'test_no_nodes.tscn',
+          anim_name: 'EmptySceneAnim',
+        },
+        config,
+      )
+
+      expect(result.content[0].text).toContain('Added animation: EmptySceneAnim')
+      const content = readFileSync(join(projectPath, 'test_no_nodes.tscn'), 'utf-8')
+      expect(content).toContain('[sub_resource type="Animation" id="Animation_EmptySceneAnim"]')
+      expect(content).toContain('resource_name = "EmptySceneAnim"')
+      expect(content.endsWith('loop_mode = 1\n')).toBe(true)
+    })
   })
 
   // ==========================================
@@ -161,6 +181,49 @@ describe('animation', () => {
       const content = readFileSync(join(projectPath, 'test.tscn'), 'utf-8')
       expect(content).toContain('tracks/value/type = "value"')
       expect(content).toContain('tracks/value/path = NodePath("Sprite:position")')
+    })
+
+    it('should throw if anim_name, node_path, or property is missing', async () => {
+      createTmpScene(projectPath, 'test.tscn', MINIMAL_TSCN)
+
+      await expect(
+        handleAnimation(
+          'add_track',
+          {
+            project_path: projectPath,
+            scene_path: 'test.tscn',
+            node_path: 'Sprite',
+            property: 'position',
+          },
+          config,
+        ),
+      ).rejects.toThrow('anim_name, node_path, and property required')
+
+      await expect(
+        handleAnimation(
+          'add_track',
+          {
+            project_path: projectPath,
+            scene_path: 'test.tscn',
+            anim_name: 'Walk',
+            property: 'position',
+          },
+          config,
+        ),
+      ).rejects.toThrow('anim_name, node_path, and property required')
+
+      await expect(
+        handleAnimation(
+          'add_track',
+          {
+            project_path: projectPath,
+            scene_path: 'test.tscn',
+            anim_name: 'Walk',
+            node_path: 'Sprite',
+          },
+          config,
+        ),
+      ).rejects.toThrow('anim_name, node_path, and property required')
     })
 
     it('should throw if animation does not exist', async () => {


### PR DESCRIPTION
🎯 **What:** The `handleAnimation` composite tool in `src/tools/composite/animation.ts` lacked test coverage for specific edge cases: missing `[node]` tags when adding animations (line 58) and missing properties when adding tracks (lines 75-80).
📊 **Coverage:** Added test cases for `add_animation` when applied to `.tscn` files without `[node]` tags. Added test cases for `add_track` to assert that a `GodotMCPError` is thrown when `anim_name`, `node_path`, or `property` is omitted.
✨ **Result:** Test coverage for `src/tools/composite/animation.ts` is now 100%.

---
*PR created automatically by Jules for task [4510133737237362341](https://jules.google.com/task/4510133737237362341) started by @n24q02m*