### PR TITLE
🧪 test: add coverage for wrapToolResult in security.ts

### DIFF
--- a/tests/helpers/security.test.ts
+++ b/tests/helpers/security.test.ts
@@ -68,6 +68,19 @@ describe('security', () => {
       expect(wrapped.content[0].text).not.toContain('<untrusted_godot_content>')
     })
 
+    it('should wrap result if isError is explicitly false', () => {
+      const toolName = 'scripts'
+      const result = {
+        isError: false,
+        content: [{ type: 'text', text: 'extends Node' }],
+      }
+      // @ts-expect-error - isError is not in the type definition but is handled in runtime
+      const wrapped = wrapToolResult(toolName, result)
+      expect(wrapped).not.toBe(result)
+      expect(wrapped.content[0].text).toContain('<untrusted_godot_content>')
+      expect(wrapped.content[0].text).toContain('extends Node')
+    })
+
     it('should handle multiple content items', () => {
       const toolName = 'scripts'
       const result = {
@@ -82,6 +95,46 @@ describe('security', () => {
       expect(wrapped.content[0].text).toContain('script1')
       expect(wrapped.content[1].text).toContain('<untrusted_godot_content>')
       expect(wrapped.content[1].text).toContain('script2')
+    })
+
+    it('should handle empty content array', () => {
+      const toolName = 'scripts'
+      const result = {
+        content: [],
+      }
+      const wrapped = wrapToolResult(toolName, result)
+      expect(wrapped).not.toBe(result)
+      expect(wrapped.content).toHaveLength(0)
+    })
+
+    it('should preserve other properties on the result object', () => {
+      const toolName = 'scripts'
+      const result = {
+        content: [{ type: 'text', text: 'extends Node' }],
+        extraProp: 'should be preserved',
+        metadata: { id: 123 },
+      }
+      // @ts-expect-error - testing extra properties
+      const wrapped = wrapToolResult(toolName, result)
+      expect(wrapped).not.toBe(result)
+      // @ts-expect-error - testing extra properties
+      expect(wrapped.extraProp).toBe('should be preserved')
+      // @ts-expect-error - testing extra properties
+      expect(wrapped.metadata).toEqual({ id: 123 })
+      expect(wrapped.content[0].text).toContain('<untrusted_godot_content>')
+    })
+
+    it('should preserve other properties on content items', () => {
+      const toolName = 'scripts'
+      const result = {
+        content: [{ type: 'text', text: 'extends Node', extraItemProp: 'kept' }],
+      }
+      // @ts-expect-error - testing extra properties
+      const wrapped = wrapToolResult(toolName, result)
+      expect(wrapped).not.toBe(result)
+      // @ts-expect-error - testing extra properties
+      expect(wrapped.content[0].extraItemProp).toBe('kept')
+      expect(wrapped.content[0].text).toContain('<untrusted_godot_content>')
     })
   })
 })


### PR DESCRIPTION
🎯 **What:** The `wrapToolResult` function in `src/tools/helpers/security.ts` had a missing unit test. Specifically, it didn't test properties handling, and explicit false on `isError`.
📊 **Coverage:** Added tests to cover when `isError` is explicitly false, to check empty content array handling, and to make sure other extra properties on the result object or content items are correctly passed through unmutated.
✨ **Result:** Test coverage for `security.ts` now captures object behavior successfully.

---
*PR created automatically by Jules for task [442966756765312137](https://jules.google.com/task/442966756765312137) started by @n24q02m*