### PR TITLE
🧪 Add test coverage for handleAudio when [resource] tag is missing

### DIFF
--- a/tests/composite/audio.test.ts
+++ b/tests/composite/audio.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { GodotConfig } from '../../src/godot/types.js'
@@ -35,7 +35,6 @@ describe('audio', () => {
       const layoutPath = join(projectPath, 'default_bus_layout.tres')
       const content = SAMPLE_BUS_LAYOUT
       // Write content manually since we don't have a helper for it, or use node:fs
-      const { writeFileSync } = await import('node:fs')
       writeFileSync(layoutPath, content, 'utf-8')
 
       const result = await handleAudio('list_buses', { project_path: projectPath }, config)
@@ -157,6 +156,30 @@ describe('audio', () => {
           config,
         ),
       ).rejects.toThrow('Bus "NonExistent" not found')
+    })
+
+    it('should append sub_resource if [resource] tag is missing', async () => {
+      // Create a layout file without [resource]
+      const { writeFileSync } = await import('node:fs')
+      const layoutPath = join(projectPath, 'default_bus_layout.tres')
+      writeFileSync(layoutPath, 'bus/0/name = "Master"\n', 'utf-8')
+
+      const result = await handleAudio(
+        'add_effect',
+        {
+          project_path: projectPath,
+          bus_name: 'Master',
+          effect_type: 'Reverb',
+        },
+        config,
+      )
+
+      expect(result.content[0].text).toContain('Added AudioEffectReverb to bus "Master"')
+
+      const content = readFileSync(layoutPath, 'utf-8')
+      expect(content).toContain('[sub_resource type="AudioEffectReverb"')
+      // Verify it was appended (since [resource] was missing)
+      expect(content.endsWith('enabled = true\n')).toBe(true)
     })
 
     it('should throw if missing args', async () => {


### PR DESCRIPTION
🎯 **What:** Added a missing test case in `tests/composite/audio.test.ts` for the `handleAudio` tool.
📊 **Coverage:** Specifically covers the `add_effect` action when appending a sub-resource to a `default_bus_layout.tres` file that is missing a `[resource]` section.
✨ **Result:** Test coverage for `src/tools/composite/audio.ts` is improved, ensuring the file modification handles both well-formed and incomplete `.tres` bus layout files successfully.

---
*PR created automatically by Jules for task [14789847436236246645](https://jules.google.com/task/14789847436236246645) started by @n24q02m*