### PR TITLE
🧹 Use shared scene-parser in scenes.ts

### DIFF
--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -5,37 +5,16 @@
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import type { GodotConfig, SceneNode } from '../../godot/types.js'
+import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import {
   getNodeProperty,
+  mapToSceneNode,
   parseSceneContent,
   removeNodeFromContent,
   renameNodeInContent,
-  type SceneNodeInfo,
   setNodePropertyInContent,
 } from '../helpers/scene-parser.js'
-
-/**
- * Map scene-parser's SceneNodeInfo to internal SceneNode format
- */
-function mapToSceneNode(node: SceneNodeInfo): SceneNode {
-  const properties = { ...node.properties }
-  let script: string | null = null
-
-  if (properties.script) {
-    script = properties.script
-    delete properties.script
-  }
-
-  return {
-    name: node.name,
-    type: node.type || 'Node',
-    parent: node.parent || null,
-    properties,
-    script,
-  }
-}
 
 function resolveScenePath(projectPath: string | null | undefined, scenePath: string): string {
   return projectPath ? resolve(projectPath, scenePath) : resolve(scenePath)

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -15,57 +15,30 @@ import {
 } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { basename, dirname, extname, join, relative, resolve } from 'node:path'
-import type { GodotConfig, SceneInfo, SceneNode } from '../../godot/types.js'
+import type { GodotConfig, SceneInfo } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { setSettingInContent } from '../helpers/project-settings.js'
+import { mapToSceneNode, parseSceneContent } from '../helpers/scene-parser.js'
 
 /**
  * Parse a .tscn file to extract scene information
  */
 async function parseTscnFile(filePath: string): Promise<SceneInfo> {
   const content = await readFile(filePath, 'utf-8')
-  const lines = content.split('\n')
+  const scene = parseSceneContent(content)
 
-  const nodes: SceneNode[] = []
-  const resources: string[] = []
-  let rootNode = ''
-  let rootType = ''
+  const nodes = scene.nodes.map(mapToSceneNode)
 
-  for (const line of lines) {
-    const trimmed = line.trim()
+  const rootNodeInfo = scene.nodes.find((n) => !n.parent || n.parent === '.') || scene.nodes[0]
+  const rootNode = rootNodeInfo?.name || ''
+  const rootType = rootNodeInfo?.type || ''
 
-    const nodeMatch = trimmed.match(/^\[node\s+name="([^"]+)"\s+type="([^"]+)"(?:\s+parent="([^"]*)")?/)
-    if (nodeMatch) {
-      const node: SceneNode = {
-        name: nodeMatch[1],
-        type: nodeMatch[2],
-        parent: nodeMatch[3] ?? null,
-        properties: {},
-        script: null,
-      }
-
-      if (!node.parent && nodes.length === 0) {
-        rootNode = node.name
-        rootType = node.type
-      }
-
-      nodes.push(node)
-      continue
-    }
-
-    const resMatch = trimmed.match(/^\[(ext_resource|sub_resource)\s+(.+)\]$/)
-    if (resMatch) {
-      resources.push(trimmed)
-      continue
-    }
-
-    if (trimmed.startsWith('script') && nodes.length > 0) {
-      const scriptMatch = trimmed.match(/^script\s*=\s*(.+)$/)
-      if (scriptMatch) {
-        nodes[nodes.length - 1].script = scriptMatch[1]
-      }
-    }
-  }
+  const resources: string[] = [
+    ...scene.extResources.map(
+      (r) => `[ext_resource type="${r.type}"${r.uid ? ` uid="${r.uid}"` : ''} path="${r.path}" id="${r.id}"]`,
+    ),
+    ...scene.subResources.map((r) => `[sub_resource type="${r.type}" id="${r.id}"]`),
+  ]
 
   return { path: filePath, rootNode, rootType, nodeCount: nodes.length, nodes, resources }
 }

--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -12,6 +12,7 @@
  */
 
 import { readFileSync, writeFileSync } from 'node:fs'
+import type { SceneNode } from '../../godot/types.js'
 
 // Pre-compiled regular expressions for parsing scene sections
 const rxGdSceneFormat = /format=(\d+)/
@@ -372,4 +373,25 @@ export function getNodeProperty(scene: ParsedScene, nodeName: string, property: 
  */
 export function writeScene(filePath: string, content: string): void {
   writeFileSync(filePath, content, 'utf-8')
+}
+
+/**
+ * Map scene-parser's SceneNodeInfo to internal SceneNode format
+ */
+export function mapToSceneNode(node: SceneNodeInfo): SceneNode {
+  const properties = { ...node.properties }
+  let script: string | null = null
+
+  if (properties.script) {
+    script = properties.script
+    delete properties.script
+  }
+
+  return {
+    name: node.name,
+    type: node.type || 'Node',
+    parent: node.parent || null,
+    properties,
+    script,
+  }
 }


### PR DESCRIPTION
🎯 **What:** The `parseTscnFile` function in `src/tools/composite/scenes.ts` was replaced with the optimized and robust `parseSceneContent` from `src/tools/helpers/scene-parser.ts`. Additionally, the `mapToSceneNode` mapping utility was moved from `nodes.ts` to `scene-parser.ts` to be reused securely and safely between tools.

💡 **Why:** This improves maintainability and readability by eliminating a duplicate custom ad-hoc regex parser for `.tscn` files, preventing divergence in feature parity and potential errors in parsing.

✅ **Verification:** Verified that changes compile correctly. Ran `pnpm run check` and `pnpm test` (with all 403 test cases passing). 

✨ **Result:** Better consolidated `.tscn` parsing logic avoiding repeated buggy structures.

---
*PR created automatically by Jules for task [5187456268599363422](https://jules.google.com/task/5187456268599363422) started by @n24q02m*