### PR TITLE
🧹 Refactor parseProjectGodot to use shared project-settings parser

### DIFF
--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -22,40 +22,27 @@ async function parseProjectGodot(projectPath: string): Promise<ProjectInfo> {
     )
   }
 
-  const content = await readFile(configPath, 'utf-8')
-  const lines = content.split('\n')
-
+  const settings = await parseProjectSettingsAsync(configPath)
   const info: ProjectInfo = { name: 'Unknown', configVersion: 5, mainScene: null, features: [], settings: {} }
-  let currentSection = ''
 
-  for (const line of lines) {
-    const trimmed = line.trim()
+  for (const [section, keys] of settings.sections.entries()) {
+    for (const [key, rawValue] of keys.entries()) {
+      const value = rawValue.replace(/^"(.*)"$/, '$1')
 
-    const sectionMatch = trimmed.match(/^\[(.+)\]$/)
-    if (sectionMatch) {
-      currentSection = sectionMatch[1]
-      continue
-    }
-
-    const kvMatch = trimmed.match(/^(\S+)\s*=\s*(.+)$/)
-    if (!kvMatch) continue
-
-    const [, key, rawValue] = kvMatch
-    const value = rawValue.replace(/^"(.*)"$/, '$1')
-
-    if (currentSection === '' || currentSection === 'application') {
-      if (key === 'config/name') info.name = value
-      if (key === 'run/main_scene') info.mainScene = value
-      if (key === 'config/features') {
-        const featMatch = rawValue.match(/PackedStringArray\((.+)\)/)
-        if (featMatch) {
-          info.features = featMatch[1].split(',').map((f) => f.trim().replace(/"/g, ''))
+      if (section === '' || section === 'application') {
+        if (key === 'config/name') info.name = value
+        if (key === 'run/main_scene') info.mainScene = value
+        if (key === 'config/features') {
+          const featMatch = rawValue.match(/PackedStringArray\((.+)\)/)
+          if (featMatch) {
+            info.features = featMatch[1].split(',').map((f) => f.trim().replace(/"/g, ''))
+          }
         }
       }
-    }
 
-    if (key === 'config_version') info.configVersion = Number.parseInt(value, 10)
-    info.settings[`${currentSection ? `${currentSection}/` : ''}${key}`] = value
+      if (key === 'config_version') info.configVersion = Number.parseInt(value, 10)
+      info.settings[`${section ? `${section}/` : ''}${key}`] = value
+    }
   }
 
   return info


### PR DESCRIPTION
🎯 What: Refactored \`parseProjectGodot\` in \`src/tools/composite/project.ts\` to use the shared \`parseProjectSettingsAsync\` utility instead of manually parsing the file line by line.
💡 Why: This improves maintainability by removing duplicated, ad-hoc text parsing and instead centralizes INI-style parsing in the optimized \`project-settings.ts\` helper.
✅ Verification: Ran \`pnpm run check\` and \`pnpm run test\` (specifically \`tests/composite/project.test.ts\`) to ensure the correct extraction of \`ProjectInfo\` fields is preserved.
✨ Result: Code is cleaner, avoids duplicated parsing logic, and benefits from the performance optimizations of the shared helper.

---
*PR created automatically by Jules for task [10025766752421532378](https://jules.google.com/task/10025766752421532378) started by @n24q02m*