### PR TITLE
🧪 [testing improvement description]

### DIFF
--- a/tests/composite/config.test.ts
+++ b/tests/composite/config.test.ts
@@ -58,6 +58,32 @@ describe('config', () => {
 
       expect(typeof data.runtime_overrides).toBe('object')
     })
+
+    it('should show unknown when godotVersion is not present', async () => {
+      config = makeConfig({ projectPath: '/tmp/proj' })
+      delete config.godotVersion
+
+      const result = await handleConfig('status', {}, config)
+      const data = JSON.parse(result.content[0].text)
+
+      expect(data.godot_version).toBe('unknown')
+    })
+
+    it('should show raw version when godotVersion is present', async () => {
+      config = makeConfig({ projectPath: '/tmp/proj' })
+      config.godotVersion = {
+        raw: '4.3.stable.official.77dcf97d8',
+        major: 4,
+        minor: 3,
+        patch: 0,
+        status: 'stable',
+      }
+
+      const result = await handleConfig('status', {}, config)
+      const data = JSON.parse(result.content[0].text)
+
+      expect(data.godot_version).toBe('4.3.stable.official.77dcf97d8')
+    })
   })
 
   // ==========================================
@@ -101,6 +127,12 @@ describe('config', () => {
 
     it('should throw when value is undefined', async () => {
       await expect(handleConfig('set', { key: 'project_path' }, config)).rejects.toThrow('No value specified')
+    })
+
+    it('should throw when value is null', async () => {
+      await expect(handleConfig('set', { key: 'project_path', value: null }, config)).rejects.toThrow(
+        'No value specified',
+      )
     })
   })
 


### PR DESCRIPTION
🎯 **What:** The `handleConfig` tool (`src/tools/composite/config.ts`) was missing test coverage for its fallback logic regarding `config.godotVersion` in the `status` action, and was missing explicit test coverage for rejecting `null` values in the `set` action.
📊 **Coverage:** Added test cases for when `godotVersion` is undefined/null and when it contains a raw version string. Also explicitly tested `null` value rejection in the `set` action.
✨ **Result:** Test coverage for `src/tools/composite/config.ts` is now at 100% across statements, lines, branches, and functions. Code health was maintained via `pnpm run check:fix`.

---
*PR created automatically by Jules for task [15924733133120073096](https://jules.google.com/task/15924733133120073096) started by @n24q02m*