### PR TITLE
🧪 Improve test coverage for handleAudio in audio.ts

### DIFF
--- a/tests/composite/audio.test.ts
+++ b/tests/composite/audio.test.ts
@@ -145,6 +145,29 @@ describe('audio', () => {
       expect(result.content[0].text).toContain('Added AudioEffectEQ to bus "Music"')
     })
 
+    it('should append effect when [resource] section is missing in layout', async () => {
+      // Create a layout missing the [resource] tag
+      const layoutPath = join(projectPath, 'default_bus_layout.tres')
+      const content = 'bus/0/name = "Master"\n'
+      const { writeFileSync } = await import('node:fs')
+      writeFileSync(layoutPath, content, 'utf-8')
+
+      const result = await handleAudio(
+        'add_effect',
+        {
+          project_path: projectPath,
+          bus_name: 'Master',
+          effect_type: 'Reverb',
+        },
+        config,
+      )
+
+      expect(result.content[0].text).toContain('Added AudioEffectReverb to bus "Master"')
+
+      const newContent = readFileSync(layoutPath, 'utf-8')
+      expect(newContent).toContain('[sub_resource type="AudioEffectReverb"')
+    })
+
     it('should throw if bus not found', async () => {
       await expect(
         handleAudio(


### PR DESCRIPTION
🎯 **What:** 
The issue highlighted a testing gap in `src/tools/composite/audio.ts`, where certain lines (specifically those handling the edge case of appending an effect when the `[resource]` section is entirely missing from `default_bus_layout.tres`) were untested.

📊 **Coverage:**
A new test case was added to `tests/composite/audio.test.ts` within the `add_effect` describe block: `it('should append effect when [resource] section is missing in layout')`. This test explicitly creates a layout file lacking the `[resource]` tag and invokes `add_effect`, asserting that the effect is correctly appended at the end of the file. 

✨ **Result:**
The test passes successfully, and test coverage for `src/tools/composite/audio.ts` is now at 100%. The full test suite also runs and passes, confirming no regressions.

---
*PR created automatically by Jules for task [5300716082675938475](https://jules.google.com/task/5300716082675938475) started by @n24q02m*