### PR TITLE
🛡️ Sentinel: [HIGH] Fix Input Validation for Path Metacharacters

### DIFF
--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -37,11 +37,11 @@ export async function handleConfig(action: string, args: Record<string, unknown>
       }
 
       // Validate paths don't contain shell metacharacters
-      if ((key === 'project_path' || key === 'godot_path') && /[;&|`$(){}]/.test(value)) {
+      if ((key === 'project_path' || key === 'godot_path') && /[;&|`$(){}<>'"\0\n\r]/.test(value)) {
         throw new GodotMCPError(
           `Invalid characters in ${key}`,
           'INVALID_ARGS',
-          'Path must not contain shell metacharacters: ; & | ` $ ( ) { }',
+          'Path must not contain shell metacharacters: ; & | ` $ ( ) { } < > \' " \\0 \\n \\r',
         )
       }
 

--- a/tests/composite/config.test.ts
+++ b/tests/composite/config.test.ts
@@ -121,6 +121,30 @@ describe('config', () => {
       )
     })
 
+    it('should reject paths with command substitution', async () => {
+      await expect(handleConfig('set', { key: 'godot_path', value: '/usr/bin/$(whoami)' }, config)).rejects.toThrow(
+        'Invalid characters',
+      )
+    })
+
+    it('should reject paths with quotes', async () => {
+      await expect(handleConfig('set', { key: 'godot_path', value: '/usr/bin/"malicious"' }, config)).rejects.toThrow(
+        'Invalid characters',
+      )
+    })
+
+    it('should reject paths with redirection', async () => {
+      await expect(handleConfig('set', { key: 'godot_path', value: '/usr/bin/godot > /tmp/out' }, config)).rejects.toThrow(
+        'Invalid characters',
+      )
+    })
+
+    it('should reject paths with newlines', async () => {
+      await expect(handleConfig('set', { key: 'godot_path', value: '/usr/bin/godot\nrm -rf /' }, config)).rejects.toThrow(
+        'Invalid characters',
+      )
+    })
+
     it('should allow timeout with numeric value (no path validation)', async () => {
       const result = await handleConfig('set', { key: 'timeout', value: '30000' }, config)
       expect(result.content[0].text).toContain('Config updated')


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The validation for `project_path` and `godot_path` only checked for basic shell injection like `;&|`$(){}` but failed to check for characters like `<>'"\0\n\r` which can also be utilized in attacks such as redirection or command substitutions.
🎯 Impact: This could have allowed a malicious actor to perform limited command injection or path traversal when configuring path strings that Godot would execute headless or with external shell APIs. 
🔧 Fix: Updated the regular expression to test for `[;&|`$(){}<>'"\0\n\r]` to explicitly deny all major shell metacharacters as defined in codebase memory constraints. Added corresponding tests.
✅ Verification: Ran test suite via `vitest run`, observing all 417 tests passed properly.

---
*PR created automatically by Jules for task [12737835369832640513](https://jules.google.com/task/12737835369832640513) started by @n24q02m*