### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal Vulnerability in Path Resolvers

### DIFF
--- a/src/tools/composite/animation.ts
+++ b/src/tools/composite/animation.ts
@@ -4,13 +4,12 @@
  */
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
 
 function resolveScene(projectPath: string | null | undefined, scenePath: string): string {
-  const fullPath = projectPath ? safeResolve(projectPath, scenePath) : resolve(scenePath)
+  const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
   if (!existsSync(fullPath))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
   return fullPath

--- a/src/tools/composite/audio.ts
+++ b/src/tools/composite/audio.ts
@@ -157,7 +157,7 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       const parent = (args.parent as string) || '.'
       const bus = (args.bus as string) || 'Master'
 
-      const fullPath = projectPath ? safeResolve(projectPath, scenePath) : resolve(scenePath)
+      const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 

--- a/src/tools/composite/navigation.ts
+++ b/src/tools/composite/navigation.ts
@@ -4,13 +4,12 @@
  */
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
 
 function resolveScene(projectPath: string | null | undefined, scenePath: string): string {
-  const fullPath = projectPath ? safeResolve(projectPath, scenePath) : resolve(scenePath)
+  const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
   if (!existsSync(fullPath))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
   return fullPath

--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -4,7 +4,6 @@
  */
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 import type { GodotConfig, SceneNode } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
@@ -39,7 +38,7 @@ function mapToSceneNode(node: SceneNodeInfo): SceneNode {
 }
 
 function resolveScenePath(projectPath: string | null | undefined, scenePath: string): string {
-  return projectPath ? safeResolve(projectPath, scenePath) : resolve(scenePath)
+  return safeResolve(projectPath || process.cwd(), scenePath)
 }
 
 export async function handleNodes(action: string, args: Record<string, unknown>, config: GodotConfig) {

--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -44,7 +44,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       const collisionLayer = args.collision_layer as number
       const collisionMask = args.collision_mask as number
 
-      const fullPath = projectPath ? safeResolve(projectPath, scenePath) : resolve(scenePath)
+      const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 
@@ -75,7 +75,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       const nodeName = args.name as string
       if (!nodeName) throw new GodotMCPError('No node name specified', 'INVALID_ARGS', 'Provide node name.')
 
-      const fullPath = projectPath ? safeResolve(projectPath, scenePath) : resolve(scenePath)
+      const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 

--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -86,7 +86,7 @@ export async function handleResources(action: string, args: Record<string, unkno
     case 'info': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-      const fullPath = projectPath ? safeResolve(projectPath, resPath) : resolve(resPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), resPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
@@ -114,7 +114,7 @@ export async function handleResources(action: string, args: Record<string, unkno
     case 'delete': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-      const fullPath = projectPath ? safeResolve(projectPath, resPath) : resolve(resPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), resPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
@@ -130,7 +130,7 @@ export async function handleResources(action: string, args: Record<string, unkno
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
 
-      const importPath = projectPath ? safeResolve(projectPath, `${resPath}.import`) : resolve(`${resPath}.import`)
+      const importPath = safeResolve(projectPath || process.cwd(), `${resPath}.import`)
 
       if (!existsSync(importPath)) {
         return formatJSON({ path: resPath, imported: false, message: 'No .import file found.' })

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -125,7 +125,7 @@ function validateSceneArgs(action: string, args: Record<string, unknown>, config
 
 function resolvePath(base: string | undefined, relativePath: string): string {
   if (base) return safeResolve(base, relativePath)
-  return resolve(relativePath)
+  return safeResolve(process.cwd(), relativePath)
 }
 
 export async function handleScenes(action: string, args: Record<string, unknown>, config: GodotConfig) {
@@ -137,7 +137,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       const rootType = (args.root_type as string) || 'Node2D'
       const rootName = (args.root_name as string) || basename(scenePath, '.tscn')
 
-      const fullPath = resolve(projectPath as string, scenePath)
+      const fullPath = safeResolve(projectPath as string, scenePath)
       if (existsSync(fullPath)) {
         throw new GodotMCPError(
           `Scene already exists: ${scenePath}`,

--- a/src/tools/composite/shader.ts
+++ b/src/tools/composite/shader.ts
@@ -88,7 +88,7 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderType = (args.shader_type as string) || 'canvas_item'
       const content = (args.content as string) || SHADER_TEMPLATES[shaderType] || SHADER_TEMPLATES.canvas_item
 
-      const fullPath = projectPath ? safeResolve(projectPath, shaderPath) : resolve(shaderPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), shaderPath)
 
       // Ensure directory exists
       await mkdir(dirname(fullPath), { recursive: true })
@@ -110,7 +110,7 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderPath = args.shader_path as string
       if (!shaderPath) throw new GodotMCPError('No shader_path specified', 'INVALID_ARGS', 'Provide shader_path.')
 
-      const fullPath = projectPath ? safeResolve(projectPath, shaderPath) : resolve(shaderPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), shaderPath)
 
       try {
         const content = await readFile(fullPath, 'utf-8')
@@ -129,7 +129,7 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const content = args.content as string
       if (!content) throw new GodotMCPError('No content specified', 'INVALID_ARGS', 'Provide shader content.')
 
-      const fullPath = projectPath ? safeResolve(projectPath, shaderPath) : resolve(shaderPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), shaderPath)
       await mkdir(dirname(fullPath), { recursive: true })
       await writeFile(fullPath, content, 'utf-8')
       return formatSuccess(`Written: ${shaderPath} (${content.length} chars)`)
@@ -139,7 +139,7 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderPath = args.shader_path as string
       if (!shaderPath) throw new GodotMCPError('No shader_path specified', 'INVALID_ARGS', 'Provide shader_path.')
 
-      const fullPath = projectPath ? safeResolve(projectPath, shaderPath) : resolve(shaderPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), shaderPath)
 
       try {
         const content = await readFile(fullPath, 'utf-8')

--- a/src/tools/composite/signals.ts
+++ b/src/tools/composite/signals.ts
@@ -4,7 +4,6 @@
  */
 
 import { readFile, writeFile } from 'node:fs/promises'
-import { resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
@@ -15,7 +14,7 @@ export async function handleSignals(action: string, args: Record<string, unknown
   const scenePath = args.scene_path as string
 
   if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
-  const fullPath = projectPath ? safeResolve(projectPath, scenePath) : resolve(scenePath)
+  const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
 
   async function readScene() {
     try {

--- a/src/tools/composite/tilemap.ts
+++ b/src/tools/composite/tilemap.ts
@@ -4,7 +4,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
+import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
@@ -23,7 +23,7 @@ export async function handleTilemap(action: string, args: Record<string, unknown
         )
       const tileSize = (args.tile_size as number) || 16
 
-      const fullPath = projectPath ? safeResolve(projectPath, tilesetPath) : resolve(tilesetPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), tilesetPath)
       if (existsSync(fullPath)) {
         throw new GodotMCPError(`TileSet already exists: ${tilesetPath}`, 'TILEMAP_ERROR', 'Use a different path.')
       }
@@ -49,7 +49,7 @@ export async function handleTilemap(action: string, args: Record<string, unknown
         throw new GodotMCPError('tileset_path and texture_path required', 'INVALID_ARGS', 'Both are required.')
       }
 
-      const fullPath = projectPath ? safeResolve(projectPath, tilesetPath) : resolve(tilesetPath)
+      const fullPath = safeResolve(projectPath || process.cwd(), tilesetPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`TileSet not found: ${tilesetPath}`, 'TILEMAP_ERROR', 'Create the tileset first.')
 
@@ -92,7 +92,7 @@ export async function handleTilemap(action: string, args: Record<string, unknown
       const scenePath = args.scene_path as string
       if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
 
-      const fullPath = projectPath ? safeResolve(projectPath, scenePath) : resolve(scenePath)
+      const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
 

--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -4,7 +4,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
+import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
@@ -32,7 +32,7 @@ const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
 }
 
 function resolveScene(projectPath: string | null | undefined, scenePath: string): string {
-  const fullPath = projectPath ? safeResolve(projectPath, scenePath) : resolve(scenePath)
+  const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
   if (!existsSync(fullPath))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
   return fullPath
@@ -88,7 +88,7 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
           'Provide theme_path (e.g., "themes/main.tres").',
         )
 
-      const fullPath = projectPath ? safeResolve(projectPath, themePath) : resolve(themePath)
+      const fullPath = safeResolve(projectPath || process.cwd(), themePath)
 
       const fontSize = (args.font_size as number) || 16
       const _fontColor = (args.font_color as string) || 'Color(1, 1, 1, 1)'


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Path Traversal Vulnerability in Path Resolvers

🚨 **Severity**: CRITICAL
💡 **Vulnerability**: A path traversal vulnerability existed in multiple files inside `src/tools/composite/` because file paths were unsafely resolved using a direct `resolve(path)` fallback when `projectPath` was falsy (e.g., `projectPath ? safeResolve(projectPath, path) : resolve(path)`).
🎯 **Impact**: If a user omitted `project_path` (or it wasn't set globally) and passed an absolute path or a path utilizing `..` (like `../../../../etc/passwd`), it fell back to the unsafe `resolve(path)`, entirely bypassing the `safeResolve` boundary checks designed to keep operations within the project root. This could lead to arbitrary file reads, modifications, or deletions anywhere on the host filesystem.
🔧 **Fix**: Substituted the flawed ternary check with a much safer, robust implementation. Now, it always enforces resolution via `safeResolve`, employing `projectPath || process.cwd()` as the secure base fallback directory. `safeResolve` correctly handles boundary validation regardless of whether the base directory originates from the user's explicit project configuration or the execution root environment.
✅ **Verification**: Verified using Vitest suite run via `pnpm test` (all tests passed). Confirmed no stray occurrences of `resolve(projectPath` remain unhandled. Recorded learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [247938793622412679](https://jules.google.com/task/247938793622412679) started by @n24q02m*