### PR TITLE
⚡ Bolt: use async I/O for file traversal to prevent event loop blocking

### DIFF
--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -3,7 +3,8 @@
  * Actions: list | info | delete | import_config
  */
 
-import { existsSync, readdirSync, readFileSync, statSync, unlinkSync } from 'node:fs'
+import { existsSync, readFileSync, statSync, unlinkSync } from 'node:fs'
+import { readdir, stat } from 'node:fs/promises'
 import { extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
@@ -33,23 +34,34 @@ interface ResourceEntry {
   size: number
 }
 
-function findResourceFiles(dir: string, extensions?: Set<string>, results: ResourceEntry[] = []): ResourceEntry[] {
+async function findResourceFiles(dir: string, extensions?: Set<string>): Promise<ResourceEntry[]> {
   const exts = extensions || RESOURCE_EXTENSIONS
   try {
-    const entries = readdirSync(dir, { withFileTypes: true })
-    for (const entry of entries) {
-      if (entry.name.startsWith('.') || entry.name === 'node_modules' || entry.name === 'build') continue
-      const fullPath = join(dir, entry.name)
+    const entries = await readdir(dir, { withFileTypes: true })
+    const promises = entries.map(async (entry) => {
+      const name = entry.name
+      if (name.startsWith('.') || name === 'node_modules' || name === 'build') return []
+
+      const fullPath = join(dir, name)
       if (entry.isDirectory()) {
-        findResourceFiles(fullPath, exts, results)
-      } else if (exts.has(extname(entry.name).toLowerCase())) {
-        results.push({ path: fullPath, size: statSync(fullPath).size })
+        return findResourceFiles(fullPath, exts)
+      } else if (exts.has(extname(name).toLowerCase())) {
+        try {
+          const fileStat = await stat(fullPath)
+          return [{ path: fullPath, size: fileStat.size }]
+        } catch {
+          return []
+        }
       }
-    }
+      return []
+    })
+
+    const results = await Promise.all(promises)
+    return results.flat()
   } catch {
     // Skip inaccessible
+    return []
   }
-  return results
 }
 
 export async function handleResources(action: string, args: Record<string, unknown>, config: GodotConfig) {
@@ -73,7 +85,7 @@ export async function handleResources(action: string, args: Record<string, unkno
         if (typeMap[filterType]) exts = new Set(typeMap[filterType])
       }
 
-      const resources = findResourceFiles(resolvedPath, exts)
+      const resources = await findResourceFiles(resolvedPath, exts)
       const relativePaths = resources.map((r) => ({
         path: relative(resolvedPath, r.path).replace(/\\/g, '/'),
         ext: extname(r.path),

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -3,8 +3,8 @@
  * Actions: create | list | info | delete | duplicate | set_main
  */
 
-import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
-import { readFile } from 'node:fs/promises'
+import { copyFileSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { readdir, readFile } from 'node:fs/promises'
 import { basename, dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig, SceneInfo, SceneNode } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
@@ -90,23 +90,28 @@ async function parseTscnFile(filePath: string): Promise<SceneInfo> {
 /**
  * Recursively find all .tscn files in a directory
  */
-function findSceneFiles(dir: string, results: string[] = []): string[] {
+async function findSceneFiles(dir: string): Promise<string[]> {
   try {
-    const entries = readdirSync(dir, { withFileTypes: true })
-    for (const entry of entries) {
-      if (entry.name.startsWith('.') || entry.name === 'node_modules' || entry.name === 'build') continue
+    const entries = await readdir(dir, { withFileTypes: true })
+    const promises = entries.map(async (entry) => {
+      const name = entry.name
+      if (name.startsWith('.') || name === 'node_modules' || name === 'build') return []
 
+      const fullPath = join(dir, name)
       if (entry.isDirectory()) {
-        findSceneFiles(join(dir, entry.name), results)
-      } else if (extname(entry.name) === '.tscn') {
-        results.push(join(dir, entry.name))
+        return findSceneFiles(fullPath)
+      } else if (extname(name) === '.tscn') {
+        return [fullPath]
       }
-    }
+      return []
+    })
+
+    const nestedResults = await Promise.all(promises)
+    return nestedResults.flat()
   } catch {
     // Skip inaccessible directories
+    return []
   }
-
-  return results
 }
 
 function generateTscnContent(rootName: string, rootType: string): string {
@@ -181,7 +186,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
     case 'list': {
       // projectPath is guaranteed
       const resolvedPath = resolve(projectPath as string)
-      const scenes = findSceneFiles(resolvedPath)
+      const scenes = await findSceneFiles(resolvedPath)
       const relativePaths = scenes.map((s) => relative(resolvedPath, s).replace(/\\/g, '/'))
 
       return formatJSON({

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -3,7 +3,8 @@
  * Actions: create | read | write | attach | list | delete
  */
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { readdir } from 'node:fs/promises'
 import { dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
@@ -97,27 +98,28 @@ function getTemplate(extendsType: string): string {
   return SCRIPT_TEMPLATES[extendsType] || `extends ${extendsType}\n\n\nfunc _ready() -> void:\n\tpass\n`
 }
 
-function findScriptFiles(dir: string, results: string[] = []): string[] {
+async function findScriptFiles(dir: string): Promise<string[]> {
   try {
-    const entries = readdirSync(dir, { withFileTypes: true })
-    for (const entry of entries) {
-      if (
-        entry.name.startsWith('.') ||
-        entry.name === 'node_modules' ||
-        entry.name === 'build' ||
-        entry.name === 'addons'
-      )
-        continue
+    const entries = await readdir(dir, { withFileTypes: true })
+    const promises = entries.map(async (entry) => {
+      const name = entry.name
+      if (name.startsWith('.') || name === 'node_modules' || name === 'build' || name === 'addons') return []
+
+      const fullPath = join(dir, name)
       if (entry.isDirectory()) {
-        findScriptFiles(join(dir, entry.name), results)
-      } else if (extname(entry.name) === '.gd') {
-        results.push(join(dir, entry.name))
+        return findScriptFiles(fullPath)
+      } else if (extname(name) === '.gd') {
+        return [fullPath]
       }
-    }
+      return []
+    })
+
+    const nestedResults = await Promise.all(promises)
+    return nestedResults.flat()
   } catch {
     // Skip inaccessible
+    return []
   }
-  return results
 }
 
 export async function handleScripts(action: string, args: Record<string, unknown>, config: GodotConfig) {
@@ -227,7 +229,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
         throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
 
       const resolvedPath = resolve(projectPath)
-      const scripts = findScriptFiles(resolvedPath)
+      const scripts = await findScriptFiles(resolvedPath)
       const relativePaths = scripts.map((s) => relative(resolvedPath, s).replace(/\\/g, '/'))
 
       return formatJSON({ project: resolvedPath, count: relativePaths.length, scripts: relativePaths })


### PR DESCRIPTION
💡 **What:** Migrated recursive directory traversal functions (`findResourceFiles`, `findSceneFiles`, `findScriptFiles`) from synchronous `node:fs` APIs to asynchronous `node:fs/promises` APIs.
🎯 **Why:** In large Godot workspaces with thousands of files, `readdirSync` and `statSync` would block the Node.js event loop, preventing the MCP server from responding to other concurrent requests or handling timeouts properly.
📊 **Impact:** Significantly improves responsiveness and scalability of the MCP server during heavy directory scans (like `list` actions). Reduces latency overhead on the main thread for recursive file discovery.
🔬 **Measurement:** Verify tests run successfully. To see the impact manually, try running `list` operations via an MCP client on an extremely large project folder; the client connection and heartbeat will no longer stall.

---
*PR created automatically by Jules for task [13304684437627304807](https://jules.google.com/task/13304684437627304807) started by @n24q02m*