### PR TITLE
feat: code health improvement] Use project-settings parser in project.ts

### DIFF
--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -23,40 +23,31 @@ async function parseProjectGodot(projectPath: string): Promise<ProjectInfo> {
     )
   }
 
-  const content = await readFile(configPath, 'utf-8')
-  const lines = content.split('\n')
-
+  const settings = await parseProjectSettingsAsync(configPath)
   const info: ProjectInfo = { name: 'Unknown', configVersion: 5, mainScene: null, features: [], settings: {} }
-  let currentSection = ''
 
-  for (const line of lines) {
-    const trimmed = line.trim()
+  const versionMatch = settings.raw.match(/^config_version\s*=\s*(\d+)/m)
+  if (versionMatch) {
+    info.configVersion = Number.parseInt(versionMatch[1], 10)
+  }
 
-    const sectionMatch = trimmed.match(/^\[(.+)\]$/)
-    if (sectionMatch) {
-      currentSection = sectionMatch[1]
-      continue
-    }
+  for (const [section, keys] of settings.sections.entries()) {
+    for (const [key, rawValue] of keys.entries()) {
+      const value = rawValue.replace(/^"(.*)"$/, '$1')
 
-    const kvMatch = trimmed.match(/^(\S+)\s*=\s*(.+)$/)
-    if (!kvMatch) continue
-
-    const [, key, rawValue] = kvMatch
-    const value = rawValue.replace(/^"(.*)"$/, '$1')
-
-    if (currentSection === '' || currentSection === 'application') {
-      if (key === 'config/name') info.name = value
-      if (key === 'run/main_scene') info.mainScene = value
-      if (key === 'config/features') {
-        const featMatch = rawValue.match(/PackedStringArray\((.+)\)/)
-        if (featMatch) {
-          info.features = featMatch[1].split(',').map((f) => f.trim().replace(/"/g, ''))
+      if (section === 'application') {
+        if (key === 'config/name') info.name = value
+        if (key === 'run/main_scene') info.mainScene = value
+        if (key === 'config/features') {
+          const featMatch = rawValue.match(/PackedStringArray\((.+)\)/)
+          if (featMatch) {
+            info.features = featMatch[1].split(',').map((f) => f.trim().replace(/"/g, ''))
+          }
         }
       }
-    }
 
-    if (key === 'config_version') info.configVersion = Number.parseInt(value, 10)
-    info.settings[`${currentSection ? `${currentSection}/` : ''}${key}`] = value
+      info.settings[`${section ? `${section}/` : ''}${key}`] = value
+    }
   }
 
   return info


### PR DESCRIPTION
🎯 **What:** 
Refactored `parseProjectGodot` in `src/tools/composite/project.ts` to utilize the existing `parseProjectSettingsAsync` utility from `project-settings.ts` instead of duplicating parsing logic (e.g. `split('\n')`, regex matching line-by-line).

💡 **Why:**
Using the shared parser improves code consistency, reduces duplication, and makes use of the performance optimizations already built into `parseProjectSettingsAsync`. It ensures that `project.godot` parsing acts uniform across the entire codebase.

✅ **Verification:**
Confirmed functionality by running `bun run check` (for types and formatting) and `pnpm test` (for unit and integration tests). All 39 test files and 583 tests passed. I specifically verified the `application` section keys extraction logic correctly handles quotes and arrays. 

✨ **Result:**
The `parseProjectGodot` function is cleaner, handles section iteration natively with the returned `ProjectSettings` map, and improves overall code maintainability.

---
*PR created automatically by Jules for task [15493423168196750797](https://jules.google.com/task/15493423168196750797) started by @n24q02m*