### PR TITLE
feat: code Health] Use enhanced project-settings parser in input-map.ts

### DIFF
--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -7,6 +7,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { getInputActions, parseProjectSettingsContent } from '../helpers/project-settings.js'
 
 /**
  * Godot 4.x Key enum numeric values (@GlobalScope.Key)
@@ -141,78 +142,6 @@ function getProjectGodotPath(projectPath: string | null | undefined): string {
   return configPath
 }
 
-/**
- * Parse input actions from project.godot
- */
-function parseInputActions(content: string): Map<string, string[]> {
-  const actions = new Map<string, string[]>()
-  let inInputSection = false
-  let currentActionName: string | null = null
-  let currentActionAccumulator = ''
-
-  for (const line of content.split('\n')) {
-    const trimmed = line.trim()
-
-    // Handle multi-line continuation
-    if (currentActionName !== null) {
-      currentActionAccumulator += trimmed
-      if (trimmed.endsWith('}')) {
-        // End of multi-line action
-        const eventsMatch = currentActionAccumulator.match(/"events":\s*\[([^\]]*)\]/)
-        const events = eventsMatch
-          ? eventsMatch[1]
-              .split(',')
-              .map((e) => e.trim())
-              .filter(Boolean)
-          : []
-        actions.set(currentActionName, events)
-        currentActionName = null
-        currentActionAccumulator = ''
-      }
-      continue
-    }
-
-    if (trimmed === '[input]') {
-      inInputSection = true
-      continue
-    }
-
-    // Stop if we hit another section
-    if (trimmed.startsWith('[') && inInputSection) {
-      inInputSection = false
-      break
-    }
-
-    if (inInputSection) {
-      // Single-line format: action_name={...}
-      const match = trimmed.match(/^(\w+)=\{(.+)\}$/)
-      if (match) {
-        const actionName = match[1]
-        const eventsMatch = match[2].match(/"events":\s*\[([^\]]*)\]/)
-        const events = eventsMatch
-          ? eventsMatch[1]
-              .split(',')
-              .map((e) => e.trim())
-              .filter(Boolean)
-          : []
-        actions.set(actionName, events)
-      } else {
-        // Multi-line format start: action_name={
-        //   "deadzone": 0.2,
-        //   "events": [...]
-        // }
-        const startMatch = trimmed.match(/^(\w+)=\{(.*)$/)
-        if (startMatch) {
-          currentActionName = startMatch[1]
-          currentActionAccumulator = startMatch[2]
-        }
-      }
-    }
-  }
-
-  return actions
-}
-
 export async function handleInputMap(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const projectPath = (args.project_path as string) || config.projectPath
 
@@ -220,12 +149,22 @@ export async function handleInputMap(action: string, args: Record<string, unknow
     case 'list': {
       const configPath = getProjectGodotPath(projectPath)
       const content = readFileSync(configPath, 'utf-8')
-      const actions = parseInputActions(content)
+      const settings = parseProjectSettingsContent(content)
+      const actions = getInputActions(settings)
 
-      const actionList = Array.from(actions.entries()).map(([name, events]) => ({
-        name,
-        eventCount: events.length,
-      }))
+      const actionList = Array.from(actions.entries()).map(([name, configStr]) => {
+        const eventsMatch = configStr.match(/"events":\s*\[([^\]]*)\]/)
+        const events = eventsMatch
+          ? eventsMatch[1]
+              .split(',')
+              .map((e) => e.trim())
+              .filter(Boolean)
+          : []
+        return {
+          name,
+          eventCount: events.length,
+        }
+      })
 
       return formatJSON({ count: actionList.length, actions: actionList })
     }


### PR DESCRIPTION
🎯 **What:** The `parseInputActions` function in `src/tools/composite/input-map.ts` was an isolated, ad-hoc parser for reading input action settings from `project.godot`. This refactoring removes the custom `parseInputActions` function and replaces it with the robust, centralized `parseProjectSettingsContent` and `getInputActions` utility functions from `src/tools/helpers/project-settings.ts`.

💡 **Why:** By reusing the existing, centralized settings parsing utilities, this change eliminates code duplication, reduces the maintenance burden, and relies on the more optimized parser found in `project-settings.ts`. It directly improves readability and code health without altering functionality.

✅ **Verification:** 
- The refactored code has been tested with `bun run check`, `bun run format`, and `npm run check:fix` to ensure no linting/formatting errors remain.
- The unit test suite for the `input-map` tool (`npx vitest run tests/composite/input-map.test.ts`) executed perfectly, passing all 20 existing tests, proving that the output and logic of the `list` action remain unchanged.

✨ **Result:** The codebase is cleaner and relies strictly on the shared `project-settings.ts` library for `project.godot` file parsing. The file size of `input-map.ts` is reduced by approximately 60 lines.

---
*PR created automatically by Jules for task [12878823664325137849](https://jules.google.com/task/12878823664325137849) started by @n24q02m*