### PR TITLE
feat: add edge case tests for parseGodotVersion

### DIFF
--- a/tests/godot/detector.test.ts
+++ b/tests/godot/detector.test.ts
@@ -68,6 +68,45 @@ describe('detector', () => {
       expect(v?.patch).toBe(1)
     })
 
+    it('should parse version with missing patch (major and minor only)', () => {
+      const v = parseGodotVersion('Godot v4.2')
+      expect(v).not.toBeNull()
+      expect(v?.major).toBe(4)
+      expect(v?.minor).toBe(2)
+      expect(v?.patch).toBe(0)
+    })
+
+    it('should parse version with dashes and unusual prefix', () => {
+      const v = parseGodotVersion('my-custom-build-v4.1.2-stable')
+      expect(v).not.toBeNull()
+      expect(v?.major).toBe(4)
+      expect(v?.minor).toBe(1)
+      expect(v?.patch).toBe(2)
+      expect(v?.label).toBe('stable')
+    })
+
+    it('should parse version without label', () => {
+      const v = parseGodotVersion('4.0.0')
+      expect(v).not.toBeNull()
+      expect(v?.major).toBe(4)
+      expect(v?.minor).toBe(0)
+      expect(v?.patch).toBe(0)
+      expect(v?.label).toBe('stable') // defaults to 'stable'
+    })
+
+    it('should handle unusual whitespace', () => {
+      const v = parseGodotVersion('  Godot Engine v4.3.0  \n')
+      expect(v).not.toBeNull()
+      expect(v?.major).toBe(4)
+      expect(v?.minor).toBe(3)
+      expect(v?.patch).toBe(0)
+      expect(v?.label).toBe('stable')
+    })
+
+    it('should return null for whitespace-only strings', () => {
+      expect(parseGodotVersion('   \n  \t  ')).toBeNull()
+    })
+
     it('should return null for invalid string', () => {
       expect(parseGodotVersion('not a version')).toBeNull()
     })


### PR DESCRIPTION
**What:** Added tests to cover edge cases when parsing Godot version strings in `tests/godot/detector.test.ts`.

**Coverage:** 
- Missing patch versions (e.g. `Godot v4.2`)
- Unusual prefixes with dashes (e.g. `my-custom-build-v4.1.2-stable`)
- No label (e.g. `4.0.0`)
- Padded with whitespace (e.g. `  Godot Engine v4.3.0  \n`)
- Empty/Whitespace-only strings (e.g. `   \n  \t  `)

**Result:** Improved test coverage for `parseGodotVersion` prevents regressions from future refactoring of its regex.

---
*PR created automatically by Jules for task [8727750743584557047](https://jules.google.com/task/8727750743584557047) started by @n24q02m*