### PR TITLE
feat: add tests for malformed inputs in parseGodotValue

### DIFF
--- a/tests/helpers/godot-types.test.ts
+++ b/tests/helpers/godot-types.test.ts
@@ -156,6 +156,27 @@ describe('godot-types', () => {
       expect(parseGodotValue('  42  ')).toBe(42)
     })
 
+    it('should return malformed Vector2 as-is', () => {
+      expect(parseGodotValue('Vector2(1)')).toBe('Vector2(1)')
+      expect(parseGodotValue('Vector2(1, a)')).toBe('Vector2(1, a)')
+    })
+
+    it('should return malformed Vector3 as-is', () => {
+      expect(parseGodotValue('Vector3(1, 2)')).toBe('Vector3(1, 2)')
+    })
+
+    it('should return malformed Color as-is', () => {
+      expect(parseGodotValue('Color(1)')).toBe('Color(1)')
+    })
+
+    it('should return malformed Rect2 as-is', () => {
+      expect(parseGodotValue('Rect2(1, 2, 3)')).toBe('Rect2(1, 2, 3)')
+    })
+
+    it('should return malformed dictionary/JSON as-is', () => {
+      expect(parseGodotValue('{"key": }')).toBe('{"key": }')
+    })
+
     it('should return unrecognized values as-is', () => {
       expect(parseGodotValue('SomeUnknownType()')).toBe('SomeUnknownType()')
     })


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for handling missing properties and malformed inputs in the `parseGodotValue` function. Previously, invalid vector inputs (e.g., `Vector2(1)`, `Vector3(1, 2)`) and incomplete dictionary strings (e.g., `'{"key": }'`) were implicitly handled by falling through to the catch-all return, but were not tested.

📊 **Coverage:** Tests have been added to verify that `parseGodotValue` gracefully handles:
- Malformed `Vector2` declarations (e.g., `Vector2(1)`, `Vector2(1, a)`)
- Malformed `Vector3` declarations (e.g., `Vector3(1, 2)`)
- Malformed `Color` declarations (e.g., `Color(1)`)
- Malformed `Rect2` declarations (e.g., `Rect2(1, 2, 3)`)
- Malformed dictionary/JSON objects (e.g., `{"key": }`)

✨ **Result:** Test coverage for `src/tools/helpers/godot-types.ts` is improved, ensuring robustness and guaranteeing that `parseGodotValue` correctly fails gracefully (returning the original string unparsed) without throwing an error when encountering improperly formatted expression strings.

---
*PR created automatically by Jules for task [9941632334951506306](https://jules.google.com/task/9941632334951506306) started by @n24q02m*