### PR TITLE
feat: replace blocking file operations with async counterparts in set_main action

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [Replace blocking file operations with async operations]
+**Learning:** Replaced `readFileSync` and `writeFileSync` with their asynchronous counterparts (`await readFile` and `await writeFile`) in `scenes.ts`'s `set_main` action. This prevents blocking the Node.js event loop during heavy operations, ensuring a more responsive MCP server.
+**Action:** When updating configuration files or handling I/O operations inside tool actions in this project, prioritize asynchronous Node.js `node:fs/promises` methods like `await readFile` and `await writeFile` instead of their synchronous versions to avoid blocking the event loop.

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -3,8 +3,8 @@
  * Actions: create | list | info | delete | duplicate | set_main
  */
 
-import { copyFileSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
-import { readdir, readFile } from 'node:fs/promises'
+import { copyFileSync, existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs'
+import { readdir, readFile, writeFile } from 'node:fs/promises'
 import { basename, dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig, SceneInfo, SceneNode } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
@@ -247,9 +247,9 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       }
 
       const resPath = `res://${scenePath.replace(/\\/g, '/')}`
-      const content = readFileSync(configPath, 'utf-8')
+      const content = await readFile(configPath, 'utf-8')
       const updated = setSettingInContent(content, 'application/run/main_scene', `"${resPath}"`)
-      writeFileSync(configPath, updated, 'utf-8')
+      await writeFile(configPath, updated, 'utf-8')
 
       return formatSuccess(`Set main scene: ${resPath}`)
     }


### PR DESCRIPTION
💡 **What:** Replaced synchronous `readFileSync` and `writeFileSync` with their asynchronous counterparts (`await readFile` and `await writeFile`) from `node:fs/promises` in the `set_main` case inside `src/tools/composite/scenes.ts`.
🎯 **Why:** To eliminate blocking I/O within the asynchronous context. Using synchronous file I/O operations block the Node.js event loop.
📊 **Measured Improvement:** While a formal benchmark was not performed since the operation is simple configuration I/O, the impact of synchronous operations in Node.js event loop is known. The improvement is a non-blocking asynchronous approach that increases the overall server responsiveness during I/O operations without causing delays to other concurrent requests.

---
*PR created automatically by Jules for task [651756316588689904](https://jules.google.com/task/651756316588689904) started by @n24q02m*