### PR TITLE
fix: fix path traversal verification in tests

### DIFF
--- a/tests/composite/scripts.test.ts
+++ b/tests/composite/scripts.test.ts
@@ -134,6 +134,19 @@ describe('scripts', () => {
         ),
       ).rejects.toThrow('not found')
     })
+
+    it('should throw for path traversal attempts', async () => {
+      await expect(
+        handleScripts(
+          'read',
+          {
+            project_path: projectPath,
+            script_path: '../outside.gd',
+          },
+          config,
+        ),
+      ).rejects.toThrow('outside the project root')
+    })
   })
 
   // ==========================================


### PR DESCRIPTION
🎯 **What:** The reported Path Traversal vulnerability in the `Scripts` tool's `read` action.
⚠️ **Risk:** The potential impact if left unfixed is allowing attackers to read files outside the Godot project directory, leading to unauthorized access to system files.
🛡️ **Solution:** The codebase was already refactored to use `safeResolve` correctly, meaning the vulnerability no longer exists in `src/tools/composite/scripts.ts`. Added a specific path traversal test in `tests/composite/scripts.test.ts` to guarantee it cannot be reintroduced without breaking tests.

---
*PR created automatically by Jules for task [8145061580145164977](https://jules.google.com/task/8145061580145164977) started by @n24q02m*