### PR TITLE
feat: code health: refactor handleNodes to use asynchronous file I/O operations

### DIFF
--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -3,7 +3,7 @@
  * Actions: add | remove | rename | list | set_property | get_property
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { access, readFile, writeFile } from 'node:fs/promises'
 import type { GodotConfig, SceneNode } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
@@ -37,6 +37,14 @@ function mapToSceneNode(node: SceneNodeInfo): SceneNode {
   }
 }
 
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
 function resolveScenePath(projectPath: string | null | undefined, scenePath: string): string {
   return safeResolve(projectPath || process.cwd(), scenePath)
 }
@@ -54,10 +62,10 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
       const parent = (args.parent as string) || '.'
 
       const fullPath = resolveScenePath(projectPath, scenePath)
-      if (!existsSync(fullPath))
+      if (!(await fileExists(fullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
 
-      const content = readFileSync(fullPath, 'utf-8')
+      const content = await readFile(fullPath, 'utf-8')
       const scene = parseSceneContent(content)
       const duplicate = scene.nodes.find((n) => n.name === nodeName && (n.parent || '.') === parent)
       if (duplicate) {
@@ -71,7 +79,7 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
       const parentAttr = parent === '.' ? '' : ` parent="${parent}"`
       const nodeDecl = `\n[node name="${nodeName}" type="${nodeType}"${parentAttr}]\n`
       const updated = `${content.trimEnd()}\n${nodeDecl}`
-      writeFileSync(fullPath, updated, 'utf-8')
+      await writeFile(fullPath, updated, 'utf-8')
 
       return formatSuccess(`Added node: ${nodeName} (${nodeType}) under ${parent}`)
     }
@@ -84,12 +92,12 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
         throw new GodotMCPError('No node name specified', 'INVALID_ARGS', 'Provide name of node to remove.')
 
       const fullPath = resolveScenePath(projectPath, scenePath)
-      if (!existsSync(fullPath))
+      if (!(await fileExists(fullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
 
-      const content = readFileSync(fullPath, 'utf-8')
+      const content = await readFile(fullPath, 'utf-8')
       const updated = removeNodeFromContent(content, nodeName)
-      writeFileSync(fullPath, updated, 'utf-8')
+      await writeFile(fullPath, updated, 'utf-8')
 
       return formatSuccess(`Removed node: ${nodeName} from ${scenePath}`)
     }
@@ -103,12 +111,12 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
         throw new GodotMCPError('Both name and new_name required', 'INVALID_ARGS', 'Provide name and new_name.')
 
       const fullPath = resolveScenePath(projectPath, scenePath)
-      if (!existsSync(fullPath))
+      if (!(await fileExists(fullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
 
-      const content = readFileSync(fullPath, 'utf-8')
+      const content = await readFile(fullPath, 'utf-8')
       const updated = renameNodeInContent(content, nodeName, newName)
-      writeFileSync(fullPath, updated, 'utf-8')
+      await writeFile(fullPath, updated, 'utf-8')
 
       return formatSuccess(`Renamed node: ${nodeName} -> ${newName} in ${scenePath}`)
     }
@@ -118,10 +126,10 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
       if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
 
       const fullPath = resolveScenePath(projectPath, scenePath)
-      if (!existsSync(fullPath))
+      if (!(await fileExists(fullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
 
-      const content = readFileSync(fullPath, 'utf-8')
+      const content = await readFile(fullPath, 'utf-8')
       const scene = parseSceneContent(content)
       const nodes = scene.nodes.map(mapToSceneNode)
 
@@ -152,12 +160,12 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
       }
 
       const fullPath = resolveScenePath(projectPath, scenePath)
-      if (!existsSync(fullPath))
+      if (!(await fileExists(fullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
 
-      const content = readFileSync(fullPath, 'utf-8')
+      const content = await readFile(fullPath, 'utf-8')
       const updated = setNodePropertyInContent(content, nodeName, property, value)
-      writeFileSync(fullPath, updated, 'utf-8')
+      await writeFile(fullPath, updated, 'utf-8')
 
       return formatSuccess(`Set ${property} = ${value} on node ${nodeName}`)
     }
@@ -172,10 +180,10 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
       }
 
       const fullPath = resolveScenePath(projectPath, scenePath)
-      if (!existsSync(fullPath))
+      if (!(await fileExists(fullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
 
-      const content = readFileSync(fullPath, 'utf-8')
+      const content = await readFile(fullPath, 'utf-8')
       const scene = parseSceneContent(content)
       const val = getNodeProperty(scene, nodeName, property)
 


### PR DESCRIPTION
🎯 What: Refactored `src/tools/composite/nodes.ts` to replace synchronous I/O operations (`readFileSync`, `writeFileSync`, `existsSync`) with asynchronous operations (`readFile`, `writeFile`, `access` from `node:fs/promises`).
💡 Why: Improves performance and responsiveness of the MCP server by preventing the Node.js event loop from being blocked during file operations, especially important when handling large Godot `.tscn` files.
✅ Verification: Confirmed functionality via existing unit tests with `bun run check && pnpm test` passing successfully.
✨ Result: Enhanced code health and alignment with asynchronous project standards without breaking functionality.

---
*PR created automatically by Jules for task [2164656149998363795](https://jules.google.com/task/2164656149998363795) started by @n24q02m*