### PR TITLE
fix: fix path traversal in resources tool

### DIFF
--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -5,7 +5,7 @@
 
 import { existsSync, readFileSync, statSync, unlinkSync } from 'node:fs'
 import { readdir, stat } from 'node:fs/promises'
-import { extname, join, relative, resolve } from 'node:path'
+import { extname, join, relative } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
@@ -65,12 +65,12 @@ async function findResourceFiles(dir: string, extensions?: Set<string>): Promise
 }
 
 export async function handleResources(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath
+  const baseProjectPath = config.projectPath || process.cwd()
+  const projectPath = args.project_path ? safeResolve(baseProjectPath, args.project_path as string) : baseProjectPath
 
   switch (action) {
     case 'list': {
-      if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
-      const resolvedPath = resolve(projectPath)
+      const resolvedPath = projectPath
       const filterType = args.type as string | undefined
       let exts: Set<string> | undefined
       if (filterType) {
@@ -98,7 +98,7 @@ export async function handleResources(action: string, args: Record<string, unkno
     case 'info': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-      const fullPath = safeResolve(projectPath || process.cwd(), resPath)
+      const fullPath = safeResolve(projectPath, resPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
@@ -126,7 +126,7 @@ export async function handleResources(action: string, args: Record<string, unkno
     case 'delete': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-      const fullPath = safeResolve(projectPath || process.cwd(), resPath)
+      const fullPath = safeResolve(projectPath, resPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
@@ -142,7 +142,7 @@ export async function handleResources(action: string, args: Record<string, unkno
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
 
-      const importPath = safeResolve(projectPath || process.cwd(), `${resPath}.import`)
+      const importPath = safeResolve(projectPath, `${resPath}.import`)
 
       if (!existsSync(importPath)) {
         return formatJSON({ path: resPath, imported: false, message: 'No .import file found.' })


### PR DESCRIPTION
🎯 **What:** A path traversal vulnerability was fixed in the resources tool that would occur if an attacker supplied an absolute path or a path attempting to traverse directories as args.project_path.
⚠️ **Risk:** If left unfixed, an attacker could supply \`args.project_path\` pointing to the filesystem root (e.g. \`/\`) and subsequently access, view, or delete files outside of the configured Godot project boundaries via \`info\`, \`delete\`, or \`import_config\` actions.
🛡️ **Solution:** Updated the resolution logic in \`handleResources\` to validate and safely resolve the provided \`args.project_path\` against the configured root directory (or \`process.cwd()\`) via the existing \`safeResolve\` utility before using it as a base path for resource discovery or file I/O operations.

---
*PR created automatically by Jules for task [1741236613577400219](https://jules.google.com/task/1741236613577400219) started by @n24q02m*