### PR TITLE
feat: optimize tilemap file I/O using async operations

### DIFF
--- a/src/tools/composite/tilemap.ts
+++ b/src/tools/composite/tilemap.ts
@@ -3,7 +3,8 @@
  * Actions: create_tileset | add_source | set_tile | paint | list
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
@@ -37,8 +38,8 @@ export async function handleTilemap(action: string, args: Record<string, unknown
         '',
       ].join('\n')
 
-      mkdirSync(dirname(fullPath), { recursive: true })
-      writeFileSync(fullPath, content, 'utf-8')
+      await mkdir(dirname(fullPath), { recursive: true })
+      await writeFile(fullPath, content, 'utf-8')
       return formatSuccess(`Created TileSet: ${tilesetPath} (tile size: ${tileSize}x${tileSize})`)
     }
 
@@ -53,7 +54,7 @@ export async function handleTilemap(action: string, args: Record<string, unknown
       if (!existsSync(fullPath))
         throw new GodotMCPError(`TileSet not found: ${tilesetPath}`, 'TILEMAP_ERROR', 'Create the tileset first.')
 
-      let content = readFileSync(fullPath, 'utf-8')
+      let content = await readFile(fullPath, 'utf-8')
       const resPath = `res://${texturePath.replace(/\\/g, '/')}`
 
       // Count existing sources to get next ID
@@ -64,7 +65,7 @@ export async function handleTilemap(action: string, args: Record<string, unknown
       const extRes = `[ext_resource type="Texture2D" path="${resPath}" id="${sourceId}"]`
       content = content.replace('[resource]', `${extRes}\n\n[resource]`)
 
-      writeFileSync(fullPath, content, 'utf-8')
+      await writeFile(fullPath, content, 'utf-8')
       return formatSuccess(`Added texture source: ${texturePath} (id: ${sourceId})`)
     }
 
@@ -96,7 +97,7 @@ export async function handleTilemap(action: string, args: Record<string, unknown
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
 
-      const content = readFileSync(fullPath, 'utf-8')
+      const content = await readFile(fullPath, 'utf-8')
       const tilemaps: string[] = []
       const tmRegex = /\[node name="([^"]+)" type="TileMapLayer"/g
       for (const match of content.matchAll(tmRegex)) {


### PR DESCRIPTION
💡 **What:** Replaced blocking synchronous file I/O operations (`readFileSync`, `writeFileSync`, `mkdirSync`) with their asynchronous counterparts (`readFile`, `writeFile`, `mkdir` from `node:fs/promises`) in `src/tools/composite/tilemap.ts`. Note: kept `existsSync` because an async exists-checking function (e.g. wrapper around `await access(path)`) wasn't explicitly needed by the user's issue and `existsSync` is heavily used across other codebase tools.

🎯 **Why:** To eliminate blocking I/O anti-patterns in an asynchronous Node.js execution context. Since MCP actions can handle large `.tscn` and `.tres` Godot files, using synchronous file read/writes was causing the Node.js event loop to block, reducing the responsiveness of the MCP server during concurrent requests.

📊 **Measured Improvement:** 
- **Baseline (`bun run benchmark-tilemap.ts`):** 1128 ms for 1000 sequential `list` actions (which reads the file synchronously).
- **Post-Optimization:** 1171 ms for 1000 sequential `list` actions.

As expected, in a purely sequential micro-benchmark, the asynchronous I/O approach adds a slight performance overhead (~3-4%) due to Promise scheduling. However, the *true* performance improvement is architectural: by yielding control back to the event loop while awaiting disk I/O, the MCP server can now process multiple concurrent requests (or other Godot-related tasks) instead of completely freezing during large file reads/writes.

---
*PR created automatically by Jules for task [9063865605375877669](https://jules.google.com/task/9063865605375877669) started by @n24q02m*