### PR TITLE
fix: security] Fix Regex Replacement Injection in Scene Parser

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## Security Fix: Regular Expression Replacement Injection
+When replacing substrings using `String.prototype.replace(regex, replacementString)` in TypeScript/JavaScript, the `replacementString` is not treated as a literal if it contains special characters like `$`, `$1`, `$&`, etc. This allows for injection vulnerabilities if the replacement string is dynamically constructed from user input.
+To fix this, either use a replacer function `String.prototype.replace(regex, () => replacementString)` or safely escape the `$` characters in the replacement string.
+
+**Context:** The `renameNodeInContent` function in `src/tools/helpers/scene-parser.ts` used string replacement and an attacker could pass `$1` as a new node name to inject backreferences, modifying the regex replacement unexpectedly. Fixed by changing the string replacements to use arrow functions `() => ...` and `(_, p1, p2) => ...`.

--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -316,15 +316,18 @@ export function renameNodeInContent(content: string, oldName: string, newName: s
   const escapedOldName = escapeRegExp(oldName)
 
   // Replace in node declarations
-  let result = content.replace(new RegExp(`name="${escapedOldName}"`, 'g'), `name="${newName}"`)
+  let result = content.replace(new RegExp(`name="${escapedOldName}"`, 'g'), () => `name="${newName}"`)
   // Replace in parent references
-  result = result.replace(new RegExp(`parent="${escapedOldName}"`, 'g'), `parent="${newName}"`)
+  result = result.replace(new RegExp(`parent="${escapedOldName}"`, 'g'), () => `parent="${newName}"`)
   // Replace in parent paths containing the old name
-  result = result.replace(new RegExp(`parent="([^"]*/)${escapedOldName}(/[^"]*)"`, 'g'), `parent="$1${newName}$2"`)
-  result = result.replace(new RegExp(`parent="([^"]*/)${escapedOldName}"`, 'g'), `parent="$1${newName}"`)
+  result = result.replace(
+    new RegExp(`parent="([^"]*/)${escapedOldName}(/[^"]*)"`, 'g'),
+    (_, p1, p2) => `parent="${p1}${newName}${p2}"`,
+  )
+  result = result.replace(new RegExp(`parent="([^"]*/)${escapedOldName}"`, 'g'), (_, p1) => `parent="${p1}${newName}"`)
   // Replace in connection references
-  result = result.replace(new RegExp(`from="${escapedOldName}"`, 'g'), `from="${newName}"`)
-  result = result.replace(new RegExp(`to="${escapedOldName}"`, 'g'), `to="${newName}"`)
+  result = result.replace(new RegExp(`from="${escapedOldName}"`, 'g'), () => `from="${newName}"`)
+  result = result.replace(new RegExp(`to="${escapedOldName}"`, 'g'), () => `to="${newName}"`)
   return result
 }
 


### PR DESCRIPTION
🎯 **What:** The `renameNodeInContent` function in `src/tools/helpers/scene-parser.ts` used `String.prototype.replace(regex, string)` to rename nodes and their references in `.tscn` files. It dynamically constructed the replacement string containing the `newName` argument without escaping special regex replacement patterns (e.g., `$1`, `$&`).
⚠️ **Risk:** An attacker controlling the `newName` argument could inject regex replacement backreferences (like `$1`, `$2`, `$&`). This could lead to unexpected regex replacement injection behavior, potentially corrupting the `.tscn` file structure by interpolating unintended substrings during replacement. 
🛡️ **Solution:** The string replacement calls have been refactored to use replacer arrow functions (e.g., `() => ...` or `(_, p1, p2) => ...`). By doing so, the replacement value is treated purely as a literal string and regex engine variable interpolation is safely bypassed. Also included is a `.jules/sentinel.md` entry documenting this codebase-specific vulnerability pattern.

---
*PR created automatically by Jules for task [7755905626667046993](https://jules.google.com/task/7755905626667046993) started by @n24q02m*