### PR TITLE
fix: fix path traversal vulnerability in Resources tool

### DIFF
--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -65,12 +65,14 @@ async function findResourceFiles(dir: string, extensions?: Set<string>): Promise
 }
 
 export async function handleResources(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath
+  const rawProjectPath = (args.project_path as string) || config.projectPath
+  const baseDir = config.projectPath || process.cwd()
+  const projectPath = rawProjectPath ? safeResolve(baseDir, rawProjectPath) : resolve(baseDir)
 
   switch (action) {
     case 'list': {
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
-      const resolvedPath = resolve(projectPath)
+      const resolvedPath = projectPath
       const filterType = args.type as string | undefined
       let exts: Set<string> | undefined
       if (filterType) {
@@ -98,7 +100,7 @@ export async function handleResources(action: string, args: Record<string, unkno
     case 'info': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-      const fullPath = safeResolve(projectPath || process.cwd(), resPath)
+      const fullPath = safeResolve(projectPath, resPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
@@ -126,7 +128,7 @@ export async function handleResources(action: string, args: Record<string, unkno
     case 'delete': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-      const fullPath = safeResolve(projectPath || process.cwd(), resPath)
+      const fullPath = safeResolve(projectPath, resPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
@@ -142,7 +144,7 @@ export async function handleResources(action: string, args: Record<string, unkno
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
 
-      const importPath = safeResolve(projectPath || process.cwd(), `${resPath}.import`)
+      const importPath = safeResolve(projectPath, `${resPath}.import`)
 
       if (!existsSync(importPath)) {
         return formatJSON({ path: resPath, imported: false, message: 'No .import file found.' })

--- a/tests/composite/resources.test.ts
+++ b/tests/composite/resources.test.ts
@@ -183,6 +183,16 @@ describe('resources', () => {
   // path traversal prevention
   // ==========================================
   describe('path traversal', () => {
+    it('should reject list with malicious project_path', async () => {
+      await expect(handleResources('list', { project_path: '../../../etc' }, config)).rejects.toThrow('Access denied')
+    })
+
+    it('should reject info with malicious project_path', async () => {
+      await expect(
+        handleResources('info', { project_path: '../../../etc', resource_path: 'passwd' }, config),
+      ).rejects.toThrow('Access denied')
+    })
+
     it('should reject info with path traversal', async () => {
       await expect(
         handleResources('info', { project_path: projectPath, resource_path: '../../../etc/passwd' }, config),


### PR DESCRIPTION
🎯 **What:** The path traversal vulnerability via malicious `project_path` input was fixed in the `Resources Tool` (`src/tools/composite/resources.ts`).
⚠️ **Risk:** An attacker could exploit `args.project_path` by providing a directory traversal path (like `../../../`) to break out of the configured project directory. This affected all actions (`list`, `info`, `delete`, `import_config`), allowing attackers to explore or delete unauthorized files in the host system.
🛡️ **Solution:** The dynamic `args.project_path` parameter is now strictly resolved securely using `safeResolve` against the root `config.projectPath` (or `process.cwd()`). This ensures the resolved `projectPath` acts as a secure boundary base directory for all operations and validates any user-provided path bounds. All individual actions now correctly pass this secured boundary down to `safeResolve` when resolving specific `args.resource_path`. Added targeted integration tests asserting an 'Access denied' exception on any bounds violations.

---
*PR created automatically by Jules for task [2298623334383193469](https://jules.google.com/task/2298623334383193469) started by @n24q02m*