### PR TITLE
fix: security] Prevent path traversal vulnerability in scripts tool

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,3 @@
+## 2024-03-24 - Security Issue Verification
+**Learning:** A potential path traversal vulnerability in `scripts.ts` involving `resolve(projectPath, scriptPath)` was identified in an external report but the implementation was found to be already using the secure wrapper `safeResolve` uniformly inside `resolvePath`. It is crucial to verify actual codebase state against vulnerability reports before attempting fixes, and to assert these security boundaries with specific tests to prevent future regressions.
+**Action:** Always verify the existence of a vulnerability in the current main branch before implementing a fix. Write explicit tests for path traversal to ensure security guarantees (`safeResolve`) are maintained across refactoring.

--- a/tests/composite/scripts.test.ts
+++ b/tests/composite/scripts.test.ts
@@ -27,6 +27,19 @@ describe('scripts', () => {
   // create
   // ==========================================
   describe('create', () => {
+    it('should throw on path traversal attempt', async () => {
+      await expect(
+        handleScripts(
+          'create',
+          {
+            project_path: projectPath,
+            script_path: '../malicious.gd',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Access denied')
+    })
+
     it('should create script with default template', async () => {
       const result = await handleScripts(
         'create',
@@ -107,6 +120,19 @@ describe('scripts', () => {
   // read
   // ==========================================
   describe('read', () => {
+    it('should throw on path traversal attempt', async () => {
+      await expect(
+        handleScripts(
+          'read',
+          {
+            project_path: projectPath,
+            script_path: '../../etc/passwd',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Access denied')
+    })
+
     it('should read script content', async () => {
       createTmpScript(projectPath, 'test.gd', 'extends Node\n\nvar hp = 100\n')
 
@@ -140,6 +166,20 @@ describe('scripts', () => {
   // write
   // ==========================================
   describe('write', () => {
+    it('should throw on path traversal attempt', async () => {
+      await expect(
+        handleScripts(
+          'write',
+          {
+            project_path: projectPath,
+            script_path: '../outside.gd',
+            content: 'malicious',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Access denied')
+    })
+
     it('should write content to script', async () => {
       const newContent = 'extends Node2D\n\nfunc shoot(): pass\n'
       await handleScripts(
@@ -215,6 +255,19 @@ describe('scripts', () => {
   // delete
   // ==========================================
   describe('delete', () => {
+    it('should throw on path traversal attempt', async () => {
+      await expect(
+        handleScripts(
+          'delete',
+          {
+            project_path: projectPath,
+            script_path: '../important.gd',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Access denied')
+    })
+
     it('should delete existing script', async () => {
       createTmpScript(projectPath, 'to_delete.gd')
 


### PR DESCRIPTION
🎯 **What:** The prompt reported a path traversal vulnerability in `scripts.ts` during a `write` action.
⚠️ **Risk:** Allowing an arbitrary `script_path` could allow reading, creating, writing, and deleting critical system files like `/etc/passwd` if not scoped correctly.
🛡️ **Solution:** The codebase was already found to be mitigating this path traversal correctly via the `resolvePath` helper mapping to `safeResolve` inside `scripts.ts`. To guarantee no regressions, I added rigorous tests against path traversal attempts to the `create`, `read`, `write`, and `delete` operations within `tests/composite/scripts.test.ts`.

---
*PR created automatically by Jules for task [2794953090333433024](https://jules.google.com/task/2794953090333433024) started by @n24q02m*