### PR TITLE
feat: refactor: Use centralized project settings parser in input-map

### DIFF
--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -7,6 +7,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { getInputActions, parseProjectSettingsContent } from '../helpers/project-settings.js'
 
 /**
  * Godot 4.x Key enum numeric values (@GlobalScope.Key)
@@ -146,67 +147,22 @@ function getProjectGodotPath(projectPath: string | null | undefined): string {
  */
 function parseInputActions(content: string): Map<string, string[]> {
   const actions = new Map<string, string[]>()
-  let inInputSection = false
-  let currentActionName: string | null = null
-  let currentActionAccumulator = ''
+  const settings = parseProjectSettingsContent(content)
+  const inputSection = getInputActions(settings)
 
-  for (const line of content.split('\n')) {
-    const trimmed = line.trim()
+  if (inputSection) {
+    for (const [key, value] of inputSection) {
+      // Normalize line endings to help matching
+      const normalizedValue = value.replace(/\r\n/g, '\n')
 
-    // Handle multi-line continuation
-    if (currentActionName !== null) {
-      currentActionAccumulator += trimmed
-      if (trimmed.endsWith('}')) {
-        // End of multi-line action
-        const eventsMatch = currentActionAccumulator.match(/"events":\s*\[([^\]]*)\]/)
-        const events = eventsMatch
-          ? eventsMatch[1]
-              .split(',')
-              .map((e) => e.trim())
-              .filter(Boolean)
-          : []
-        actions.set(currentActionName, events)
-        currentActionName = null
-        currentActionAccumulator = ''
-      }
-      continue
-    }
-
-    if (trimmed === '[input]') {
-      inInputSection = true
-      continue
-    }
-
-    // Stop if we hit another section
-    if (trimmed.startsWith('[') && inInputSection) {
-      inInputSection = false
-      break
-    }
-
-    if (inInputSection) {
-      // Single-line format: action_name={...}
-      const match = trimmed.match(/^(\w+)=\{(.+)\}$/)
-      if (match) {
-        const actionName = match[1]
-        const eventsMatch = match[2].match(/"events":\s*\[([^\]]*)\]/)
-        const events = eventsMatch
-          ? eventsMatch[1]
-              .split(',')
-              .map((e) => e.trim())
-              .filter(Boolean)
-          : []
-        actions.set(actionName, events)
-      } else {
-        // Multi-line format start: action_name={
-        //   "deadzone": 0.2,
-        //   "events": [...]
-        // }
-        const startMatch = trimmed.match(/^(\w+)=\{(.*)$/)
-        if (startMatch) {
-          currentActionName = startMatch[1]
-          currentActionAccumulator = startMatch[2]
-        }
-      }
+      const eventsMatch = normalizedValue.match(/"events":\s*\[([^\]]*)\]/)
+      const events = eventsMatch
+        ? eventsMatch[1]
+            .split(',')
+            .map((e) => e.trim())
+            .filter(Boolean)
+        : []
+      actions.set(key, events)
     }
   }
 

--- a/src/tools/helpers/project-settings.ts
+++ b/src/tools/helpers/project-settings.ts
@@ -79,8 +79,23 @@ export function parseProjectSettingsContent(content: string): ProjectSettings {
         while (valStart < end && content.charCodeAt(valStart) <= 32) valStart++
 
         const key = content.slice(start, keyEnd)
-        const value = content.slice(valStart, end)
 
+        // Handle multi-line block values starting with '{'
+        if (content.charCodeAt(valStart) === 123) {
+          // 123 is '{'
+          const blockEnd = content.indexOf('}', valStart)
+          if (blockEnd !== -1) {
+            const value = content.slice(valStart, blockEnd + 1)
+            sections.get(currentSection)?.set(key, value)
+
+            // Advance pos to the end of the block's line to prevent infinite loop
+            const afterBlockEnd = content.indexOf('\n', blockEnd)
+            pos = afterBlockEnd === -1 ? len : afterBlockEnd + 1
+            continue
+          }
+        }
+
+        const value = content.slice(valStart, end)
         sections.get(currentSection)?.set(key, value)
       }
     }


### PR DESCRIPTION
🎯 **What:** 
Removed custom string-splitting and regex parsing of the Godot `project.godot` input section in `input-map.ts`. It now natively uses the enhanced `parseProjectSettingsContent` utility. Additionally, `parseProjectSettingsContent` was augmented to correctly traverse and store multi-line `{}` value blocks.

💡 **Why:**
Previously, `input-map.ts` duplicated parsing rules and did complex string matching to determine what an action was. By enhancing `project-settings.ts` to properly identify `{` starting multi-line blocks, the main `project-settings` parser can do all the heavy lifting in one place natively without creating complex nested structures. This improves readability, eliminates fragile duplicate implementations, and establishes a single source of truth for handling `.godot` INI files.

✅ **Verification:**
1. Ran the comprehensive Vitest suite. `input-map.test.ts`, `project-settings.test.ts` and all 583 total tests across 39 files pass reliably without regression. 
2. Ran `biome check .` and verified code quality.

✨ **Result:**
Reduced fragile parsing code duplication. The parsing mechanism for `project.godot` files is now more robust and centralized.

---
*PR created automatically by Jules for task [2990667601332480810](https://jules.google.com/task/2990667601332480810) started by @n24q02m*