### PR TITLE
feat: code Health: Improve project-settings parser for multiline values

### DIFF
--- a/src/tools/helpers/project-settings.ts
+++ b/src/tools/helpers/project-settings.ts
@@ -76,10 +76,91 @@ export function parseProjectSettingsContent(content: string): ProjectSettings {
         while (keyEnd > start && content.charCodeAt(keyEnd - 1) <= 32) keyEnd--
 
         let valStart = eqIdx + 1
-        while (valStart < end && content.charCodeAt(valStart) <= 32) valStart++
+        while (valStart < len && content.charCodeAt(valStart) <= 32 && content.charCodeAt(valStart) !== 10) valStart++
 
         const key = content.slice(start, keyEnd)
-        const value = content.slice(valStart, end)
+
+        let valueEnd = end
+        let value = ''
+
+        if (valStart < len) {
+          const firstChar = content.charCodeAt(valStart)
+
+          // Handle multi-line blocks starting with {
+          if (firstChar === 123) {
+            // '{'
+            let blockEnd = valStart + 1
+            let bracketCount = 1
+            let inString = false
+            let isEscaped = false
+
+            while (blockEnd < len) {
+              const char = content.charCodeAt(blockEnd)
+
+              if (isEscaped) {
+                isEscaped = false
+              } else if (char === 92) {
+                // '\'
+                isEscaped = true
+              } else if (char === 34) {
+                // '"'
+                inString = !inString
+              } else if (!inString) {
+                if (char === 123) {
+                  // '{'
+                  bracketCount++
+                } else if (char === 125) {
+                  // '}'
+                  bracketCount--
+                  if (bracketCount === 0) {
+                    blockEnd++
+                    break
+                  }
+                }
+              }
+              blockEnd++
+            }
+
+            valueEnd = blockEnd
+            // find next newline
+            const nl = content.indexOf('\n', valueEnd)
+            pos = nl === -1 ? len : nl + 1
+            value = content.slice(valStart, valueEnd)
+          }
+          // Handle multi-line strings starting with "
+          else if (firstChar === 34) {
+            // '"'
+            let stringEnd = valStart + 1
+            let isEscaped = false
+
+            while (stringEnd < len) {
+              const char = content.charCodeAt(stringEnd)
+
+              if (isEscaped) {
+                isEscaped = false
+              } else if (char === 92) {
+                // '\'
+                isEscaped = true
+              } else if (char === 34) {
+                // '"'
+                stringEnd++
+                break
+              }
+              stringEnd++
+            }
+
+            valueEnd = stringEnd
+            // find next newline
+            const nl = content.indexOf('\n', valueEnd)
+            pos = nl === -1 ? len : nl + 1
+            value = content.slice(valStart, valueEnd)
+          } else {
+            // Normal single line value
+            value = content.slice(valStart, end)
+          }
+        } else {
+          value = content.slice(valStart, end)
+        }
 
         sections.get(currentSection)?.set(key, value)
       }

--- a/tests/helpers/project-settings.test.ts
+++ b/tests/helpers/project-settings.test.ts
@@ -144,3 +144,34 @@ describe('project-settings', () => {
     })
   })
 })
+
+describe('multiline parsing', () => {
+  it('should parse multiline strings', () => {
+    const content = `[application]
+config/description="This is a
+multiline description
+with multiple lines"
+run/main_scene="res://main.tscn"`
+    const settings = parseProjectSettingsContent(content)
+    const app = settings.sections.get('application')
+    expect(app?.get('config/description')).toBe('"This is a\nmultiline description\nwith multiple lines"')
+    expect(app?.get('run/main_scene')).toBe('"res://main.tscn"')
+  })
+
+  it('should parse multiline blocks (like input actions)', () => {
+    const content = `[input]
+action={
+  "deadzone": 0.5,
+  "events": [
+    Object(InputEventKey,"keycode":65)
+  ]
+}
+run/main_scene="res://main.tscn"`
+    const settings = parseProjectSettingsContent(content)
+    const input = settings.sections.get('input')
+    expect(input?.get('action')).toBe(
+      '{\n  "deadzone": 0.5,\n  "events": [\n    Object(InputEventKey,"keycode":65)\n  ]\n}',
+    )
+    expect(input?.get('run/main_scene')).toBe('"res://main.tscn"')
+  })
+})


### PR DESCRIPTION
🎯 **What:**
Updated the `parseProjectSettingsContent` function in `src/tools/helpers/project-settings.ts` to correctly handle multi-line strings (enclosed in `""`) and multi-line objects/blocks (enclosed in `{}`).

💡 **Why:**
Godot's `project.godot` file supports multiline values, commonly used in areas like `[input]` actions (which use multiline blocks `{ ... }`) and application descriptions (which use multiline strings `"..."`). The previous parser used a strict line-by-line traversal that broke when it encountered these multiline values, truncating the value to the first line and improperly interpreting subsequent lines as new keys or sections. Adding robust state-machine parsing prevents config corruption and allows this utility to be universally reliable across the codebase.

✅ **Verification:**
- Added comprehensive unit tests in `tests/helpers/project-settings.test.ts` for both `""` multiline strings and `{}` blocks.
- Ran `bun test` and verified all 585 tests across 39 suites pass.
- Verified parsing logic correctly handles internal escaping (`\"`) and nested brackets.
- Ran `bun run check` and `bun run format` to ensure no linting/formatting issues.

✨ **Result:**
The parser now securely and reliably reads all complex nested and multiline configurations out of `project.godot` without corrupting state or hanging the event loop.

---
*PR created automatically by Jules for task [9815282095393839576](https://jules.google.com/task/9815282095393839576) started by @n24q02m*