### PR TITLE
fix: security] Fix path traversal in Scenes tool via project_path argument

### DIFF
--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -119,7 +119,12 @@ function generateTscnContent(rootName: string, rootType: string): string {
 }
 
 function validateSceneArgs(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath || undefined
+  let projectPath = config.projectPath || undefined
+  if (args.project_path) {
+    const base = config.projectPath || process.cwd()
+    projectPath = safeResolve(base, args.project_path as string)
+  }
+
   const scenePath = args.scene_path as string
   const newPath = args.new_path as string
 
@@ -186,6 +191,11 @@ export async function handleScenes(action: string, args: Record<string, unknown>
     case 'list': {
       // projectPath is guaranteed
       const resolvedPath = resolve(projectPath as string)
+
+      // Additional validation to ensure resolvedPath stays within the project directory
+      const base = config.projectPath || process.cwd()
+      safeResolve(base, resolvedPath)
+
       const scenes = await findSceneFiles(resolvedPath)
       const relativePaths = scenes.map((s) => relative(resolvedPath, s).replace(/\\/g, '/'))
 
@@ -199,6 +209,11 @@ export async function handleScenes(action: string, args: Record<string, unknown>
     case 'info': {
       // scenePath is guaranteed
       const fullPath = resolvePath(projectPath, scenePath)
+
+      // Additional validation to ensure fullPath stays within the project directory
+      const base = config.projectPath || process.cwd()
+      safeResolve(base, fullPath)
+
       if (!existsSync(fullPath)) {
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path and try again.')
       }
@@ -210,6 +225,11 @@ export async function handleScenes(action: string, args: Record<string, unknown>
     case 'delete': {
       // scenePath is guaranteed
       const fullPath = resolvePath(projectPath, scenePath)
+
+      // Additional validation to ensure fullPath stays within the project directory
+      const base = config.projectPath || process.cwd()
+      safeResolve(base, fullPath)
+
       if (!existsSync(fullPath)) {
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
       }
@@ -222,6 +242,11 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       // scenePath and newPath are guaranteed
       const srcFull = resolvePath(projectPath, scenePath)
       const dstFull = resolvePath(projectPath, newPath as string)
+
+      // Additional validation to ensure paths stay within the project directory
+      const base = config.projectPath || process.cwd()
+      safeResolve(base, srcFull)
+      safeResolve(base, dstFull)
 
       if (!existsSync(srcFull)) {
         throw new GodotMCPError(`Source scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the source path.')

--- a/tests/composite/scenes.test.ts
+++ b/tests/composite/scenes.test.ts
@@ -273,9 +273,7 @@ describe('scenes', () => {
     })
 
     it('should reject path traversal via project_path argument in list', async () => {
-      await expect(
-        handleScenes('list', { project_path: '../../../etc' }, config),
-      ).rejects.toThrow('Access denied')
+      await expect(handleScenes('list', { project_path: '../../../etc' }, config)).rejects.toThrow('Access denied')
     })
 
     it('should reject path traversal via project_path argument', async () => {

--- a/tests/composite/scenes.test.ts
+++ b/tests/composite/scenes.test.ts
@@ -266,6 +266,24 @@ describe('scenes', () => {
   // path traversal prevention
   // ==========================================
   describe('path traversal', () => {
+    it('should reject path traversal via project_path argument in info', async () => {
+      await expect(
+        handleScenes('info', { project_path: '../../../etc', scene_path: 'passwd' }, config),
+      ).rejects.toThrow('Access denied')
+    })
+
+    it('should reject path traversal via project_path argument in list', async () => {
+      await expect(
+        handleScenes('list', { project_path: '../../../etc' }, config),
+      ).rejects.toThrow('Access denied')
+    })
+
+    it('should reject path traversal via project_path argument', async () => {
+      await expect(
+        handleScenes('info', { project_path: '../../../etc', scene_path: 'passwd' }, config),
+      ).rejects.toThrow('Access denied')
+    })
+
     it('should reject info with ../etc/passwd traversal', async () => {
       await expect(
         handleScenes('info', { project_path: projectPath, scene_path: '../../../etc/passwd' }, config),


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Fixed a path traversal vulnerability in `src/tools/composite/scenes.ts` where actions such as `info`, `list`, `delete`, and `duplicate` resolved paths using an unverified `args.project_path` base. Because `resolvePath` directly resolved relative paths against this unverified base, attackers could provide `project_path = "../../../etc"` to escape the workspace entirely.

⚠️ **Risk:** The potential impact if left unfixed
An attacker could read or delete arbitrary files on the host filesystem that the MCP server had access to, by explicitly providing an absolute or relative traversed path to the `project_path` argument, bypassing the checks meant only for `scene_path`.

🛡️ **Solution:** How the fix addresses the vulnerability
Added robust verification directly before file operations in `handleScenes` (`info`, `list`, `delete`, `duplicate`). The code now resolves the target paths (`fullPath` or `resolvedPath`) and then validates them using `safeResolve(base, path)` against a trusted base (`config.projectPath` or `process.cwd()`). This ensures the final filesystem path is strictly contained within the intended Godot workspace. Also added integration tests to verify that path traversal via the `project_path` argument is explicitly rejected.

---
*PR created automatically by Jules for task [1320017208343169731](https://jules.google.com/task/1320017208343169731) started by @n24q02m*