### PR TITLE
feat: refactor project-settings INI parser to natively support multiline values

### DIFF
--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -1,3 +1,4 @@
+import { parseProjectSettingsContent } from '../helpers/project-settings.js'
 /**
  * Input Map tool - Input action management via project.godot
  * Actions: list | add_action | remove_action | add_event
@@ -146,49 +147,13 @@ function getProjectGodotPath(projectPath: string | null | undefined): string {
  */
 function parseInputActions(content: string): Map<string, string[]> {
   const actions = new Map<string, string[]>()
-  let inInputSection = false
-  let currentActionName: string | null = null
-  let currentActionAccumulator = ''
+  const settings = parseProjectSettingsContent(content)
+  const inputSection = settings.sections.get('input')
 
-  for (const line of content.split('\n')) {
-    const trimmed = line.trim()
-
-    // Handle multi-line continuation
-    if (currentActionName !== null) {
-      currentActionAccumulator += trimmed
-      if (trimmed.endsWith('}')) {
-        // End of multi-line action
-        const eventsMatch = currentActionAccumulator.match(/"events":\s*\[([^\]]*)\]/)
-        const events = eventsMatch
-          ? eventsMatch[1]
-              .split(',')
-              .map((e) => e.trim())
-              .filter(Boolean)
-          : []
-        actions.set(currentActionName, events)
-        currentActionName = null
-        currentActionAccumulator = ''
-      }
-      continue
-    }
-
-    if (trimmed === '[input]') {
-      inInputSection = true
-      continue
-    }
-
-    // Stop if we hit another section
-    if (trimmed.startsWith('[') && inInputSection) {
-      inInputSection = false
-      break
-    }
-
-    if (inInputSection) {
-      // Single-line format: action_name={...}
-      const match = trimmed.match(/^(\w+)=\{(.+)\}$/)
-      if (match) {
-        const actionName = match[1]
-        const eventsMatch = match[2].match(/"events":\s*\[([^\]]*)\]/)
+  if (inputSection) {
+    for (const [actionName, actionData] of inputSection.entries()) {
+      if (actionData.startsWith('{')) {
+        const eventsMatch = actionData.match(/"events":\s*\[([^\]]*)\]/)
         const events = eventsMatch
           ? eventsMatch[1]
               .split(',')
@@ -196,16 +161,6 @@ function parseInputActions(content: string): Map<string, string[]> {
               .filter(Boolean)
           : []
         actions.set(actionName, events)
-      } else {
-        // Multi-line format start: action_name={
-        //   "deadzone": 0.2,
-        //   "events": [...]
-        // }
-        const startMatch = trimmed.match(/^(\w+)=\{(.*)$/)
-        if (startMatch) {
-          currentActionName = startMatch[1]
-          currentActionAccumulator = startMatch[2]
-        }
       }
     }
   }

--- a/src/tools/helpers/project-settings.ts
+++ b/src/tools/helpers/project-settings.ts
@@ -44,7 +44,7 @@ export function parseProjectSettingsContent(content: string): ProjectSettings {
   const len = content.length
 
   while (pos < len) {
-    const nextNewline = content.indexOf('\n', pos)
+    let nextNewline = content.indexOf('\n', pos)
     const lineEnd = nextNewline === -1 ? len : nextNewline
 
     // Trim line manually (whitespace <= 32)
@@ -79,7 +79,52 @@ export function parseProjectSettingsContent(content: string): ProjectSettings {
         while (valStart < end && content.charCodeAt(valStart) <= 32) valStart++
 
         const key = content.slice(start, keyEnd)
-        const value = content.slice(valStart, end)
+        let value = content.slice(valStart, end)
+
+        // Handle multi-line dictionary values enclosed in {}
+        if (value.charCodeAt(0) === 123) {
+          // 123 is '{'
+          let dictEnd = end
+          // Look for closing '}' or until end of string
+          while (dictEnd < len) {
+            if (content.charCodeAt(dictEnd - 1) === 125) {
+              // 125 is '}'
+              // Re-check if this line actually ends with '}' (ignoring trailing whitespace)
+              let actualEnd = dictEnd - 1
+              while (actualEnd > valStart && content.charCodeAt(actualEnd) <= 32) actualEnd--
+              if (content.charCodeAt(actualEnd) === 125) {
+                break
+              }
+            }
+
+            const nextLineEnd = content.indexOf('\n', dictEnd)
+            if (nextLineEnd === -1) {
+              dictEnd = len
+              break
+            }
+
+            dictEnd = nextLineEnd + 1 // include newline
+
+            // Check if the current line ends with '}'
+            let tempEnd = dictEnd - 1
+            while (tempEnd > valStart && content.charCodeAt(tempEnd) <= 32) tempEnd--
+            if (content.charCodeAt(tempEnd) === 125) {
+              break
+            }
+          }
+
+          if (dictEnd > end) {
+            value = content.slice(valStart, dictEnd)
+            // Update pos and nextNewline to skip the lines we just read
+            pos = dictEnd
+            nextNewline = dictEnd - 1
+
+            // trim trailing whitespaces
+            let finalEnd = value.length
+            while (finalEnd > 0 && value.charCodeAt(finalEnd - 1) <= 32) finalEnd--
+            value = value.slice(0, finalEnd)
+          }
+        }
 
         sections.get(currentSection)?.set(key, value)
       }

--- a/tests/helpers/project-settings-multiline.test.ts
+++ b/tests/helpers/project-settings-multiline.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { parseProjectSettingsContent } from '../../src/tools/helpers/project-settings.js'
+
+describe('project-settings multiline', () => {
+  it('should parse multiline values', () => {
+    const content = `[input]
+action={
+"deadzone": 0.5,
+"events": [
+  Object(InputEventKey,"keycode":65)
+]
+}
+other=123`
+    const settings = parseProjectSettingsContent(content)
+    const input = settings.sections.get('input')
+    expect(input?.get('action')).toBe('{\n"deadzone": 0.5,\n"events": [\n  Object(InputEventKey,"keycode":65)\n]\n}')
+    expect(input?.get('other')).toBe('123')
+  })
+})

--- a/tests/helpers/project-settings.test.ts
+++ b/tests/helpers/project-settings.test.ts
@@ -60,6 +60,21 @@ describe('project-settings', () => {
       const settings = parseProjectSettingsContent(SAMPLE_PROJECT_GODOT)
       expect(settings.raw).toBe(SAMPLE_PROJECT_GODOT)
     })
+
+    it('should parse multiline values enclosed in {}', () => {
+      const multilineContent = `[input]
+action={
+"deadzone": 0.5,
+"events": [
+  Object(InputEventKey,"keycode":65)
+]
+}
+other=123`
+      const settings = parseProjectSettingsContent(multilineContent)
+      const input = settings.sections.get('input')
+      expect(input?.get('action')).toBe('{\n"deadzone": 0.5,\n"events": [\n  Object(InputEventKey,"keycode":65)\n]\n}')
+      expect(input?.get('other')).toBe('123')
+    })
   })
 
   // ==========================================


### PR DESCRIPTION
🎯 What
Enhanced the `parseProjectSettingsContent` function in `src/tools/helpers/project-settings.ts` to natively support parsing multiline dictionary values (enclosed in `{}`).
Removed the complex, duplicate multiline parsing logic from `src/tools/composite/input-map.ts`, replacing it with a clean consumption of the generalized parser.

💡 Why
The custom INI-like format used by `.godot` files allows values (like input mappings) to span multiple lines. Previously, `parseProjectSettingsContent` only read single lines, forcing `input-map.ts` to implement a rigid ~40-line state machine to re-parse the file just for `[input]` actions.
By centralizing this capability in `project-settings.ts`, we improve maintainability, reduce code duplication, and ensure that any tool needing to read multiline project settings in the future can do so reliably.

✅ Verification
1. Created new tests in `tests/helpers/project-settings.test.ts` and `tests/helpers/project-settings-multiline.test.ts` specifically asserting that multiline values are correctly extracted.
2. Ran the existing `tests/composite/input-map.test.ts` suite. All 20 tests pass, confirming the refactored implementation behaves identically to the old one.
3. Ran the complete project test suite using `pnpm test` (585 passing tests).
4. Ran `bun run check` and `bun run format` to ensure linter and formatter compliance. No errors were found.

✨ Result
A cleaner, more robust, and centralized parser for `project.godot` files, with a significantly simplified `input-map.ts` tool. Functional equivalence is preserved while improving codebase health.

---
*PR created automatically by Jules for task [3543908225601428270](https://jules.google.com/task/3543908225601428270) started by @n24q02m*