### PR TITLE
feat: consolidate argument validation logic across tools

### DIFF
--- a/src/tools/composite/animation.ts
+++ b/src/tools/composite/animation.ts
@@ -7,6 +7,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
+import { validateSceneArgs } from '../helpers/scene-parser.js'
 
 function resolveScene(projectPath: string | null | undefined, scenePath: string): string {
   const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
@@ -16,12 +17,11 @@ function resolveScene(projectPath: string | null | undefined, scenePath: string)
 }
 
 export async function handleAnimation(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath
+  const { projectPath } = validateSceneArgs(args, config, false)
 
   switch (action) {
     case 'create_player': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const { scenePath } = validateSceneArgs(args, config)
       const playerName = (args.name as string) || 'AnimationPlayer'
       const parent = (args.parent as string) || '.'
 
@@ -37,8 +37,7 @@ export async function handleAnimation(action: string, args: Record<string, unkno
     }
 
     case 'add_animation': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const { scenePath } = validateSceneArgs(args, config)
       const animName = args.anim_name as string
       if (!animName) throw new GodotMCPError('No anim_name specified', 'INVALID_ARGS', 'Provide animation name.')
       const duration = (args.duration as number) || 1.0
@@ -65,8 +64,7 @@ export async function handleAnimation(action: string, args: Record<string, unkno
     }
 
     case 'add_track': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const { scenePath } = validateSceneArgs(args, config)
       const animName = args.anim_name as string
       const trackType = (args.track_type as string) || 'value'
       const nodePath = args.node_path as string
@@ -113,8 +111,7 @@ export async function handleAnimation(action: string, args: Record<string, unkno
     }
 
     case 'list': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const { scenePath } = validateSceneArgs(args, config)
 
       const fullPath = resolveScene(projectPath, scenePath)
       const content = readFileSync(fullPath, 'utf-8')

--- a/src/tools/composite/audio.ts
+++ b/src/tools/composite/audio.ts
@@ -8,9 +8,10 @@ import { resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
+import { validateSceneArgs } from '../helpers/scene-parser.js'
 
 export async function handleAudio(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath
+  const { projectPath } = validateSceneArgs(args, config, false)
 
   switch (action) {
     case 'list_buses': {
@@ -150,8 +151,7 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
     }
 
     case 'create_stream': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const { scenePath } = validateSceneArgs(args, config)
       const nodeName = (args.name as string) || 'AudioStreamPlayer'
       const streamType = (args.stream_type as string) || '2D'
       const parent = (args.parent as string) || '.'

--- a/src/tools/composite/navigation.ts
+++ b/src/tools/composite/navigation.ts
@@ -7,6 +7,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
+import { validateSceneArgs } from '../helpers/scene-parser.js'
 
 function resolveScene(projectPath: string | null | undefined, scenePath: string): string {
   const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
@@ -23,12 +24,11 @@ function appendNode(content: string, name: string, type: string, parent: string,
 }
 
 export async function handleNavigation(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath
+  const { projectPath } = validateSceneArgs(args, config, false)
 
   switch (action) {
     case 'create_region': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const { scenePath } = validateSceneArgs(args, config)
       const regionName = (args.name as string) || 'NavigationRegion3D'
       const parent = (args.parent as string) || '.'
       const dimension = (args.dimension as string) || '3D'
@@ -44,8 +44,7 @@ export async function handleNavigation(action: string, args: Record<string, unkn
     }
 
     case 'add_agent': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const { scenePath } = validateSceneArgs(args, config)
       const agentName = (args.name as string) || 'NavigationAgent3D'
       const parent = (args.parent as string) || '.'
       const dimension = (args.dimension as string) || '3D'
@@ -67,8 +66,7 @@ export async function handleNavigation(action: string, args: Record<string, unkn
     }
 
     case 'add_obstacle': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const { scenePath } = validateSceneArgs(args, config)
       const obstacleName = (args.name as string) || 'NavigationObstacle3D'
       const parent = (args.parent as string) || '.'
       const dimension = (args.dimension as string) || '3D'

--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -14,6 +14,7 @@ import {
   renameNodeInContent,
   type SceneNodeInfo,
   setNodePropertyInContent,
+  validateSceneArgs,
 } from '../helpers/scene-parser.js'
 
 /**
@@ -42,12 +43,11 @@ function resolveScenePath(projectPath: string | null | undefined, scenePath: str
 }
 
 export async function handleNodes(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath
+  const { projectPath } = validateSceneArgs(args, config, false)
 
   switch (action) {
     case 'add': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const { scenePath } = validateSceneArgs(args, config)
       const nodeName = args.name as string
       if (!nodeName) throw new GodotMCPError('No node name specified', 'INVALID_ARGS', 'Provide name for the new node.')
       const nodeType = (args.type as string) || 'Node'
@@ -77,8 +77,7 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
     }
 
     case 'remove': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const { scenePath } = validateSceneArgs(args, config)
       const nodeName = args.name as string
       if (!nodeName)
         throw new GodotMCPError('No node name specified', 'INVALID_ARGS', 'Provide name of node to remove.')
@@ -95,8 +94,7 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
     }
 
     case 'rename': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const { scenePath } = validateSceneArgs(args, config)
       const nodeName = args.name as string
       const newName = args.new_name as string
       if (!nodeName || !newName)
@@ -114,8 +112,7 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
     }
 
     case 'list': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const { scenePath } = validateSceneArgs(args, config)
 
       const fullPath = resolveScenePath(projectPath, scenePath)
       if (!existsSync(fullPath))
@@ -138,8 +135,7 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
     }
 
     case 'set_property': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const { scenePath } = validateSceneArgs(args, config)
       const nodeName = args.name as string
       const property = args.property as string
       const value = args.value as string
@@ -163,8 +159,7 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
     }
 
     case 'get_property': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const { scenePath } = validateSceneArgs(args, config)
       const nodeName = args.name as string
       const property = args.property as string
       if (!nodeName || !property) {

--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -9,9 +9,10 @@ import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
 import { parseProjectSettings, setSettingInContent } from '../helpers/project-settings.js'
+import { validateSceneArgs } from '../helpers/scene-parser.js'
 
 export async function handlePhysics(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath
+  const { projectPath } = validateSceneArgs(args, config, false)
 
   switch (action) {
     case 'layers': {
@@ -37,8 +38,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
     }
 
     case 'collision_setup': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const { scenePath } = validateSceneArgs(args, config)
       const nodeName = args.name as string
       if (!nodeName) throw new GodotMCPError('No node name specified', 'INVALID_ARGS', 'Provide node name.')
       const collisionLayer = args.collision_layer as number
@@ -70,8 +70,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
     }
 
     case 'body_config': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const { scenePath } = validateSceneArgs(args, config)
       const nodeName = args.name as string
       if (!nodeName) throw new GodotMCPError('No node name specified', 'INVALID_ARGS', 'Provide node name.')
 

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -10,6 +10,7 @@ import type { GodotConfig, SceneInfo, SceneNode } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
 import { setSettingInContent } from '../helpers/project-settings.js'
+import { validateSceneArgs } from '../helpers/scene-parser.js'
 
 // Pre-compiled regex for parsing scene metadata without splitting lines
 const rxNode = /^\[node\s+name="([^"]+)"\s+type="([^"]+)"(?:\s+parent="([^"]*)")?/
@@ -118,9 +119,8 @@ function generateTscnContent(rootName: string, rootType: string): string {
   return [`[gd_scene format=3]`, '', `[node name="${rootName}" type="${rootType}"]`, ''].join('\n')
 }
 
-function validateSceneArgs(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath || undefined
-  const scenePath = args.scene_path as string
+function validateScenesToolArgs(action: string, args: Record<string, unknown>, config: GodotConfig) {
+  const { projectPath, scenePath } = validateSceneArgs(args, config, false)
   const newPath = args.new_path as string
 
   // project_path required
@@ -159,7 +159,7 @@ function resolvePath(base: string | undefined, relativePath: string): string {
 }
 
 export async function handleScenes(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const { projectPath, scenePath, newPath } = validateSceneArgs(action, args, config)
+  const { projectPath, scenePath, newPath } = validateScenesToolArgs(action, args, config)
 
   switch (action) {
     case 'create': {

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -9,6 +9,7 @@ import { dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
+import { validateSceneArgs } from '../helpers/scene-parser.js'
 
 const SCRIPT_TEMPLATES: Record<string, string> = {
   Node: `extends Node
@@ -123,7 +124,7 @@ async function findScriptFiles(dir: string): Promise<string[]> {
 }
 
 export async function handleScripts(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath
+  const { projectPath } = validateSceneArgs(args, config, false)
 
   if (!projectPath && action !== 'list') {
     // List handles missing projectPath internally, but others need it for safeResolve base
@@ -188,7 +189,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
     }
 
     case 'attach': {
-      const scenePath = args.scene_path as string
+      const { scenePath } = validateSceneArgs(args, config, false)
       const scriptPath = args.script_path as string
       const nodeName = args.node_name as string
       if (!scenePath || !scriptPath) {

--- a/src/tools/composite/signals.ts
+++ b/src/tools/composite/signals.ts
@@ -7,13 +7,10 @@ import { readFile, writeFile } from 'node:fs/promises'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
-import { parseSceneContent } from '../helpers/scene-parser.js'
+import { parseSceneContent, validateSceneArgs } from '../helpers/scene-parser.js'
 
 export async function handleSignals(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath
-  const scenePath = args.scene_path as string
-
-  if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+  const { projectPath, scenePath } = validateSceneArgs(args, config)
   const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
 
   async function readScene() {

--- a/src/tools/composite/tilemap.ts
+++ b/src/tools/composite/tilemap.ts
@@ -8,9 +8,10 @@ import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
+import { validateSceneArgs } from '../helpers/scene-parser.js'
 
 export async function handleTilemap(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath
+  const { projectPath } = validateSceneArgs(args, config, false)
 
   switch (action) {
     case 'create_tileset': {
@@ -77,9 +78,7 @@ export async function handleTilemap(action: string, args: Record<string, unknown
     }
 
     case 'paint': {
-      const scenePath = args.scene_path as string
-      if (!scenePath)
-        throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path with TileMapLayer node.')
+      validateSceneArgs(args, config)
 
       return formatSuccess(
         'TileMap painting requires modifying tile_map_data which is binary-encoded.\n' +
@@ -89,9 +88,7 @@ export async function handleTilemap(action: string, args: Record<string, unknown
     }
 
     case 'list': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
-
+      const { scenePath } = validateSceneArgs(args, config)
       const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')

--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -8,7 +8,7 @@ import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
-import { parseScene } from '../helpers/scene-parser.js'
+import { parseScene, validateSceneArgs } from '../helpers/scene-parser.js'
 
 const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
   Button: { text: '"Click"' },
@@ -39,12 +39,11 @@ function resolveScene(projectPath: string | null | undefined, scenePath: string)
 }
 
 export async function handleUI(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath
+  const { projectPath } = validateSceneArgs(args, config, false)
 
   switch (action) {
     case 'create_control': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const { scenePath } = validateSceneArgs(args, config)
       const controlName = args.name as string
       const controlType = (args.type as string) || 'Control'
       const parent = (args.parent as string) || '.'
@@ -109,8 +108,7 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
     }
 
     case 'layout': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const { scenePath } = validateSceneArgs(args, config)
       const nodeName = args.name as string
       if (!nodeName) throw new GodotMCPError('No name specified', 'INVALID_ARGS', 'Provide node name.')
       const preset = (args.preset as string) || 'full_rect'
@@ -164,8 +162,7 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
     }
 
     case 'list_controls': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const { scenePath } = validateSceneArgs(args, config)
 
       const fullPath = resolveScene(projectPath, scenePath)
       const scene = parseScene(fullPath)

--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -1,3 +1,5 @@
+import type { GodotConfig } from '../../godot/types.js'
+import { GodotMCPError } from './errors.js'
 /**
  * Scene Parser - Parse Godot .tscn (text scene) format
  *
@@ -391,4 +393,19 @@ export function getNodeProperty(scene: ParsedScene, nodeName: string, property: 
  */
 export function writeScene(filePath: string, content: string): void {
   writeFileSync(filePath, content, 'utf-8')
+}
+
+/**
+ * Validate and resolve standard scene arguments
+ * Reusable helper to consolidate argument validation logic
+ */
+export function validateSceneArgs(args: Record<string, unknown>, config: GodotConfig, requireScenePath = true) {
+  const projectPath = (args.project_path as string) || config.projectPath || undefined
+  const scenePath = args.scene_path as string
+
+  if (requireScenePath && !scenePath) {
+    throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+  }
+
+  return { projectPath, scenePath }
 }


### PR DESCRIPTION
🎯 **What:** Extracted repetitive argument validation logic (checking for `scene_path` presence) from 10 composite tool files into a shared `validateSceneArgs` helper in `src/tools/helpers/scene-parser.ts`.
💡 **Why:** Reduces code duplication, improves maintainability, and ensures standardized error messages when `scene_path` is missing across all tools.
✅ **Verification:** Ran `bun run check` to verify types and format. Ran `npx vitest run` and confirmed all 583 tests across 39 suites pass without regression. 
✨ **Result:** Cleaned up boilerplate code in animation, audio, navigation, nodes, physics, scenes, scripts, signals, tilemap, and ui tools.

---
*PR created automatically by Jules for task [11352837721958474845](https://jules.google.com/task/11352837721958474845) started by @n24q02m*