### PR TITLE
fix: security fix] Fix Command Injection in Config Tool

### DIFF
--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -3,6 +3,7 @@
  * Actions: status | set
  */
 
+import fs from 'node:fs'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 
@@ -22,7 +23,7 @@ export async function handleConfig(action: string, args: Record<string, unknown>
 
     case 'set': {
       const key = args.key as string
-      const value = args.value as string
+      const value = args.value
 
       if (!key) {
         throw new GodotMCPError('No key specified', 'INVALID_ARGS', 'Provide key to set (e.g., project_path).')
@@ -31,18 +32,50 @@ export async function handleConfig(action: string, args: Record<string, unknown>
         throw new GodotMCPError('No value specified', 'INVALID_ARGS', 'Provide value for the key.')
       }
 
+      if (typeof value !== 'string') {
+        throw new GodotMCPError('Invalid value type', 'INVALID_ARGS', 'Value must be a string.')
+      }
+
       const validKeys = ['project_path', 'godot_path', 'timeout']
       if (!validKeys.includes(key)) {
         throw new GodotMCPError(`Invalid config key: ${key}`, 'INVALID_ARGS', `Valid keys: ${validKeys.join(', ')}`)
       }
 
-      // Validate paths don't contain shell metacharacters
-      if ((key === 'project_path' || key === 'godot_path') && /[;&|`$(){}<>'"\0\n\r]/.test(value)) {
-        throw new GodotMCPError(
-          `Invalid characters in ${key}`,
-          'INVALID_ARGS',
-          'Path must not contain shell metacharacters: ; & | ` $ ( ) { } < > \' " \\0 \\n \\r',
-        )
+      // Strict validation for paths
+      if (key === 'project_path' || key === 'godot_path') {
+        // Prevent command injection by explicitly rejecting shell metacharacters
+        if (/[;&|`$(){}<>'"\0\n\r]/.test(value)) {
+          throw new GodotMCPError(
+            `Invalid characters in ${key}`,
+            'INVALID_ARGS',
+            'Path must not contain shell metacharacters: ; & | ` $ ( ) { } < > \' " \\0 \\n \\r',
+          )
+        }
+
+        // Ensure godot_path points to an actual executable file.
+        // This prevents executing arbitrary commands or passing arguments via spaces
+        // (e.g. "node -e '...'" or "/bin/sh -c '...'").
+        if (key === 'godot_path') {
+          try {
+            if (!fs.existsSync(value)) {
+              throw new GodotMCPError(
+                'Invalid godot_path',
+                'INVALID_ARGS',
+                `The executable does not exist at path: ${value}`,
+              )
+            }
+            if (!fs.statSync(value).isFile()) {
+              throw new GodotMCPError('Invalid godot_path', 'INVALID_ARGS', `The path provided is not a file: ${value}`)
+            }
+          } catch (e) {
+            if (e instanceof GodotMCPError) throw e
+            throw new GodotMCPError(
+              'Invalid godot_path',
+              'INVALID_ARGS',
+              `Could not access the specified path: ${value}`,
+            )
+          }
+        }
       }
 
       runtimeConfig[key] = value

--- a/tests/composite/config.test.ts
+++ b/tests/composite/config.test.ts
@@ -2,10 +2,17 @@
  * Integration tests for Config tool
  */
 
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { GodotConfig } from '../../src/godot/types.js'
 import { handleConfig } from '../../src/tools/composite/config.js'
 import { makeConfig } from '../fixtures.js'
+
+vi.mock('node:fs', () => ({
+  default: {
+    existsSync: vi.fn().mockReturnValue(true),
+    statSync: vi.fn().mockReturnValue({ isFile: () => true }),
+  },
+}))
 
 describe('config', () => {
   let config: GodotConfig


### PR DESCRIPTION
🎯 What: Prevented an arbitrary argument/array injection vulnerability in `src/tools/composite/config.ts`.
⚠️ Risk: If the configured `godotPath` is an array or malicious string executable, `execGodotSync` could execute arbitrary commands and cause a severe command injection vulnerability.
🛡️ Solution: Add robust string type-checking for `value` and explicitly enforce that the path provided to `godotPath` exists and is a legitimate file via `fs.existsSync(value)` and `fs.statSync(value).isFile()`. This robustly prevents passing arguments via spaces (e.g. `node -e '...'`) because no such file exists on the disk.

---
*PR created automatically by Jules for task [921584366480364367](https://jules.google.com/task/921584366480364367) started by @n24q02m*