### PR TITLE
feat: project] use project-settings parser for godot project parsing

### DIFF
--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -4,8 +4,8 @@
  */
 
 import { execFileSync } from 'node:child_process'
-import { existsSync } from 'node:fs'
-import { readFile, writeFile } from 'node:fs/promises'
+import { access, constants, readFile, writeFile } from 'node:fs/promises'
+
 import { join, resolve } from 'node:path'
 import { execGodotSync, runGodotProject } from '../../godot/headless.js'
 import type { GodotConfig, ProjectInfo } from '../../godot/types.js'
@@ -13,9 +13,18 @@ import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
 import { getSetting, parseProjectSettingsAsync, setSettingInContent } from '../helpers/project-settings.js'
 
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath, constants.F_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
 async function parseProjectGodot(projectPath: string): Promise<ProjectInfo> {
   const configPath = join(projectPath, 'project.godot')
-  if (!existsSync(configPath)) {
+  if (!(await fileExists(configPath))) {
     throw new GodotMCPError(
       `No project.godot found at ${projectPath}`,
       'PROJECT_NOT_FOUND',
@@ -23,40 +32,37 @@ async function parseProjectGodot(projectPath: string): Promise<ProjectInfo> {
     )
   }
 
-  const content = await readFile(configPath, 'utf-8')
-  const lines = content.split('\n')
+  const projectSettings = await parseProjectSettingsAsync(configPath)
 
   const info: ProjectInfo = { name: 'Unknown', configVersion: 5, mainScene: null, features: [], settings: {} }
-  let currentSection = ''
 
-  for (const line of lines) {
-    const trimmed = line.trim()
+  // Extract config_version from raw content (it appears before any section)
+  const configVersionMatch = projectSettings.raw.match(/^config_version\s*=\s*(\d+)/m)
+  if (configVersionMatch) {
+    info.configVersion = Number.parseInt(configVersionMatch[1], 10)
+    info.settings['config_version'] = configVersionMatch[1]
+  }
 
-    const sectionMatch = trimmed.match(/^\[(.+)\]$/)
-    if (sectionMatch) {
-      currentSection = sectionMatch[1]
-      continue
-    }
+  // Iterate over sections and populate info.settings
+  for (const [section, map] of projectSettings.sections.entries()) {
+    for (const [key, rawValue] of map.entries()) {
+      // For info extraction, we need the unquoted value
+      const value = rawValue.replace(/^"(.*)"$/, '$1')
+      const fullKey = `${section}/${key}`
 
-    const kvMatch = trimmed.match(/^(\S+)\s*=\s*(.+)$/)
-    if (!kvMatch) continue
+      info.settings[fullKey] = value
 
-    const [, key, rawValue] = kvMatch
-    const value = rawValue.replace(/^"(.*)"$/, '$1')
-
-    if (currentSection === '' || currentSection === 'application') {
-      if (key === 'config/name') info.name = value
-      if (key === 'run/main_scene') info.mainScene = value
-      if (key === 'config/features') {
-        const featMatch = rawValue.match(/PackedStringArray\((.+)\)/)
-        if (featMatch) {
-          info.features = featMatch[1].split(',').map((f) => f.trim().replace(/"/g, ''))
+      if (section === 'application') {
+        if (key === 'config/name') info.name = value
+        if (key === 'run/main_scene') info.mainScene = value
+        if (key === 'config/features') {
+          const featMatch = rawValue.match(/PackedStringArray\((.+)\)/)
+          if (featMatch) {
+            info.features = featMatch[1].split(',').map((f) => f.trim().replace(/"/g, ''))
+          }
         }
       }
     }
-
-    if (key === 'config_version') info.configVersion = Number.parseInt(value, 10)
-    info.settings[`${currentSection ? `${currentSection}/` : ''}${key}`] = value
   }
 
   return info
@@ -116,7 +122,7 @@ export async function handleProject(action: string, args: Record<string, unknown
         throw new GodotMCPError('No key specified', 'INVALID_ARGS', 'Provide key (e.g., "application/config/name").')
 
       const configPath = join(resolve(projectPath), 'project.godot')
-      if (!existsSync(configPath))
+      if (!(await fileExists(configPath)))
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')
 
       const settings = await parseProjectSettingsAsync(configPath)
@@ -134,7 +140,7 @@ export async function handleProject(action: string, args: Record<string, unknown
         throw new GodotMCPError('key and value required', 'INVALID_ARGS', 'Provide key and value.')
 
       const configPath = join(resolve(projectPath), 'project.godot')
-      if (!existsSync(configPath))
+      if (!(await fileExists(configPath)))
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')
 
       const content = await readFile(configPath, 'utf-8')


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
- Updated `src/tools/composite/project.ts` to use `parseProjectSettingsAsync` instead of implementing manual string-splitting and regex parsing logic for Godot project files.
- Replaced the synchronous, thread-blocking `existsSync` calls from `node:fs` with a custom, asynchronous `fileExists` helper using `access` from `node:fs/promises`.

💡 **Why:** How this improves maintainability
- Resolves code duplication and ensures that `project.godot` files are consistently processed by the shared, well-tested project-settings parser (`parseProjectSettingsAsync`). 
- Using asynchronous file I/O operations (`await access`) instead of synchronous equivalents (`existsSync`) adheres strictly to project guidelines, preventing the Node.js event loop from being blocked by file-system queries. 

✅ **Verification:** How you confirmed the change is safe
- Ran `bun run test tests/composite/project.test.ts` to confirm that all 24 existing project tests pass flawlessly.
- Assured correct data extraction semantics by comparing before/after property handling (like preserving raw array brackets for strings vs splitting correctly into JavaScript strings).
- Ran code formatter (`bun run format`) and linters (`bun run check`) successfully.

✨ **Result:** The improvement achieved
- A cleaner, robust, non-blocking `parseProjectGodot` extraction process that naturally respects Godot file configurations without imposing local micro-optimizations that violated separation of concerns.

---
*PR created automatically by Jules for task [8013374840732278759](https://jules.google.com/task/8013374840732278759) started by @n24q02m*