### PR TITLE
fix: fix Path Traversal in Scripts Tool (Read)

### DIFF
--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, relative, resolve } from 'node:path'
+import { isAbsolute, normalize, relative, resolve, sep } from 'node:path'
 import { GodotMCPError } from './errors.js'
 
 /**
@@ -18,10 +18,17 @@ export function safeResolve(baseDir: string, targetPath: string): string {
   const relativePath = relative(resolvedBase, resolvedTarget)
 
   // Check if path is outside base directory
-  // 1. Starts with .. (parent directory)
-  // 2. Is absolute (on Windows, could be different drive)
-  // 3. relativePath should not be absolute if it's inside base
-  if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+  const baseWithSep = resolvedBase.endsWith(sep) ? resolvedBase : resolvedBase + sep
+
+  // If base is root, resolve() strips '..' so we must also check the normalized targetPath
+  const isRootBypass = resolvedBase === resolve('/') && normalize(targetPath).startsWith('..')
+
+  if (
+    (!resolvedTarget.startsWith(baseWithSep) && resolvedTarget !== resolvedBase) ||
+    relativePath.startsWith('..') ||
+    isAbsolute(relativePath) ||
+    isRootBypass
+  ) {
     throw new GodotMCPError(
       `Access denied: Path '${targetPath}' resolves to '${resolvedTarget}' which is outside the project root '${resolvedBase}'.`,
       'INVALID_ARGS',

--- a/tests/helpers/paths.test.ts
+++ b/tests/helpers/paths.test.ts
@@ -1,0 +1,39 @@
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { GodotMCPError } from '../../src/tools/helpers/errors.js'
+import { safeResolve } from '../../src/tools/helpers/paths.js'
+
+describe('safeResolve', () => {
+  it('should safely resolve paths within project directory', () => {
+    const baseDir = resolve('/mock-project')
+    expect(safeResolve(baseDir, 'file.txt')).toBe(join(baseDir, 'file.txt'))
+    expect(safeResolve(baseDir, 'subdir/file.txt')).toBe(join(baseDir, 'subdir/file.txt'))
+    expect(safeResolve(baseDir, './file.txt')).toBe(join(baseDir, 'file.txt'))
+  })
+
+  it('should prevent path traversal outside project directory', () => {
+    const baseDir = resolve('/mock-project')
+    expect(() => safeResolve(baseDir, '../outside.txt')).toThrow(GodotMCPError)
+    expect(() => safeResolve(baseDir, '../../etc/passwd')).toThrow(GodotMCPError)
+    expect(() => safeResolve(baseDir, 'subdir/../../outside.txt')).toThrow(GodotMCPError)
+  })
+
+  it('should throw when path resolves to exactly outside prefix', () => {
+    // Prefix-matching vulnerability test (e.g. /project vs /project-secrets)
+    const baseDir = resolve('/mock-project')
+    expect(() => safeResolve(baseDir, '../mock-project-secrets/file.txt')).toThrow(GodotMCPError)
+  })
+
+  it('should prevent path traversal when base is the root directory', () => {
+    // Root directory traversal test
+    const baseDir = resolve('/')
+    // This previously bypassed checks because relative('/', '/etc/passwd') does not start with '..'
+    expect(() => safeResolve(baseDir, '../etc/passwd')).toThrow(GodotMCPError)
+  })
+
+  it('should allow resolving exact base directory', () => {
+    const baseDir = resolve('/mock-project')
+    expect(safeResolve(baseDir, '.')).toBe(baseDir)
+    expect(safeResolve(baseDir, '')).toBe(baseDir)
+  })
+})


### PR DESCRIPTION
🔒 Fix Path Traversal in Scripts Tool (Read)

🎯 **What:** The `safeResolve` function in `src/tools/helpers/paths.ts` allowed path traversal when the base directory was the root directory (`/`). This allowed reading arbitrary files (e.g. `../etc/passwd`) using the scripts tool.
⚠️ **Risk:** An attacker or malicious user could exploit this to read sensitive files on the host system outside of the project directory.
🛡️ **Solution:** Updated `safeResolve` to strictly enforce path boundaries using `startsWith` and `isAbsolute` along with validating the normalized target path to detect root traversal bypasses. Added thorough unit tests to prevent regressions.

---
*PR created automatically by Jules for task [17578739584187394280](https://jules.google.com/task/17578739584187394280) started by @n24q02m*