### PR TITLE
feat: extract file search logic to reusable findFiles helper

### DIFF
--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -4,6 +4,7 @@
  */
 
 import { existsSync, readFileSync, statSync, unlinkSync } from 'node:fs'
+import { stat } from 'node:fs/promises'
 import { extname, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'

--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -4,11 +4,10 @@
  */
 
 import { existsSync, readFileSync, statSync, unlinkSync } from 'node:fs'
-import { readdir, stat } from 'node:fs/promises'
-import { extname, join, relative, resolve } from 'node:path'
+import { extname, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
-import { safeResolve } from '../helpers/paths.js'
+import { findFiles, safeResolve } from '../helpers/paths.js'
 
 const RESOURCE_EXTENSIONS = new Set([
   '.tres',
@@ -29,40 +28,24 @@ const RESOURCE_EXTENSIONS = new Set([
   '.import',
 ])
 
-interface ResourceEntry {
-  path: string
-  size: number
-}
-
-async function findResourceFiles(dir: string, extensions?: Set<string>): Promise<ResourceEntry[]> {
-  const exts = extensions || RESOURCE_EXTENSIONS
-  try {
-    const entries = await readdir(dir, { withFileTypes: true })
-    const promises = entries.map(async (entry) => {
-      const name = entry.name
-      if (name.startsWith('.') || name === 'node_modules' || name === 'build') return []
-
-      const fullPath = join(dir, name)
-      if (entry.isDirectory()) {
-        return findResourceFiles(fullPath, exts)
-      } else if (exts.has(extname(name).toLowerCase())) {
-        try {
-          const fileStat = await stat(fullPath)
-          return [{ path: fullPath, size: fileStat.size }]
-        } catch {
-          return []
-        }
-      }
-      return []
-    })
-
-    const results = await Promise.all(promises)
-    return results.flat()
-  } catch {
-    // Skip inaccessible
-    return []
-  }
-}
+const _RESOURCE_EXTENSIONS = new Set([
+  '.tres',
+  '.res',
+  '.tscn',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.svg',
+  '.webp',
+  '.wav',
+  '.ogg',
+  '.mp3',
+  '.ttf',
+  '.otf',
+  '.gdshader',
+  '.gdshaderinc',
+  '.import',
+])
 
 export async function handleResources(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const projectPath = (args.project_path as string) || config.projectPath
@@ -85,7 +68,17 @@ export async function handleResources(action: string, args: Record<string, unkno
         if (typeMap[filterType]) exts = new Set(typeMap[filterType])
       }
 
-      const resources = await findResourceFiles(resolvedPath, exts)
+      const files = await findFiles(resolvedPath, Array.from(exts || RESOURCE_EXTENSIONS))
+      const resources = await Promise.all(
+        files.map(async (fullPath) => {
+          try {
+            const fileStat = await stat(fullPath)
+            return { path: fullPath, size: fileStat.size }
+          } catch {
+            return { path: fullPath, size: 0 }
+          }
+        }),
+      )
       const relativePaths = resources.map((r) => ({
         path: relative(resolvedPath, r.path).replace(/\\/g, '/'),
         ext: extname(r.path),

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -4,11 +4,11 @@
  */
 
 import { copyFileSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
-import { readdir, readFile } from 'node:fs/promises'
-import { basename, dirname, extname, join, relative, resolve } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import { basename, dirname, join, relative, resolve } from 'node:path'
 import type { GodotConfig, SceneInfo, SceneNode } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
-import { safeResolve } from '../helpers/paths.js'
+import { findFiles, safeResolve } from '../helpers/paths.js'
 import { setSettingInContent } from '../helpers/project-settings.js'
 
 // Pre-compiled regex for parsing scene metadata without splitting lines
@@ -90,29 +90,6 @@ async function parseTscnFile(filePath: string): Promise<SceneInfo> {
 /**
  * Recursively find all .tscn files in a directory
  */
-async function findSceneFiles(dir: string): Promise<string[]> {
-  try {
-    const entries = await readdir(dir, { withFileTypes: true })
-    const promises = entries.map(async (entry) => {
-      const name = entry.name
-      if (name.startsWith('.') || name === 'node_modules' || name === 'build') return []
-
-      const fullPath = join(dir, name)
-      if (entry.isDirectory()) {
-        return findSceneFiles(fullPath)
-      } else if (extname(name) === '.tscn') {
-        return [fullPath]
-      }
-      return []
-    })
-
-    const nestedResults = await Promise.all(promises)
-    return nestedResults.flat()
-  } catch {
-    // Skip inaccessible directories
-    return []
-  }
-}
 
 function generateTscnContent(rootName: string, rootType: string): string {
   return [`[gd_scene format=3]`, '', `[node name="${rootName}" type="${rootType}"]`, ''].join('\n')
@@ -186,7 +163,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
     case 'list': {
       // projectPath is guaranteed
       const resolvedPath = resolve(projectPath as string)
-      const scenes = await findSceneFiles(resolvedPath)
+      const scenes = await findFiles(resolvedPath, ['.tscn'])
       const relativePaths = scenes.map((s) => relative(resolvedPath, s).replace(/\\/g, '/'))
 
       return formatJSON({

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -4,11 +4,10 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
-import { readdir } from 'node:fs/promises'
-import { dirname, extname, join, relative, resolve } from 'node:path'
+import { dirname, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
-import { safeResolve } from '../helpers/paths.js'
+import { findFiles, safeResolve } from '../helpers/paths.js'
 
 const SCRIPT_TEMPLATES: Record<string, string> = {
   Node: `extends Node
@@ -96,30 +95,6 @@ func _ready() -> void:
 
 function getTemplate(extendsType: string): string {
   return SCRIPT_TEMPLATES[extendsType] || `extends ${extendsType}\n\n\nfunc _ready() -> void:\n\tpass\n`
-}
-
-async function findScriptFiles(dir: string): Promise<string[]> {
-  try {
-    const entries = await readdir(dir, { withFileTypes: true })
-    const promises = entries.map(async (entry) => {
-      const name = entry.name
-      if (name.startsWith('.') || name === 'node_modules' || name === 'build' || name === 'addons') return []
-
-      const fullPath = join(dir, name)
-      if (entry.isDirectory()) {
-        return findScriptFiles(fullPath)
-      } else if (extname(name) === '.gd') {
-        return [fullPath]
-      }
-      return []
-    })
-
-    const nestedResults = await Promise.all(promises)
-    return nestedResults.flat()
-  } catch {
-    // Skip inaccessible
-    return []
-  }
 }
 
 export async function handleScripts(action: string, args: Record<string, unknown>, config: GodotConfig) {
@@ -229,7 +204,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
         throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
 
       const resolvedPath = resolve(projectPath)
-      const scripts = await findScriptFiles(resolvedPath)
+      const scripts = await findFiles(resolvedPath, ['.gd'], ['addons'])
       const relativePaths = scripts.map((s) => relative(resolvedPath, s).replace(/\\/g, '/'))
 
       return formatJSON({ project: resolvedPath, count: relativePaths.length, scripts: relativePaths })

--- a/src/tools/composite/shader.ts
+++ b/src/tools/composite/shader.ts
@@ -3,11 +3,11 @@
  * Actions: create | read | write | get_params | list
  */
 
-import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
-import { dirname, extname, join, relative, resolve } from 'node:path'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
-import { safeResolve } from '../helpers/paths.js'
+import { findFiles, safeResolve } from '../helpers/paths.js'
 
 const SHADER_TEMPLATES: Record<string, string> = {
   canvas_item: `shader_type canvas_item;
@@ -47,30 +47,6 @@ void fog() {
 \tALBEDO = vec3(0.8);
 }
 `,
-}
-
-async function findShaderFiles(dir: string): Promise<string[]> {
-  try {
-    const entries = await readdir(dir, { withFileTypes: true })
-    const promises = entries.map(async (entry) => {
-      const name = entry.name
-      if (name.startsWith('.') || name === 'node_modules' || name === 'build') return []
-      const fullPath = join(dir, name)
-
-      if (entry.isDirectory()) {
-        return findShaderFiles(fullPath)
-      } else if (entry.isFile() && (extname(name) === '.gdshader' || extname(name) === '.gdshaderinc')) {
-        return [fullPath]
-      }
-      return []
-    })
-
-    const nestedResults = await Promise.all(promises)
-    return nestedResults.flat()
-  } catch {
-    // Skip inaccessible
-    return []
-  }
 }
 
 export async function handleShader(action: string, args: Record<string, unknown>, config: GodotConfig) {
@@ -173,7 +149,7 @@ export async function handleShader(action: string, args: Record<string, unknown>
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
 
       const resolvedPath = resolve(projectPath)
-      const shaders = await findShaderFiles(resolvedPath)
+      const shaders = await findFiles(resolvedPath, ['.gdshader', '.gdshaderinc'])
       const relativePaths = shaders.map((s) => relative(resolvedPath, s).replace(/\\/g, '/'))
 
       return formatJSON({ project: resolvedPath, count: relativePaths.length, shaders: relativePaths })

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,4 +1,5 @@
-import { isAbsolute, relative, resolve } from 'node:path'
+import { readdir } from 'node:fs/promises'
+import { extname, isAbsolute, join, relative, resolve } from 'node:path'
 import { GodotMCPError } from './errors.js'
 
 /**
@@ -30,4 +31,37 @@ export function safeResolve(baseDir: string, targetPath: string): string {
   }
 
   return resolvedTarget
+}
+
+/**
+ * Recursively finds files in a directory that match specific extensions.
+ *
+ * @param dir The directory to search in
+ * @param validExtensions Array of allowed file extensions (e.g., ['.gd', '.tscn'])
+ * @param ignoredDirs Array of directory names to ignore (defaults to ['.', 'node_modules', 'build'])
+ * @returns Array of absolute file paths
+ */
+export async function findFiles(dir: string, validExtensions: string[], ignoredDirs?: string[]): Promise<string[]> {
+  const ignoreList = new Set(['node_modules', 'build', ...(ignoredDirs || [])])
+  try {
+    const entries = await readdir(dir, { withFileTypes: true })
+    const promises = entries.map(async (entry) => {
+      const name = entry.name
+      if (name.startsWith('.') || ignoreList.has(name)) return []
+
+      const fullPath = join(dir, name)
+      if (entry.isDirectory()) {
+        return findFiles(fullPath, validExtensions, ignoredDirs)
+      } else if (validExtensions.includes(extname(name).toLowerCase())) {
+        return [fullPath]
+      }
+      return []
+    })
+
+    const nestedResults = await Promise.all(promises)
+    return nestedResults.flat()
+  } catch {
+    // Skip inaccessible
+    return []
+  }
 }


### PR DESCRIPTION
🎯 What: Extracted duplicated file search logic (`findScriptFiles`, `findSceneFiles`, `findShaderFiles`, `findResourceFiles`) into a shared `findFiles` helper parameterized by file extensions in `src/tools/helpers/paths.ts`.
💡 Why: This significantly reduces code duplication across multiple composite tools and centralizes recursive directory traversal logic.
✅ Verification: Ran format and lint checks (`bun run check`), executed the full Vitest test suite (`bun run test`) which verified functionality in all impacted tools, and ensured all checks passed without regression.
✨ Result: Improved maintainability by replacing ~80 lines of duplicated custom directory traversal code with a robust, asynchronous shared helper, while keeping I/O non-blocking and supporting custom ignore directories.

---
*PR created automatically by Jules for task [16447577159557309389](https://jules.google.com/task/16447577159557309389) started by @n24q02m*