### PR TITLE
fix: security fix] Prevent array bypass in config path validation

### DIFF
--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -37,7 +37,7 @@ export async function handleConfig(action: string, args: Record<string, unknown>
       }
 
       // Validate paths don't contain shell metacharacters
-      if ((key === 'project_path' || key === 'godot_path') && /[;&|`$(){}<>'"\0\n\r]/.test(value)) {
+      if ((key === 'project_path' || key === 'godot_path') && (typeof value !== 'string' || /[;&|`$(){}<>'"\0\n\r]/.test(value))) {
         throw new GodotMCPError(
           `Invalid characters in ${key}`,
           'INVALID_ARGS',

--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -37,7 +37,10 @@ export async function handleConfig(action: string, args: Record<string, unknown>
       }
 
       // Validate paths don't contain shell metacharacters
-      if ((key === 'project_path' || key === 'godot_path') && (typeof value !== 'string' || /[;&|`$(){}<>'"\0\n\r]/.test(value))) {
+      if (
+        (key === 'project_path' || key === 'godot_path') &&
+        (typeof value !== 'string' || /[;&|`$(){}<>'"\0\n\r]/.test(value))
+      ) {
         throw new GodotMCPError(
           `Invalid characters in ${key}`,
           'INVALID_ARGS',

--- a/tests/composite/config.test.ts
+++ b/tests/composite/config.test.ts
@@ -145,6 +145,13 @@ describe('config', () => {
       ).rejects.toThrow('Invalid characters')
     })
 
+
+    it('should reject paths that are not strings (e.g. arrays to bypass regex)', async () => {
+      await expect(
+        handleConfig('set', { key: 'godot_path', value: ['node', '-e', 'pwned'] as unknown as string }, config),
+      ).rejects.toThrow('Invalid characters')
+    })
+
     it('should allow timeout with numeric value (no path validation)', async () => {
       const result = await handleConfig('set', { key: 'timeout', value: '30000' }, config)
       expect(result.content[0].text).toContain('Config updated')

--- a/tests/composite/config.test.ts
+++ b/tests/composite/config.test.ts
@@ -145,7 +145,6 @@ describe('config', () => {
       ).rejects.toThrow('Invalid characters')
     })
 
-
     it('should reject paths that are not strings (e.g. arrays to bypass regex)', async () => {
       await expect(
         handleConfig('set', { key: 'godot_path', value: ['node', '-e', 'pwned'] as unknown as string }, config),


### PR DESCRIPTION
🎯 **What:** The path validation for `godot_path` and `project_path` in `src/tools/composite/config.ts` was bypassing the regex check if the user-provided `value` was an array instead of a string.
⚠️ **Risk:** An attacker could exploit this by providing a JSON array like `["node", "-e", "malicious_code"]` for `godot_path`. Since `RegExp.prototype.test()` implicitly calls `.join(',')` on arrays, the tested string becomes `node,-e,malicious_code`. This string doesn't contain any matched shell metacharacters (`;&|` etc.), effectively evading the security check. Downstream execution functions may use this unsanitized input leading to command execution or arbitrary code execution.
🛡️ **Solution:** Updated the validation to strictly require `typeof value === 'string'` so any non-string type (like an Array) falls through to the rejection branch. Added an automated test in `tests/composite/config.test.ts` to ensure arrays are properly blocked.

---
*PR created automatically by Jules for task [4429719772254943239](https://jules.google.com/task/4429719772254943239) started by @n24q02m*