### PR TITLE
feat: refactor parseProjectSettingsContent to handle multiline values

### DIFF
--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -7,6 +7,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { getInputActions, parseProjectSettingsContent } from '../helpers/project-settings.js'
 
 /**
  * Godot 4.x Key enum numeric values (@GlobalScope.Key)
@@ -141,78 +142,6 @@ function getProjectGodotPath(projectPath: string | null | undefined): string {
   return configPath
 }
 
-/**
- * Parse input actions from project.godot
- */
-function parseInputActions(content: string): Map<string, string[]> {
-  const actions = new Map<string, string[]>()
-  let inInputSection = false
-  let currentActionName: string | null = null
-  let currentActionAccumulator = ''
-
-  for (const line of content.split('\n')) {
-    const trimmed = line.trim()
-
-    // Handle multi-line continuation
-    if (currentActionName !== null) {
-      currentActionAccumulator += trimmed
-      if (trimmed.endsWith('}')) {
-        // End of multi-line action
-        const eventsMatch = currentActionAccumulator.match(/"events":\s*\[([^\]]*)\]/)
-        const events = eventsMatch
-          ? eventsMatch[1]
-              .split(',')
-              .map((e) => e.trim())
-              .filter(Boolean)
-          : []
-        actions.set(currentActionName, events)
-        currentActionName = null
-        currentActionAccumulator = ''
-      }
-      continue
-    }
-
-    if (trimmed === '[input]') {
-      inInputSection = true
-      continue
-    }
-
-    // Stop if we hit another section
-    if (trimmed.startsWith('[') && inInputSection) {
-      inInputSection = false
-      break
-    }
-
-    if (inInputSection) {
-      // Single-line format: action_name={...}
-      const match = trimmed.match(/^(\w+)=\{(.+)\}$/)
-      if (match) {
-        const actionName = match[1]
-        const eventsMatch = match[2].match(/"events":\s*\[([^\]]*)\]/)
-        const events = eventsMatch
-          ? eventsMatch[1]
-              .split(',')
-              .map((e) => e.trim())
-              .filter(Boolean)
-          : []
-        actions.set(actionName, events)
-      } else {
-        // Multi-line format start: action_name={
-        //   "deadzone": 0.2,
-        //   "events": [...]
-        // }
-        const startMatch = trimmed.match(/^(\w+)=\{(.*)$/)
-        if (startMatch) {
-          currentActionName = startMatch[1]
-          currentActionAccumulator = startMatch[2]
-        }
-      }
-    }
-  }
-
-  return actions
-}
-
 export async function handleInputMap(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const projectPath = (args.project_path as string) || config.projectPath
 
@@ -220,12 +149,22 @@ export async function handleInputMap(action: string, args: Record<string, unknow
     case 'list': {
       const configPath = getProjectGodotPath(projectPath)
       const content = readFileSync(configPath, 'utf-8')
-      const actions = parseInputActions(content)
+      const settings = parseProjectSettingsContent(content)
+      const actions = getInputActions(settings)
 
-      const actionList = Array.from(actions.entries()).map(([name, events]) => ({
-        name,
-        eventCount: events.length,
-      }))
+      const actionList = Array.from(actions.entries()).map(([name, value]) => {
+        const eventsMatch = value.match(/"events":\s*\[([^\]]*)\]/)
+        const events = eventsMatch
+          ? eventsMatch[1]
+              .split(',')
+              .map((e) => e.trim())
+              .filter(Boolean)
+          : []
+        return {
+          name,
+          eventCount: events.length,
+        }
+      })
 
       return formatJSON({ count: actionList.length, actions: actionList })
     }

--- a/src/tools/helpers/project-settings.ts
+++ b/src/tools/helpers/project-settings.ts
@@ -35,6 +35,7 @@ export async function parseProjectSettingsAsync(filePath: string): Promise<Proje
  * Parse project.godot content string
  * Optimized to traverse the string directly instead of using split('\n') and regex.
  * Parses large project.godot files ~60% faster by avoiding string allocations.
+ * Now supports multi-line values for both blocks enclosed in {} and strings enclosed in "".
  */
 export function parseProjectSettingsContent(content: string): ProjectSettings {
   const sections = new Map<string, Map<string, string>>()
@@ -44,48 +45,88 @@ export function parseProjectSettingsContent(content: string): ProjectSettings {
   const len = content.length
 
   while (pos < len) {
-    const nextNewline = content.indexOf('\n', pos)
-    const lineEnd = nextNewline === -1 ? len : nextNewline
+    // Trim leading whitespace for the line
+    while (pos < len && content.charCodeAt(pos) <= 32) pos++
+    if (pos >= len) break
 
-    // Trim line manually (whitespace <= 32)
-    let start = pos
-    let end = lineEnd
-    while (start < end && content.charCodeAt(start) <= 32) start++
-    while (end > start && content.charCodeAt(end - 1) <= 32) end--
-
-    // Skip empty lines or comments (59 is ';')
-    if (start === end || content.charCodeAt(start) === 59) {
+    // Skip comments
+    if (content.charCodeAt(pos) === 59) {
+      // ';'
+      const nextNewline = content.indexOf('\n', pos)
       pos = nextNewline === -1 ? len : nextNewline + 1
       continue
     }
 
-    const firstChar = content.charCodeAt(start)
-    const lastChar = content.charCodeAt(end - 1)
-
-    // Section header: starts with '[' (91) and ends with ']' (93)
-    if (firstChar === 91 && lastChar === 93) {
-      currentSection = content.slice(start + 1, end - 1)
-      if (!sections.has(currentSection)) {
-        sections.set(currentSection, new Map())
-      }
-    } else if (currentSection) {
-      // Key=value
-      const eqIdx = content.indexOf('=', start)
-      if (eqIdx !== -1 && eqIdx < end) {
-        let keyEnd = eqIdx
-        while (keyEnd > start && content.charCodeAt(keyEnd - 1) <= 32) keyEnd--
-
-        let valStart = eqIdx + 1
-        while (valStart < end && content.charCodeAt(valStart) <= 32) valStart++
-
-        const key = content.slice(start, keyEnd)
-        const value = content.slice(valStart, end)
-
-        sections.get(currentSection)?.set(key, value)
+    // Section header: starts with '[' (91)
+    if (content.charCodeAt(pos) === 91) {
+      const endBracket = content.indexOf(']', pos)
+      if (endBracket !== -1) {
+        currentSection = content.slice(pos + 1, endBracket).trim()
+        if (!sections.has(currentSection)) {
+          sections.set(currentSection, new Map())
+        }
+        const nextNewline = content.indexOf('\n', endBracket)
+        pos = nextNewline === -1 ? len : nextNewline + 1
+        continue
       }
     }
 
-    pos = nextNewline === -1 ? len : nextNewline + 1
+    // Key=value pairs
+    if (currentSection) {
+      const eqIdx = content.indexOf('=', pos)
+      const nextNewline = content.indexOf('\n', pos)
+
+      // If we found an '=' before the end of the line (or file)
+      if (eqIdx !== -1 && (nextNewline === -1 || eqIdx < nextNewline)) {
+        let keyEnd = eqIdx
+        while (keyEnd > pos && content.charCodeAt(keyEnd - 1) <= 32) keyEnd--
+        const key = content.slice(pos, keyEnd)
+
+        let valStart = eqIdx + 1
+        while (valStart < len && content.charCodeAt(valStart) <= 32 && content.charCodeAt(valStart) !== 10) valStart++
+
+        let inString = false
+        let braceDepth = 0
+        let valEnd = valStart
+
+        // State machine to parse the value
+        while (valEnd < len) {
+          const char = content.charCodeAt(valEnd)
+
+          if (char === 34 && content.charCodeAt(valEnd - 1) !== 92) {
+            // '"' not escaped by '\'
+            inString = !inString
+          } else if (!inString) {
+            if (char === 123) {
+              // '{'
+              braceDepth++
+            } else if (char === 125) {
+              // '}'
+              braceDepth--
+            } else if (char === 10 && braceDepth === 0) {
+              // '\n' outside blocks
+              break
+            }
+          }
+
+          valEnd++
+        }
+
+        // We might have ended on a newline or EOF. Trim trailing whitespace.
+        let end = valEnd
+        while (end > valStart && content.charCodeAt(end - 1) <= 32) end--
+
+        const value = content.slice(valStart, end)
+        sections.get(currentSection)?.set(key, value)
+
+        pos = valEnd < len ? valEnd + 1 : len // move past the terminating character (usually newline)
+        continue
+      }
+    }
+
+    // Fallback: move to the next line if we couldn't parse as section or key=value
+    const fallbackNextNewline = content.indexOf('\n', pos)
+    pos = fallbackNextNewline === -1 ? len : fallbackNextNewline + 1
   }
 
   return { sections, raw: content }

--- a/tests/helpers/project-settings.test.ts
+++ b/tests/helpers/project-settings.test.ts
@@ -60,6 +60,38 @@ describe('project-settings', () => {
       const settings = parseProjectSettingsContent(SAMPLE_PROJECT_GODOT)
       expect(settings.raw).toBe(SAMPLE_PROJECT_GODOT)
     })
+
+    it('should parse multi-line block values', () => {
+      const content = `[input]
+move_left={
+"deadzone": 0.5,
+"events": [
+  Object(InputEventKey,"keycode":65)
+]
+}
+`
+      const settings = parseProjectSettingsContent(content)
+      const input = settings.sections.get('input')
+      const expected = `{
+"deadzone": 0.5,
+"events": [
+  Object(InputEventKey,"keycode":65)
+]
+}`
+      expect(input?.get('move_left')).toBe(expected)
+    })
+
+    it('should parse multi-line string values', () => {
+      const content = `[rendering]
+test="multiline
+string
+here"
+`
+      const settings = parseProjectSettingsContent(content)
+      const rendering = settings.sections.get('rendering')
+      const expected = `"multiline\nstring\nhere"`
+      expect(rendering?.get('test')).toBe(expected)
+    })
   })
 
   // ==========================================


### PR DESCRIPTION
🎯 **What:** The `parseProjectSettingsContent` function was rewritten using a simple string traversal state machine to properly support multi-line dictionary blocks (`{}`) and multi-line strings (`""`). Subsequently, the custom `parseInputActions` logic in `src/tools/composite/input-map.ts` was deleted and replaced with the newly shared capabilities.
💡 **Why:** Extending the core parser ensures consistent INI parsing across the application, deletes complex and redundant regex-based manual parsing from individual tools, and makes the codebase easier to read and maintain.
✅ **Verification:** Unit tests covering multi-line strings and blocks were appended to `project-settings.test.ts`. Full test suite (`bun run test`) and type/formatting checks (`bun run check`) passed, ensuring behaviour remained completely consistent.
✨ **Result:** A single point of truth for Godot INI file parsing, deletion of custom regex in `input-map.ts`, and full capability to accurately process complex `project.godot` definitions.

---
*PR created automatically by Jules for task [15511561088460184997](https://jules.google.com/task/15511561088460184997) started by @n24q02m*