### PR TITLE
fix: fix path traversal in Resources tool via project_path argument

### DIFF
--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -98,7 +98,8 @@ export async function handleResources(action: string, args: Record<string, unkno
     case 'info': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-      const fullPath = safeResolve(projectPath || process.cwd(), resPath)
+      const trustedBase = config.projectPath || process.cwd()
+      const fullPath = safeResolve(projectPath ? safeResolve(trustedBase, projectPath) : trustedBase, resPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
@@ -126,7 +127,8 @@ export async function handleResources(action: string, args: Record<string, unkno
     case 'delete': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-      const fullPath = safeResolve(projectPath || process.cwd(), resPath)
+      const trustedBase = config.projectPath || process.cwd()
+      const fullPath = safeResolve(projectPath ? safeResolve(trustedBase, projectPath) : trustedBase, resPath)
       if (!existsSync(fullPath))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
@@ -142,7 +144,11 @@ export async function handleResources(action: string, args: Record<string, unkno
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
 
-      const importPath = safeResolve(projectPath || process.cwd(), `${resPath}.import`)
+      const trustedBase = config.projectPath || process.cwd()
+      const importPath = safeResolve(
+        projectPath ? safeResolve(trustedBase, projectPath) : trustedBase,
+        `${resPath}.import`,
+      )
 
       if (!existsSync(importPath)) {
         return formatJSON({ path: resPath, imported: false, message: 'No .import file found.' })

--- a/tests/composite/resources.test.ts
+++ b/tests/composite/resources.test.ts
@@ -200,6 +200,12 @@ describe('resources', () => {
         handleResources('import_config', { project_path: projectPath, resource_path: '../../../etc/passwd' }, config),
       ).rejects.toThrow('Access denied')
     })
+
+    it('should reject access outside project via project_path argument', async () => {
+      await expect(handleResources('info', { project_path: '/', resource_path: 'etc/passwd' }, config)).rejects.toThrow(
+        'Access denied',
+      )
+    })
   })
 
   it('should throw for unknown action', async () => {


### PR DESCRIPTION
🎯 **What:** Fixed a path traversal vulnerability in `src/tools/composite/resources.ts`. Specifically, fixed the `projectPath` resolution to use `safeResolve` against `config.projectPath || process.cwd()`, and used `safeResolve` inside `info`, `delete`, and `import_config` dynamically.
⚠️ **Risk:** The previous implementation could be bypassed by an attacker providing a completely different absolute path for `project_path` like `/`, which effectively changes the "trusted" project boundary, allowing `safeResolve` to resolve external files.
🛡️ **Solution:** Passed the user-supplied `project_path` into `safeResolve(trustedBase, userProjectPath)` where `trustedBase` is defined as `config.projectPath || process.cwd()`. This safely confines `project_path` overrides, and using it to resolve the resource path ensures the final path stays firmly within the trusted boundary. Added `should reject access outside project via project_path argument` unit test to enforce this fix explicitly.

---
*PR created automatically by Jules for task [15669978106565227402](https://jules.google.com/task/15669978106565227402) started by @n24q02m*