### PR TITLE
fix: fix path traversal in project tools and paths helper

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [Path Traversal bypass using prefix matching]
+**Vulnerability:** The `safeResolve` helper used a simple `relativePath.startsWith('..')` which allows false-positive prevention of perfectly safe sibling folders starting with `..` (like `..secret`). Additionally, multiple tools (`project.ts`, `editor.ts`) simply resolved user-supplied `project_path` strings using `resolve(projectPath)`, exposing the server to out-of-bounds traversal to anywhere on the disk.
+**Learning:** Checking for path traversal merely via `.startsWith('..')` is buggy against prefixes. And user inputs representing file paths *must always* be run through a bounding check like `safeResolve` against a known good boundary (`process.cwd()` or `config.projectPath`).
+**Prevention:** Always restrict paths using `relativePath === '..' || relativePath.startsWith('..' + sep)` and consistently apply `safeResolve(boundary, targetPath)` across all user-facing endpoints.

--- a/src/tools/composite/editor.ts
+++ b/src/tools/composite/editor.ts
@@ -4,11 +4,11 @@
  */
 
 import { execFile } from 'node:child_process'
-import { resolve } from 'node:path'
 import { promisify } from 'node:util'
 import { launchGodotEditor } from '../../godot/headless.js'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const execFileAsync = promisify(execFile)
 
@@ -60,7 +60,7 @@ export async function handleEditor(action: string, args: Record<string, unknown>
         throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
       }
 
-      const { pid } = launchGodotEditor(config.godotPath, resolve(projectPath))
+      const { pid } = launchGodotEditor(config.godotPath, safeResolve(config.projectPath || process.cwd(), projectPath))
       return formatSuccess(`Godot editor launched (PID: ${pid})`)
     }
 

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -6,7 +6,7 @@
 import { execFileSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
+import { join } from 'node:path'
 import { execGodotSync, runGodotProject } from '../../godot/headless.js'
 import type { GodotConfig, ProjectInfo } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
@@ -73,7 +73,7 @@ export async function handleProject(action: string, args: Record<string, unknown
           'Provide project_path argument or set it via config.set action.',
         )
       }
-      const info = await parseProjectGodot(resolve(projectPath))
+      const info = await parseProjectGodot(safeResolve(config.projectPath || process.cwd(), projectPath))
       return formatJSON(info)
     }
 
@@ -91,7 +91,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       const projectPath = (args.project_path as string) || config.projectPath
       if (!projectPath)
         throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
-      const { pid } = runGodotProject(config.godotPath, resolve(projectPath))
+      const { pid } = runGodotProject(config.godotPath, safeResolve(config.projectPath || process.cwd(), projectPath))
       return formatSuccess(`Godot project started (PID: ${pid})`)
     }
 
@@ -115,7 +115,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (!key)
         throw new GodotMCPError('No key specified', 'INVALID_ARGS', 'Provide key (e.g., "application/config/name").')
 
-      const configPath = join(resolve(projectPath), 'project.godot')
+      const configPath = join(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
       if (!existsSync(configPath))
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')
 
@@ -133,7 +133,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (!key || value === undefined)
         throw new GodotMCPError('key and value required', 'INVALID_ARGS', 'Provide key and value.')
 
-      const configPath = join(resolve(projectPath), 'project.godot')
+      const configPath = join(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
       if (!existsSync(configPath))
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')
 
@@ -159,13 +159,14 @@ export async function handleProject(action: string, args: Record<string, unknown
         )
       }
 
+      const resolvedProjectPath = safeResolve(config.projectPath || process.cwd(), projectPath)
       const result = execGodotSync(config.godotPath, [
         '--headless',
         '--path',
-        resolve(projectPath),
+        resolvedProjectPath,
         '--export-release',
         preset,
-        safeResolve(projectPath, outputPath),
+        safeResolve(resolvedProjectPath, outputPath),
       ])
 
       return formatSuccess(`Export complete: ${outputPath}\n${result.stdout}`)

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, relative, resolve } from 'node:path'
+import { isAbsolute, relative, resolve, sep } from 'node:path'
 import { GodotMCPError } from './errors.js'
 
 /**
@@ -21,7 +21,7 @@ export function safeResolve(baseDir: string, targetPath: string): string {
   // 1. Starts with .. (parent directory)
   // 2. Is absolute (on Windows, could be different drive)
   // 3. relativePath should not be absolute if it's inside base
-  if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+  if (relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
     throw new GodotMCPError(
       `Access denied: Path '${targetPath}' resolves to '${resolvedTarget}' which is outside the project root '${resolvedBase}'.`,
       'INVALID_ARGS',

--- a/tests/composite/project.test.ts
+++ b/tests/composite/project.test.ts
@@ -66,7 +66,8 @@ describe('project', () => {
     })
 
     it('should throw for non-existent project directory', async () => {
-      await expect(handleProject('info', { project_path: '/tmp/nonexistent' }, config)).rejects.toThrow(
+      // The path should be inside the config project path to test "not found" instead of "access denied"
+      await expect(handleProject('info', { project_path: 'nonexistent' }, config)).rejects.toThrow(
         'No project.godot found',
       )
     })
@@ -170,9 +171,9 @@ describe('project', () => {
     })
 
     it('should throw for missing project.godot', async () => {
-      await expect(
-        handleProject('settings_get', { project_path: '/tmp/nonexistent', key: 'a' }, config),
-      ).rejects.toThrow('No project.godot found')
+      await expect(handleProject('settings_get', { project_path: 'nonexistent', key: 'a' }, config)).rejects.toThrow(
+        'No project.godot found',
+      )
     })
   })
 
@@ -219,7 +220,7 @@ describe('project', () => {
 
     it('should throw for missing project.godot', async () => {
       await expect(
-        handleProject('settings_set', { project_path: '/tmp/nonexistent', key: 'a', value: 'b' }, config),
+        handleProject('settings_set', { project_path: 'nonexistent', key: 'test/key', value: 'value' }, config),
       ).rejects.toThrow('No project.godot found')
     })
   })


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `project.ts` and `editor.ts` resolved user-supplied `project_path` inputs using a raw `resolve()` without bounding it to an expected project root directory, leading to a path traversal/arbitrary file read vulnerability anywhere on the filesystem. Additionally, the `safeResolve` helper itself contained a path validation logic flaw preventing access to harmless sibling directories prefixed with `..` (e.g. `..secrets`).
🎯 Impact: Attackers or malicious user prompts could arbitrarily resolve out-of-bounds configurations, executing editor commands or viewing sensitive files outside the project root.
🔧 Fix: Upgraded `safeResolve` to strictly use `relativePath === '..' || relativePath.startsWith('..' + sep)`. Then correctly migrated path resolutions for `info`, `run`, `settings_get`, `settings_set`, `export`, and editor `launch` commands to bounce off of `safeResolve` properly.
✅ Verification: Ran unit tests and Biome linter, fixing testing scenarios where "access denied" exceptions are explicitly meant to trigger. Checked the application logic locally.

---
*PR created automatically by Jules for task [12724420917286343018](https://jules.google.com/task/12724420917286343018) started by @n24q02m*