### PR TITLE
feat: add input type validation to prevent RegExp Array bypass in input-map

### DIFF
--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -235,7 +235,7 @@ export async function handleInputMap(action: string, args: Record<string, unknow
       const configPath = getProjectGodotPath(projectPath)
       const actionName = args.action_name as string
       if (!actionName) throw new GodotMCPError('No action_name specified', 'INVALID_ARGS', 'Provide action_name.')
-      if (!/^[a-zA-Z0-9_-]+$/.test(actionName)) {
+      if (typeof actionName !== 'string' || !/^[a-zA-Z0-9_-]+$/.test(actionName)) {
         throw new GodotMCPError(
           `Invalid action name: ${actionName}`,
           'INVALID_ARGS',
@@ -268,7 +268,7 @@ export async function handleInputMap(action: string, args: Record<string, unknow
       const configPath = getProjectGodotPath(projectPath)
       const actionName = args.action_name as string
       if (!actionName) throw new GodotMCPError('No action_name specified', 'INVALID_ARGS', 'Provide action_name.')
-      if (!/^[a-zA-Z0-9_-]+$/.test(actionName)) {
+      if (typeof actionName !== 'string' || !/^[a-zA-Z0-9_-]+$/.test(actionName)) {
         throw new GodotMCPError(
           `Invalid action name: ${actionName}`,
           'INVALID_ARGS',
@@ -301,7 +301,7 @@ export async function handleInputMap(action: string, args: Record<string, unknow
           'Provide action_name, event_type (key/mouse/joypad), and event_value (e.g., "KEY_SPACE").',
         )
       }
-      if (!/^[a-zA-Z0-9_-]+$/.test(actionName)) {
+      if (typeof actionName !== 'string' || !/^[a-zA-Z0-9_-]+$/.test(actionName)) {
         throw new GodotMCPError(
           `Invalid action name: ${actionName}`,
           'INVALID_ARGS',


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unvalidated untrusted input (`args.action_name`) cast to `string` in `input-map.ts` allows malicious Array payloads (e.g., `["actionName"]`) to bypass regular expression whitelists (like `/^[a-zA-Z0-9_-]+$/`). This occurs because arrays implicitly stringify with commas, evading strict bounds checking if carefully crafted, or causing internal server unhandled exceptions (DoS) when passed downstream to functions like `escapeRegExp` that expect strings and call `String.prototype.replace`.
🎯 **Impact:** Potential bypass of input validation, type confusion, or Denial of Service via unhandled Node.js exceptions (`TypeError: string.replace is not a function`).
🔧 **Fix:** Explicitly verified the input is strictly a string (`typeof actionName !== 'string'`) before executing `.test()` or processing the action name across `add_action`, `remove_action`, and `add_event` handlers.
✅ **Verification:** Verified that tests pass via `bun run test` and linters via `bun run check`.

---
*PR created automatically by Jules for task [13937605921633570026](https://jules.google.com/task/13937605921633570026) started by @n24q02m*