### PR TITLE
feat: refactor physics and ui tools to use async file I/O operations

### DIFF
--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -3,12 +3,12 @@
  * Actions: layers | collision_setup | body_config | set_layer_name
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { readFile, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
-import { safeResolve } from '../helpers/paths.js'
-import { parseProjectSettings, setSettingInContent } from '../helpers/project-settings.js'
+import { pathExists, safeResolve } from '../helpers/paths.js'
+import { parseProjectSettingsAsync, setSettingInContent } from '../helpers/project-settings.js'
 import { escapeRegExp } from '../helpers/scene-parser.js'
 
 export async function handlePhysics(action: string, args: Record<string, unknown>, config: GodotConfig) {
@@ -18,10 +18,10 @@ export async function handlePhysics(action: string, args: Record<string, unknown
     case 'layers': {
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
       const configPath = join(resolve(projectPath), 'project.godot')
-      if (!existsSync(configPath))
+      if (!(await pathExists(configPath)))
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify project path.')
 
-      const settings = parseProjectSettings(configPath)
+      const settings = await parseProjectSettingsAsync(configPath)
       const layers2d: Record<string, string> = {}
       const layers3d: Record<string, string> = {}
 
@@ -46,10 +46,10 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       const collisionMask = args.collision_mask as number
 
       const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
-      if (!existsSync(fullPath))
+      if (!(await pathExists(fullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 
-      let content = readFileSync(fullPath, 'utf-8')
+      let content = await readFile(fullPath, 'utf-8')
       const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
       const match = content.match(nodeRegex)
       if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
@@ -63,7 +63,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       if (collisionMask !== undefined) props += `\ncollision_mask = ${collisionMask}`
 
       content = `${content.slice(0, insertPoint)}${props}${content.slice(insertPoint)}`
-      writeFileSync(fullPath, content, 'utf-8')
+      await writeFile(fullPath, content, 'utf-8')
 
       return formatSuccess(
         `Set collision on ${nodeName}: layer=${collisionLayer ?? 'unchanged'}, mask=${collisionMask ?? 'unchanged'}`,
@@ -77,10 +77,10 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       if (!nodeName) throw new GodotMCPError('No node name specified', 'INVALID_ARGS', 'Provide node name.')
 
       const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
-      if (!existsSync(fullPath))
+      if (!(await pathExists(fullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 
-      let content = readFileSync(fullPath, 'utf-8')
+      let content = await readFile(fullPath, 'utf-8')
       const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
       const match = content.match(nodeRegex)
       if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
@@ -96,7 +96,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
         throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
       const insertPoint = match.index + match[0].length
       content = `${content.slice(0, insertPoint)}${props}${content.slice(insertPoint)}`
-      writeFileSync(fullPath, content, 'utf-8')
+      await writeFile(fullPath, content, 'utf-8')
 
       return formatSuccess(`Configured physics body: ${nodeName}`)
     }
@@ -109,13 +109,13 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       if (!name) throw new GodotMCPError('No name specified', 'INVALID_ARGS', 'Provide layer name.')
 
       const configPath = join(resolve(projectPath), 'project.godot')
-      if (!existsSync(configPath))
+      if (!(await pathExists(configPath)))
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify project path.')
 
-      const content = readFileSync(configPath, 'utf-8')
+      const content = await readFile(configPath, 'utf-8')
       const key = `layer_names/${dimension}_physics/layer_${layerNum}`
       const updated = setSettingInContent(content, key, `"${name}"`)
-      writeFileSync(configPath, updated, 'utf-8')
+      await writeFile(configPath, updated, 'utf-8')
 
       return formatSuccess(`Set ${dimension} physics layer ${layerNum}: "${name}"`)
     }

--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -3,12 +3,12 @@
  * Actions: create_control | set_theme | layout | list_controls
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
-import { safeResolve } from '../helpers/paths.js'
-import { escapeRegExp, parseScene } from '../helpers/scene-parser.js'
+import { pathExists, safeResolve } from '../helpers/paths.js'
+import { escapeRegExp, parseSceneContent } from '../helpers/scene-parser.js'
 
 const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
   Button: { text: '"Click"' },
@@ -31,9 +31,9 @@ const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
   GridContainer: { columns: '2' },
 }
 
-function resolveScene(projectPath: string | null | undefined, scenePath: string): string {
+async function resolveScene(projectPath: string | null | undefined, scenePath: string): Promise<string> {
   const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
-  if (!existsSync(fullPath))
+  if (!(await pathExists(fullPath)))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
   return fullPath
 }
@@ -51,8 +51,8 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
 
       if (!controlName) throw new GodotMCPError('No name specified', 'INVALID_ARGS', 'Provide control node name.')
 
-      const fullPath = resolveScene(projectPath, scenePath)
-      let content = readFileSync(fullPath, 'utf-8')
+      const fullPath = await resolveScene(projectPath, scenePath)
+      let content = await readFile(fullPath, 'utf-8')
 
       const parentAttr = parent === '.' ? '' : ` parent="${parent}"`
       let nodeDecl = `\n[node name="${controlName}" type="${controlType}"${parentAttr}]\n`
@@ -74,7 +74,7 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
       }
 
       content = `${content.trimEnd()}\n${nodeDecl}`
-      writeFileSync(fullPath, content, 'utf-8')
+      await writeFile(fullPath, content, 'utf-8')
 
       return formatSuccess(`Created UI control: ${controlName} (${controlType}) under ${parent}`)
     }
@@ -102,8 +102,8 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
         '',
       ].join('\n')
 
-      mkdirSync(dirname(fullPath), { recursive: true })
-      writeFileSync(fullPath, content, 'utf-8')
+      await mkdir(dirname(fullPath), { recursive: true })
+      await writeFile(fullPath, content, 'utf-8')
 
       return formatSuccess(`Created theme: ${themePath} (font size: ${fontSize})`)
     }
@@ -115,8 +115,8 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
       if (!nodeName) throw new GodotMCPError('No name specified', 'INVALID_ARGS', 'Provide node name.')
       const preset = (args.preset as string) || 'full_rect'
 
-      const fullPath = resolveScene(projectPath, scenePath)
-      let content = readFileSync(fullPath, 'utf-8')
+      const fullPath = await resolveScene(projectPath, scenePath)
+      let content = await readFile(fullPath, 'utf-8')
 
       const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
       const match = content.match(nodeRegex)
@@ -158,7 +158,7 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
         throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
       const insertPoint = match.index + match[0].length
       content = `${content.slice(0, insertPoint)}${layoutProps}${content.slice(insertPoint)}`
-      writeFileSync(fullPath, content, 'utf-8')
+      await writeFile(fullPath, content, 'utf-8')
 
       return formatSuccess(`Set layout preset "${preset}" on ${nodeName}`)
     }
@@ -167,8 +167,9 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
       const scenePath = args.scene_path as string
       if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
 
-      const fullPath = resolveScene(projectPath, scenePath)
-      const scene = parseScene(fullPath)
+      const fullPath = await resolveScene(projectPath, scenePath)
+      const content = await readFile(fullPath, 'utf-8')
+      const scene = parseSceneContent(content)
 
       const controlTypes = new Set([
         'Control',

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,5 +1,19 @@
+import { constants } from 'node:fs'
+import { access } from 'node:fs/promises'
 import { isAbsolute, relative, resolve, sep } from 'node:path'
 import { GodotMCPError } from './errors.js'
+
+/**
+ * Checks if a path exists asynchronously
+ */
+export async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK)
+    return true
+  } catch {
+    return false
+  }
+}
 
 /**
  * Safely resolves a path relative to a base directory, preventing path traversal.


### PR DESCRIPTION
💡 **What:** Replaced synchronous `node:fs` I/O operations (`readFileSync`, `writeFileSync`, `existsSync`, `mkdirSync`) with their asynchronous counterparts from `node:fs/promises` (`readFile`, `writeFile`, `access`, `mkdir`) in `src/tools/composite/physics.ts` and `src/tools/composite/ui.ts`. Also extracted a shared `pathExists` helper in `paths.ts`.

🎯 **Why:** To improve performance and prevent blocking the Node.js event loop. Godot scene files (`.tscn`) and project settings can be large. Synchronous I/O blocks the server from processing other incoming MCP requests, causing latency spikes. Async I/O allows other operations to run concurrently while waiting for disk access.

📊 **Impact:** Increases the concurrency and throughput of the MCP server, especially under load or when operating on larger Godot projects with substantial scene files. 

🔬 **Measurement:** Verify by running `pnpm test` (all tests pass) and observing the server's responsiveness when handling concurrent operations modifying scenes via the `ui` or `physics` tools.

---
*PR created automatically by Jules for task [6765878073941187544](https://jules.google.com/task/6765878073941187544) started by @n24q02m*