### PR TITLE
feat: code health improvement] Remove unused regex variable in scenes tool

### DIFF
--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -13,7 +13,6 @@ import { setSettingInContent } from '../helpers/project-settings.js'
 
 // Pre-compiled regex for parsing scene metadata without splitting lines
 const rxNode = /^\[node\s+name="([^"]+)"\s+type="([^"]+)"(?:\s+parent="([^"]*)")?/
-const _rxRes = /^\[(?:ext_resource|sub_resource)\s+(.+)\]$/
 const rxScript = /^script\s*=\s*(.+)$/
 
 /**


### PR DESCRIPTION
🎯 **What:** Removed the unused `_rxRes` variable from `src/tools/composite/scenes.ts`.
💡 **Why:** The regex was defined at the top level of the file but was no longer used after previous optimizations, becoming dead code that increases cognitive load.
✅ **Verification:** Ran `bun run check` to confirm formatting and linting rules are met. Ran `bun run test tests/composite/scenes.test.ts` and `bun run test` to confirm no tests broke.
✨ **Result:** Cleaned up unused variable to improve maintainability with no functional changes.

---
*PR created automatically by Jules for task [3374250586634636168](https://jules.google.com/task/3374250586634636168) started by @n24q02m*