### PR TITLE
feat: remove unused variables in ui tool]

### DIFF
--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -91,8 +91,6 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
       const fullPath = safeResolve(projectPath || process.cwd(), themePath)
 
       const fontSize = (args.font_size as number) || 16
-      const _fontColor = (args.font_color as string) || 'Color(1, 1, 1, 1)'
-      const _bgColor = (args.bg_color as string) || 'Color(0.15, 0.15, 0.15, 1)'
 
       const content = [
         '[gd_resource type="Theme" format=3]',


### PR DESCRIPTION
**🎯 What:** 
Removed unused variables `_fontColor` and `_bgColor` from the `set_theme` action in the `ui` tool.

**💡 Why:**
The parameters `args.font_color` and `args.bg_color` were extracted into `_fontColor` and `_bgColor`, but these variables were never actually used when generating the `.tres` file content string for the new theme. Leaving them was clutter and potential for confusion. Removing them improves code maintainability.

**✅ Verification:**
1. Ran `bun run check` to verify TypeScript typings and formatting via Biome.
2. Ran the full test suite via `bun run test` (including `ui.test.ts`), confirming that `set_theme` behaviour remains correct. No assertions on colors existed anyway.

**✨ Result:**
Cleaner `set_theme` action in `ui.ts` without unused variables.

---
*PR created automatically by Jules for task [7811088413716523707](https://jules.google.com/task/7811088413716523707) started by @n24q02m*