### PR TITLE
fix: testing improvement] Fix strict type checks for readdirSync mock

### DIFF
--- a/tests/godot/detector.test.ts
+++ b/tests/godot/detector.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync, type PathLike, readdirSync } from 'node:fs'
+import { type Dirent, existsSync, type PathLike, readdirSync } from 'node:fs'
 /**
  * Tests for Godot binary detector
  */
@@ -301,24 +301,20 @@ describe('detector', () => {
         return false
       })
 
-      // Fix strict type checks by using unknown then casting to expected return type
-      vi.mocked(readdirSync).mockImplementation(((path: PathLike) => {
+      vi.mocked(readdirSync).mockImplementation(((path: PathLike, _options?: unknown) => {
         if (path === packagesDir) {
           return [
             {
               isDirectory: () => true,
               name: 'GodotEngine.GodotEngine_Microsoft.Winget.Source_8wekyb3d8bbwe',
-            },
-          ] as unknown as ReturnType<typeof readdirSync>
+            } as Dirent,
+          ]
         }
         if (path === pkgDir) {
-          return ['Godot_v4.3-stable_win64.exe', 'Godot_v4.3-stable_win64_console.exe'] as unknown as ReturnType<
-            typeof readdirSync
-          >
+          return ['Godot_v4.3-stable_win64.exe', 'Godot_v4.3-stable_win64_console.exe']
         }
-        return [] as unknown as ReturnType<typeof readdirSync>
-        // biome-ignore lint/suspicious/noExplicitAny: mock overload
-      }) as any)
+        return []
+      }) as typeof readdirSync)
 
       vi.mocked(execFileSync).mockImplementation((cmd) => {
         if (typeof cmd === 'string' && cmd.includes('Godot_v4.3-stable_win64.exe'))
@@ -339,8 +335,7 @@ describe('detector', () => {
         throw new Error('not found')
       })
       vi.mocked(existsSync).mockReturnValue(false)
-      // biome-ignore lint/suspicious/noExplicitAny: mock overload
-      vi.mocked(readdirSync).mockImplementation(((_path: PathLike) => []) as any)
+      vi.mocked(readdirSync).mockImplementation(((_path: PathLike, _options?: unknown) => []) as typeof readdirSync)
 
       expect(detectGodot()).toBeNull()
     })


### PR DESCRIPTION
What:
Fixed strict type checking for the mocked implementation of `fs.readdirSync` in `tests/godot/detector.test.ts`.

Coverage:
Removed explicit `any` and `unknown` type casts that bypassed strict type checking and resolved the Biome linter suppression comment `// biome-ignore lint/suspicious/noExplicitAny: mock overload`. Properly imported `node:fs/Dirent` to define the correct objects and typed the mocked implementation with `as typeof readdirSync`. Added the `_options?: unknown` argument to strictly match Node's overloads.

Result:
Improved maintainability, enforced full type safety in test mocks, and resolved linter warnings.

---
*PR created automatically by Jules for task [4813252785022418990](https://jules.google.com/task/4813252785022418990) started by @n24q02m*