### PR TITLE
fix: refactor duplicated node regex matching and error handling into a shared helper

### DIFF
--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -9,7 +9,7 @@ import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
 import { parseProjectSettings, setSettingInContent } from '../helpers/project-settings.js'
-import { escapeRegExp } from '../helpers/scene-parser.js'
+import { matchNodeOrThrow } from '../helpers/scene-parser.js'
 
 export async function handlePhysics(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const projectPath = (args.project_path as string) || config.projectPath
@@ -50,14 +50,10 @@ export async function handlePhysics(action: string, args: Record<string, unknown
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 
       let content = readFileSync(fullPath, 'utf-8')
-      const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-      const match = content.match(nodeRegex)
-      if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+      const match = matchNodeOrThrow(content, nodeName)
 
       // Find or create properties after node declaration
-      if (match.index === undefined)
-        throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-      const insertPoint = match.index + match[0].length
+      const insertPoint = (match.index as number) + match[0].length
       let props = ''
       if (collisionLayer !== undefined) props += `\ncollision_layer = ${collisionLayer}`
       if (collisionMask !== undefined) props += `\ncollision_mask = ${collisionMask}`
@@ -81,9 +77,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 
       let content = readFileSync(fullPath, 'utf-8')
-      const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-      const match = content.match(nodeRegex)
-      if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+      const match = matchNodeOrThrow(content, nodeName)
 
       let props = ''
       if (args.gravity_scale !== undefined) props += `\ngravity_scale = ${args.gravity_scale}`
@@ -92,9 +86,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       if (args.angular_damp !== undefined) props += `\nangular_damp = ${args.angular_damp}`
       if (args.freeze !== undefined) props += `\nfreeze = ${args.freeze}`
 
-      if (match.index === undefined)
-        throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-      const insertPoint = match.index + match[0].length
+      const insertPoint = (match.index as number) + match[0].length
       content = `${content.slice(0, insertPoint)}${props}${content.slice(insertPoint)}`
       writeFileSync(fullPath, content, 'utf-8')
 

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -9,7 +9,7 @@ import { dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
-import { escapeRegExp } from '../helpers/scene-parser.js'
+import { getNodeHeaderRegex } from '../helpers/scene-parser.js'
 
 const SCRIPT_TEMPLATES: Record<string, string> = {
   Node: `extends Node
@@ -208,7 +208,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       const resPath = `res://${scriptPath.replace(/\\/g, '/')}`
 
       if (nodeName) {
-        const nodePattern = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
+        const nodePattern = getNodeHeaderRegex(nodeName)
         const match = content.match(nodePattern)
         if (!match)
           throw new GodotMCPError(

--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -8,7 +8,7 @@ import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
-import { escapeRegExp, parseScene } from '../helpers/scene-parser.js'
+import { matchNodeOrThrow, parseScene } from '../helpers/scene-parser.js'
 
 const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
   Button: { text: '"Click"' },
@@ -118,9 +118,7 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
       const fullPath = resolveScene(projectPath, scenePath)
       let content = readFileSync(fullPath, 'utf-8')
 
-      const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-      const match = content.match(nodeRegex)
-      if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+      const match = matchNodeOrThrow(content, nodeName)
 
       let layoutProps = ''
       switch (preset) {
@@ -154,9 +152,7 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
           )
       }
 
-      if (match.index === undefined)
-        throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-      const insertPoint = match.index + match[0].length
+      const insertPoint = (match.index as number) + match[0].length
       content = `${content.slice(0, insertPoint)}${layoutProps}${content.slice(insertPoint)}`
       writeFileSync(fullPath, content, 'utf-8')
 

--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -12,6 +12,7 @@
  */
 
 import { readFileSync, writeFileSync } from 'node:fs'
+import { GodotMCPError } from './errors.js'
 
 // Pre-compiled regular expressions for parsing scene sections
 const rxGdSceneFormat = /format=(\d+)/
@@ -391,4 +392,22 @@ export function getNodeProperty(scene: ParsedScene, nodeName: string, property: 
  */
 export function writeScene(filePath: string, content: string): void {
   writeFileSync(filePath, content, 'utf-8')
+}
+
+/**
+ * Create a regular expression for matching a specific node's header in a Godot scene file.
+ */
+export function getNodeHeaderRegex(nodeName: string): RegExp {
+  return new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
+}
+
+/**
+ * Find a node declaration by name in scene file content, or throw a GodotMCPError if not found.
+ */
+export function matchNodeOrThrow(content: string, nodeName: string): RegExpMatchArray {
+  const match = content.match(getNodeHeaderRegex(nodeName))
+  if (!match || match.index === undefined) {
+    throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+  }
+  return match
 }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the duplicated logic to find a Godot scene node declaration using regex and manually checking for match/throwing a `GodotMCPError`.
💡 **Why:** This improves maintainability by centralizing the `getNodeHeaderRegex` and `matchNodeOrThrow` inside `src/tools/helpers/scene-parser.ts`. Now, `src/tools/composite/ui.ts`, `src/tools/composite/physics.ts`, and `src/tools/composite/scripts.ts` all use these helpers.
✅ **Verification:** Checked the codebase with `bun run test` and `bun run check`. The tests passed indicating that no existing behavior changed.
✨ **Result:** Reduced duplicate node parsing lines and improved readability.

---
*PR created automatically by Jules for task [14787488498652818300](https://jules.google.com/task/14787488498652818300) started by @n24q02m*