### PR TITLE
feat: testing improvement] Add tests for malformed project-settings content

### DIFF
--- a/tests/helpers/project-settings.test.ts
+++ b/tests/helpers/project-settings.test.ts
@@ -60,6 +60,28 @@ describe('project-settings', () => {
       const settings = parseProjectSettingsContent(SAMPLE_PROJECT_GODOT)
       expect(settings.raw).toBe(SAMPLE_PROJECT_GODOT)
     })
+    it('should ignore malformed section header (missing closing bracket)', () => {
+      const settings = parseProjectSettingsContent('[application\nconfig/name="Test"\n')
+      expect(settings.sections.has('application')).toBe(false)
+    })
+
+    it('should ignore malformed section header (missing opening bracket)', () => {
+      const settings = parseProjectSettingsContent('application]\nconfig/name="Test"\n')
+      expect(settings.sections.has('application')).toBe(false)
+    })
+
+    it('should ignore key-value pair without equals sign', () => {
+      const settings = parseProjectSettingsContent('[application]\nconfig/name "Test"\n')
+      const app = settings.sections.get('application')
+      expect(app?.has('config/name')).toBe(false)
+      expect(app?.size).toBe(0)
+    })
+
+    it('should ignore key-value pair before any section is declared', () => {
+      const settings = parseProjectSettingsContent('config/name="Test"\n[application]\n')
+      const app = settings.sections.get('application')
+      expect(app?.has('config/name')).toBe(false)
+    })
   })
 
   // ==========================================


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `parseProjectSettingsContent` function handles custom `.ini`-style parsing for Godot configuration files. While its functionality on valid configuration files was adequately tested, edge cases for malformed content—such as incomplete section headers or invalid key-value declarations—were missing explicit test coverage.

📊 **Coverage:** What scenarios are now tested
Added new unit tests targeting `parseProjectSettingsContent` to cover:
- Section headers missing a closing bracket (e.g., `[application`).
- Section headers missing an opening bracket (e.g., `application]`).
- Key-value pairs missing an equals sign (e.g., `config/name "Test"`).
- Key-value pairs declared before any section header exists.

✨ **Result:** The improvement in test coverage
The test suite explicitly verifies the function gracefully skips malformed sections or keys instead of throwing unhandled exceptions or incorrectly interpreting invalid syntax, improving the robustness of the project settings parser.

---
*PR created automatically by Jules for task [14597895298950628392](https://jules.google.com/task/14597895298950628392) started by @n24q02m*