### PR TITLE
fix: security fix] Fix path traversal vulnerability in Nodes tool

### DIFF
--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -37,12 +37,13 @@ function mapToSceneNode(node: SceneNodeInfo): SceneNode {
   }
 }
 
-function resolveScenePath(projectPath: string | null | undefined, scenePath: string): string {
-  return safeResolve(projectPath || process.cwd(), scenePath)
+function resolveScenePath(projectPath: string, scenePath: string): string {
+  return safeResolve(projectPath, scenePath)
 }
 
 export async function handleNodes(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath
+  const baseProjectPath = config.projectPath || process.cwd()
+  const projectPath = args.project_path ? safeResolve(baseProjectPath, args.project_path as string) : baseProjectPath
 
   switch (action) {
     case 'add': {

--- a/tests/composite/nodes.test.ts
+++ b/tests/composite/nodes.test.ts
@@ -98,6 +98,20 @@ describe('nodes', () => {
         ),
       ).rejects.toThrow('not found')
     })
+
+    it('should throw for path traversal in project_path', async () => {
+      await expect(
+        handleNodes(
+          'add',
+          {
+            project_path: '../../',
+            scene_path: 'test.tscn',
+            name: 'Hacker',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Access denied')
+    })
   })
 
   // ==========================================


### PR DESCRIPTION
🎯 **What:** The `projectPath` provided via `args.project_path` in `src/tools/composite/nodes.ts` was used as the base directory for `safeResolve`, which bypasses path traversal protections if an attacker supplies a malicious base directory.

⚠️ **Risk:** An attacker could exploit this path traversal vulnerability by providing an explicit payload (e.g., `../../`) via the `project_path` argument to manipulate files outside of the intended project directory, which leads to arbitrary file system read and write access on the host.

🛡️ **Solution:** The code was updated to evaluate `args.project_path` against a safe base directory (`config.projectPath || process.cwd()`). This ensures the user-provided `projectPath` cannot break out of the configured workspace. Tests were also added to explicitly verify that attempts to traverse the path using `args.project_path` throw an 'Access denied' error.

---
*PR created automatically by Jules for task [144986965395924205](https://jules.google.com/task/144986965395924205) started by @n24q02m*