### PR TITLE
feat: missing tests for node creation]

### DIFF
--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -69,7 +69,29 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
       }
 
       const parentAttr = parent === '.' ? '' : ` parent="${parent}"`
-      const nodeDecl = `\n[node name="${nodeName}" type="${nodeType}"${parentAttr}]\n`
+      let nodeDecl = `\n[node name="${nodeName}" type="${nodeType}"${parentAttr}]\n`
+
+      // Handle properties parsing
+      if (args.properties !== undefined) {
+        if (typeof args.properties !== 'object' || args.properties === null || Array.isArray(args.properties)) {
+          throw new GodotMCPError(
+            'Invalid properties format',
+            'INVALID_ARGS',
+            'properties must be an object with string keys and values.',
+          )
+        }
+        for (const [key, value] of Object.entries(args.properties)) {
+          if (typeof key !== 'string' || typeof value !== 'string') {
+            throw new GodotMCPError(
+              'Invalid property value',
+              'INVALID_ARGS',
+              'Property keys and values must be strings.',
+            )
+          }
+          nodeDecl += `${key} = ${value}\n`
+        }
+      }
+
       const updated = `${content.trimEnd()}\n${nodeDecl}`
       writeFileSync(fullPath, updated, 'utf-8')
 

--- a/tests/composite/nodes.test.ts
+++ b/tests/composite/nodes.test.ts
@@ -1,3 +1,5 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
 /**
  * Integration tests for Nodes tool
  */
@@ -68,6 +70,78 @@ describe('nodes', () => {
       expect(content).toContain('parent="UI"')
     })
 
+    it('should add node with properties', async () => {
+      createTmpScene(projectPath, 'test.tscn', MINIMAL_TSCN)
+
+      const result = await handleNodes(
+        'add',
+        {
+          project_path: projectPath,
+          scene_path: 'test.tscn',
+          name: 'Player',
+          type: 'CharacterBody2D',
+          properties: {
+            speed: '300',
+            health: '100',
+          },
+        },
+        config,
+      )
+
+      expect(result.content[0].text).toContain('Added node')
+      const content = fs.readFileSync(path.join(projectPath, 'test.tscn'), 'utf-8')
+      expect(content).toContain('name="Player"')
+      expect(content).toContain('speed = 300')
+      expect(content).toContain('health = 100')
+    })
+
+    it('should throw when properties is not an object', async () => {
+      createTmpScene(projectPath, 'test.tscn', MINIMAL_TSCN)
+      await expect(
+        handleNodes(
+          'add',
+          {
+            project_path: projectPath,
+            scene_path: 'test.tscn',
+            name: 'Player',
+            properties: 'invalid', // string instead of object
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid properties format')
+
+      await expect(
+        handleNodes(
+          'add',
+          {
+            project_path: projectPath,
+            scene_path: 'test.tscn',
+            name: 'Player2',
+            properties: ['invalid'], // array instead of object
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid properties format')
+    })
+
+    it('should throw when property values are not strings', async () => {
+      createTmpScene(projectPath, 'test.tscn', MINIMAL_TSCN)
+      await expect(
+        handleNodes(
+          'add',
+          {
+            project_path: projectPath,
+            scene_path: 'test.tscn',
+            name: 'Player',
+            properties: {
+              speed: 300, // number instead of string
+            },
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid property value')
+    })
+
     it('should throw for duplicate node name at same parent', async () => {
       createTmpScene(projectPath, 'test.tscn', COMPLEX_TSCN)
 
@@ -83,6 +157,35 @@ describe('nodes', () => {
           config,
         ),
       ).rejects.toThrow('already exists')
+    })
+
+    it('should throw when scene_path is missing', async () => {
+      await expect(
+        handleNodes(
+          'add',
+          {
+            project_path: projectPath,
+            name: 'Player',
+            type: 'CharacterBody2D',
+          },
+          config,
+        ),
+      ).rejects.toThrow('No scene_path specified')
+    })
+
+    it('should throw when node name is missing', async () => {
+      createTmpScene(projectPath, 'test.tscn')
+      await expect(
+        handleNodes(
+          'add',
+          {
+            project_path: projectPath,
+            scene_path: 'test.tscn',
+            type: 'CharacterBody2D',
+          },
+          config,
+        ),
+      ).rejects.toThrow('No node name specified')
     })
 
     it('should throw for missing scene', async () => {
@@ -174,6 +277,34 @@ describe('nodes', () => {
   // rename
   // ==========================================
   describe('rename', () => {
+    it('should throw when scene_path is missing', async () => {
+      await expect(
+        handleNodes(
+          'rename',
+          {
+            project_path: projectPath,
+            name: 'Sprite',
+            new_name: 'PlayerSprite',
+          },
+          config,
+        ),
+      ).rejects.toThrow('No scene_path specified')
+    })
+
+    it('should throw when name or new_name is missing', async () => {
+      createTmpScene(projectPath, 'test.tscn')
+      await expect(
+        handleNodes(
+          'rename',
+          {
+            project_path: projectPath,
+            scene_path: 'test.tscn',
+            name: 'Sprite',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Both name and new_name required')
+    })
     it('should rename a node', async () => {
       createTmpScene(projectPath, 'test.tscn', COMPLEX_TSCN)
 
@@ -199,6 +330,17 @@ describe('nodes', () => {
   // list
   // ==========================================
   describe('list', () => {
+    it('should throw when scene_path is missing', async () => {
+      await expect(
+        handleNodes(
+          'list',
+          {
+            project_path: projectPath,
+          },
+          config,
+        ),
+      ).rejects.toThrow('No scene_path specified')
+    })
     it('should list all nodes with info', async () => {
       createTmpScene(projectPath, 'test.tscn', COMPLEX_TSCN)
 
@@ -239,6 +381,36 @@ describe('nodes', () => {
   // set_property
   // ==========================================
   describe('set_property', () => {
+    it('should throw when scene_path is missing', async () => {
+      await expect(
+        handleNodes(
+          'set_property',
+          {
+            project_path: projectPath,
+            name: 'Player',
+            property: 'speed',
+            value: '500',
+          },
+          config,
+        ),
+      ).rejects.toThrow('No scene_path specified')
+    })
+
+    it('should throw when name, property, or value is missing', async () => {
+      createTmpScene(projectPath, 'test.tscn')
+      await expect(
+        handleNodes(
+          'set_property',
+          {
+            project_path: projectPath,
+            scene_path: 'test.tscn',
+            name: 'Player',
+            property: 'speed',
+          },
+          config,
+        ),
+      ).rejects.toThrow('name, property, and value required')
+    })
     it('should set property on a node', async () => {
       createTmpScene(projectPath, 'test.tscn', MINIMAL_TSCN)
 
@@ -283,6 +455,34 @@ describe('nodes', () => {
   // get_property
   // ==========================================
   describe('get_property', () => {
+    it('should throw when scene_path is missing', async () => {
+      await expect(
+        handleNodes(
+          'get_property',
+          {
+            project_path: projectPath,
+            name: 'Player',
+            property: 'speed',
+          },
+          config,
+        ),
+      ).rejects.toThrow('No scene_path specified')
+    })
+
+    it('should throw when name or property is missing', async () => {
+      createTmpScene(projectPath, 'test.tscn')
+      await expect(
+        handleNodes(
+          'get_property',
+          {
+            project_path: projectPath,
+            scene_path: 'test.tscn',
+            name: 'Player',
+          },
+          config,
+        ),
+      ).rejects.toThrow('name and property required')
+    })
     it('should get property value', async () => {
       createTmpScene(projectPath, 'test.tscn', COMPLEX_TSCN)
 


### PR DESCRIPTION
🎯 **What:** Implemented properties validation and parsing for node creation in `nodes.ts` and added testing coverage for invalid properties and missing arguments across the `nodes.test.ts` suite.
📊 **Coverage:** Added test coverage for invalid `properties` during node creation (e.g. non-object inputs, nested non-string values). Also increased coverage to assert that all actions (`rename`, `list`, `set_property`, `get_property`) reject invalid/missing arguments (e.g. missing `scene_path` or `name`).
✨ **Result:** Nodes tool is now far more robust to malformed inputs, and tests explicitly verify correct `GodotMCPError` propagation when user/model-provided arguments are incorrect or incomplete.

---
*PR created automatically by Jules for task [2797742854517844669](https://jules.google.com/task/2797742854517844669) started by @n24q02m*