### PR TITLE
fix: testing improvement] Add complex path traversal edge cases to safeResolve

### DIFF
--- a/tests/helpers/paths.test.ts
+++ b/tests/helpers/paths.test.ts
@@ -45,4 +45,28 @@ describe('safeResolve', () => {
     const target = '../../mock/base/dir/file.ts'
     expect(() => safeResolve(baseDir, target)).toThrowError(GodotMCPError)
   })
+
+  it('throws GodotMCPError on complex path traversals (e.g., Unix /etc/passwd)', () => {
+    const target = '../../../../../../../../../../etc/passwd'
+    expect(() => safeResolve(baseDir, target)).toThrowError(GodotMCPError)
+    expect(() => safeResolve(baseDir, target)).toThrow(/Access denied/)
+  })
+
+  it.skipIf(process.platform !== 'win32')('throws GodotMCPError on Windows-style path traversals', () => {
+    const target = '..\\..\\..\\Windows\\System32\\cmd.exe'
+    expect(() => safeResolve(baseDir, target)).toThrowError(GodotMCPError)
+    expect(() => safeResolve(baseDir, target)).toThrow(/Access denied/)
+  })
+
+  it('throws GodotMCPError for prefix-matching directory traversal attempts (relative)', () => {
+    const target = '../dir-secret/file.ts'
+    expect(() => safeResolve(baseDir, target)).toThrowError(GodotMCPError)
+    expect(() => safeResolve(baseDir, target)).toThrow(/Access denied/)
+  })
+
+  it('throws GodotMCPError for prefix-matching directory traversal attempts (absolute)', () => {
+    const target = '/mock/base/dir-secret/file.ts'
+    expect(() => safeResolve(baseDir, target)).toThrowError(GodotMCPError)
+    expect(() => safeResolve(baseDir, target)).toThrow(/Access denied/)
+  })
 })


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was missing edge case tests for safeResolve to verify it correctly prevents malicious path traversal attempts (e.g., escaping out using '../../../etc/passwd').
📊 **Coverage:** Scenarios now tested include complex Unix-style traversals (../../etc/passwd), Windows-style traversals (..\\..\\Windows\\System32\\cmd.exe) using a skipIf check on non-Windows platforms, and prefix-matching directory traversal attempts.
✨ **Result:** Increased test coverage and security guarantees for path traversal prevention.

---
*PR created automatically by Jules for task [10690128972873119850](https://jules.google.com/task/10690128972873119850) started by @n24q02m*