### PR TITLE
fix: standardize async I/O and error handling across all tools

### DIFF
--- a/src/tools/composite/animation.ts
+++ b/src/tools/composite/animation.ts
@@ -3,14 +3,14 @@
  * Actions: create_player | add_animation | add_track | add_keyframe | list
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { readFile, writeFile } from 'node:fs/promises'
 import type { GodotConfig } from '../../godot/types.js'
-import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
-import { safeResolve } from '../helpers/paths.js'
+import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
+import { pathExists, safeResolve } from '../helpers/paths.js'
 
-function resolveScene(projectPath: string | null | undefined, scenePath: string): string {
+async function resolveScene(projectPath: string | null | undefined, scenePath: string): Promise<string> {
   const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
-  if (!existsSync(fullPath))
+  if (!(await pathExists(fullPath)))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
   return fullPath
 }
@@ -25,14 +25,14 @@ export async function handleAnimation(action: string, args: Record<string, unkno
       const playerName = (args.name as string) || 'AnimationPlayer'
       const parent = (args.parent as string) || '.'
 
-      const fullPath = resolveScene(projectPath, scenePath)
-      let content = readFileSync(fullPath, 'utf-8')
+      const fullPath = await resolveScene(projectPath, scenePath)
+      let content = await readFile(fullPath, 'utf-8')
 
       const parentAttr = parent === '.' ? '' : ` parent="${parent}"`
       const nodeDecl = `\n[node name="${playerName}" type="AnimationPlayer"${parentAttr}]\n`
       content = `${content.trimEnd()}\n${nodeDecl}`
 
-      writeFileSync(fullPath, content, 'utf-8')
+      await writeFile(fullPath, content, 'utf-8')
       return formatSuccess(`Created AnimationPlayer: ${playerName} under ${parent}`)
     }
 
@@ -44,8 +44,8 @@ export async function handleAnimation(action: string, args: Record<string, unkno
       const duration = (args.duration as number) || 1.0
       const loop = args.loop !== false
 
-      const fullPath = resolveScene(projectPath, scenePath)
-      let content = readFileSync(fullPath, 'utf-8')
+      const fullPath = await resolveScene(projectPath, scenePath)
+      let content = await readFile(fullPath, 'utf-8')
 
       // Add sub_resource for animation
       const animId = `Animation_${animName}`
@@ -60,7 +60,7 @@ export async function handleAnimation(action: string, args: Record<string, unkno
         content = `${content.slice(0, nodeIdx)}${animResource}\n${content.slice(nodeIdx)}`
       }
 
-      writeFileSync(fullPath, content, 'utf-8')
+      await writeFile(fullPath, content, 'utf-8')
       return formatSuccess(`Added animation: ${animName} (duration: ${duration}s, loop: ${loop})`)
     }
 
@@ -79,8 +79,8 @@ export async function handleAnimation(action: string, args: Record<string, unkno
         )
       }
 
-      const fullPath = resolveScene(projectPath, scenePath)
-      const content = readFileSync(fullPath, 'utf-8')
+      const fullPath = await resolveScene(projectPath, scenePath)
+      const content = await readFile(fullPath, 'utf-8')
 
       const trackPath = `${nodePath}:${property}`
       const trackInfo = `tracks/${trackType}/type = "${trackType}"\ntracks/${trackType}/path = NodePath("${trackPath}")\n`
@@ -97,7 +97,7 @@ export async function handleAnimation(action: string, args: Record<string, unkno
       if (endIdx === -1) endIdx = content.length
 
       const updated = `${content.slice(0, endIdx)}\n${trackInfo}${content.slice(endIdx)}`
-      writeFileSync(fullPath, updated, 'utf-8')
+      await writeFile(fullPath, updated, 'utf-8')
 
       return formatSuccess(`Added ${trackType} track: ${trackPath} to animation ${animName}`)
     }
@@ -116,8 +116,8 @@ export async function handleAnimation(action: string, args: Record<string, unkno
       const scenePath = args.scene_path as string
       if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
 
-      const fullPath = resolveScene(projectPath, scenePath)
-      const content = readFileSync(fullPath, 'utf-8')
+      const fullPath = await resolveScene(projectPath, scenePath)
+      const content = await readFile(fullPath, 'utf-8')
 
       const animations: { name: string; duration?: string; loop?: boolean }[] = []
       const animRegex = /\[sub_resource type="Animation" id="([^"]+)"\]/g
@@ -144,10 +144,6 @@ export async function handleAnimation(action: string, args: Record<string, unkno
     }
 
     default:
-      throw new GodotMCPError(
-        `Unknown action: ${action}`,
-        'INVALID_ACTION',
-        'Valid actions: create_player, add_animation, add_track, add_keyframe, list. Use help tool for full docs.',
-      )
+      throwUnknownAction(action, ['create_player', 'add_animation', 'add_track', 'add_keyframe', 'list'])
   }
 }

--- a/src/tools/composite/audio.ts
+++ b/src/tools/composite/audio.ts
@@ -3,11 +3,11 @@
  * Actions: list_buses | add_bus | add_effect | create_stream
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { readFile, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
-import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
-import { safeResolve } from '../helpers/paths.js'
+import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
+import { pathExists, safeResolve } from '../helpers/paths.js'
 
 export async function handleAudio(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const projectPath = (args.project_path as string) || config.projectPath
@@ -17,11 +17,11 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
       const busLayoutPath = resolve(projectPath, 'default_bus_layout.tres')
 
-      if (!existsSync(busLayoutPath)) {
+      if (!(await pathExists(busLayoutPath))) {
         return formatJSON({ buses: [{ name: 'Master', volume: 0, effects: [] }], note: 'Using default bus layout.' })
       }
 
-      const content = readFileSync(busLayoutPath, 'utf-8')
+      const content = await readFile(busLayoutPath, 'utf-8')
       const buses: { name: string; volume?: string; solo?: boolean; mute?: boolean }[] = []
 
       // Parse bus entries
@@ -43,8 +43,8 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       const busLayoutPath = resolve(projectPath, 'default_bus_layout.tres')
       let content: string
 
-      if (existsSync(busLayoutPath)) {
-        content = readFileSync(busLayoutPath, 'utf-8')
+      if (await pathExists(busLayoutPath)) {
+        content = await readFile(busLayoutPath, 'utf-8')
       } else {
         content = [
           '[gd_resource type="AudioBusLayout" format=3]',
@@ -72,7 +72,7 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       ].join('\n')
 
       content = `${content.trimEnd()}\n${newBus}\n`
-      writeFileSync(busLayoutPath, content, 'utf-8')
+      await writeFile(busLayoutPath, content, 'utf-8')
 
       return formatSuccess(`Added audio bus: ${busName} (send to: ${sendTo})`)
     }
@@ -95,8 +95,8 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       const busLayoutPath = resolve(projectPath, 'default_bus_layout.tres')
       let content: string
 
-      if (existsSync(busLayoutPath)) {
-        content = readFileSync(busLayoutPath, 'utf-8')
+      if (await pathExists(busLayoutPath)) {
+        content = await readFile(busLayoutPath, 'utf-8')
       } else {
         content = [
           '[gd_resource type="AudioBusLayout" format=3]',
@@ -145,7 +145,7 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       const effectRef = `bus/${busIndex}/effect/${effectIndex}/effect = SubResource("${subResId}")\nbus/${busIndex}/effect/${effectIndex}/enabled = true\n`
       content = `${content.trimEnd()}\n${effectRef}`
 
-      writeFileSync(busLayoutPath, content, 'utf-8')
+      await writeFile(busLayoutPath, content, 'utf-8')
       return formatSuccess(`Added ${fullEffectType} to bus "${busName}" (effect index: ${effectIndex})`)
     }
 
@@ -158,25 +158,21 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       const bus = (args.bus as string) || 'Master'
 
       const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
-      if (!existsSync(fullPath))
+      if (!(await pathExists(fullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 
-      let content = readFileSync(fullPath, 'utf-8')
+      let content = await readFile(fullPath, 'utf-8')
       const nodeType =
         streamType === '3D' ? 'AudioStreamPlayer3D' : streamType === '2D' ? 'AudioStreamPlayer2D' : 'AudioStreamPlayer'
       const parentAttr = parent === '.' ? '' : ` parent="${parent}"`
       const nodeDecl = `\n[node name="${nodeName}" type="${nodeType}"${parentAttr}]\nbus = "${bus}"\n`
       content = `${content.trimEnd()}\n${nodeDecl}`
 
-      writeFileSync(fullPath, content, 'utf-8')
+      await writeFile(fullPath, content, 'utf-8')
       return formatSuccess(`Created ${nodeType}: ${nodeName} (bus: ${bus})`)
     }
 
     default:
-      throw new GodotMCPError(
-        `Unknown action: ${action}`,
-        'INVALID_ACTION',
-        'Valid actions: list_buses, add_bus, add_effect, create_stream. Use help tool for full docs.',
-      )
+      throwUnknownAction(action, ['list_buses', 'add_bus', 'add_effect', 'create_stream'])
   }
 }

--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -4,7 +4,7 @@
  */
 
 import type { GodotConfig } from '../../godot/types.js'
-import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 
 // Mutable runtime config
 const runtimeConfig: Record<string, string> = {}
@@ -61,10 +61,6 @@ export async function handleConfig(action: string, args: Record<string, unknown>
     }
 
     default:
-      throw new GodotMCPError(
-        `Unknown action: ${action}`,
-        'INVALID_ACTION',
-        'Valid actions: status, set. Use help tool for full docs.',
-      )
+      throwUnknownAction(action, ['status', 'set'])
   }
 }

--- a/src/tools/composite/editor.ts
+++ b/src/tools/composite/editor.ts
@@ -7,7 +7,7 @@ import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import { launchGodotEditor } from '../../godot/headless.js'
 import type { GodotConfig } from '../../godot/types.js'
-import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
 
 const execFileAsync = promisify(execFile)
@@ -74,10 +74,6 @@ export async function handleEditor(action: string, args: Record<string, unknown>
     }
 
     default:
-      throw new GodotMCPError(
-        `Unknown action: ${action}`,
-        'INVALID_ACTION',
-        'Valid actions: launch, status. Use help tool for full docs.',
-      )
+      throwUnknownAction(action, ['launch', 'status'])
   }
 }

--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -3,10 +3,11 @@
  * Actions: list | add_action | remove_action | add_event
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { readFile, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
-import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
+import { pathExists } from '../helpers/paths.js'
 import { escapeRegExp } from '../helpers/scene-parser.js'
 
 /**
@@ -134,10 +135,10 @@ function resolveMouseCode(value: string): number {
   )
 }
 
-function getProjectGodotPath(projectPath: string | null | undefined): string {
+async function getProjectGodotPath(projectPath: string | null | undefined): Promise<string> {
   if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
   const configPath = join(resolve(projectPath), 'project.godot')
-  if (!existsSync(configPath))
+  if (!(await pathExists(configPath)))
     throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')
   return configPath
 }
@@ -219,8 +220,8 @@ export async function handleInputMap(action: string, args: Record<string, unknow
 
   switch (action) {
     case 'list': {
-      const configPath = getProjectGodotPath(projectPath)
-      const content = readFileSync(configPath, 'utf-8')
+      const configPath = await getProjectGodotPath(projectPath)
+      const content = await readFile(configPath, 'utf-8')
       const actions = parseInputActions(content)
 
       const actionList = Array.from(actions.entries()).map(([name, events]) => ({
@@ -232,7 +233,7 @@ export async function handleInputMap(action: string, args: Record<string, unknow
     }
 
     case 'add_action': {
-      const configPath = getProjectGodotPath(projectPath)
+      const configPath = await getProjectGodotPath(projectPath)
       const actionName = args.action_name as string
       if (!actionName) throw new GodotMCPError('No action_name specified', 'INVALID_ARGS', 'Provide action_name.')
       if (typeof actionName !== 'string' || !/^[a-zA-Z0-9_-]+$/.test(actionName)) {
@@ -244,7 +245,7 @@ export async function handleInputMap(action: string, args: Record<string, unknow
       }
       const deadzone = (args.deadzone as number) || 0.5
 
-      let content = readFileSync(configPath, 'utf-8')
+      let content = await readFile(configPath, 'utf-8')
 
       // Check if [input] section exists
       if (!content.includes('[input]')) {
@@ -260,12 +261,12 @@ export async function handleInputMap(action: string, args: Record<string, unknow
       const actionLine = `${actionName}={\n"deadzone": ${deadzone},\n"events": []\n}`
       content = content.replace('[input]', `[input]\n${actionLine}`)
 
-      writeFileSync(configPath, content, 'utf-8')
+      await writeFile(configPath, content, 'utf-8')
       return formatSuccess(`Added input action: ${actionName} (deadzone: ${deadzone})`)
     }
 
     case 'remove_action': {
-      const configPath = getProjectGodotPath(projectPath)
+      const configPath = await getProjectGodotPath(projectPath)
       const actionName = args.action_name as string
       if (!actionName) throw new GodotMCPError('No action_name specified', 'INVALID_ARGS', 'Provide action_name.')
       if (typeof actionName !== 'string' || !/^[a-zA-Z0-9_-]+$/.test(actionName)) {
@@ -276,7 +277,7 @@ export async function handleInputMap(action: string, args: Record<string, unknow
         )
       }
 
-      const content = readFileSync(configPath, 'utf-8')
+      const content = await readFile(configPath, 'utf-8')
       // Remove the action line(s) - handles multi-line format
       const pattern = new RegExp(`${escapeRegExp(actionName)}=\\{[^}]*\\}\\n?`, 'g')
       const updated = content.replace(pattern, '')
@@ -285,12 +286,12 @@ export async function handleInputMap(action: string, args: Record<string, unknow
         throw new GodotMCPError(`Action "${actionName}" not found`, 'INPUT_ERROR', 'Check action name with list.')
       }
 
-      writeFileSync(configPath, updated, 'utf-8')
+      await writeFile(configPath, updated, 'utf-8')
       return formatSuccess(`Removed input action: ${actionName}`)
     }
 
     case 'add_event': {
-      const configPath = getProjectGodotPath(projectPath)
+      const configPath = await getProjectGodotPath(projectPath)
       const actionName = args.action_name as string
       const eventType = args.event_type as string
       const eventValue = args.event_value as string
@@ -309,7 +310,7 @@ export async function handleInputMap(action: string, args: Record<string, unknow
         )
       }
 
-      const content = readFileSync(configPath, 'utf-8')
+      const content = await readFile(configPath, 'utf-8')
 
       // Build event object based on type
       let eventObj: string
@@ -350,15 +351,11 @@ export async function handleInputMap(action: string, args: Record<string, unknow
       const newEvents = existingEvents ? `${existingEvents}, ${eventObj}` : eventObj
       const updated = content.replace(actionRegex, `$1${newEvents}]`)
 
-      writeFileSync(configPath, updated, 'utf-8')
+      await writeFile(configPath, updated, 'utf-8')
       return formatSuccess(`Added ${eventType} event to action: ${actionName}`)
     }
 
     default:
-      throw new GodotMCPError(
-        `Unknown input map action: ${action}`,
-        'INVALID_ACTION',
-        'Valid actions: list, add_action, remove_action, add_event. Use help tool for full docs.',
-      )
+      throwUnknownAction(action, ['list', 'add_action', 'remove_action', 'add_event'])
   }
 }

--- a/src/tools/composite/navigation.ts
+++ b/src/tools/composite/navigation.ts
@@ -3,14 +3,14 @@
  * Actions: create_region | add_agent | add_obstacle
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { readFile, writeFile } from 'node:fs/promises'
 import type { GodotConfig } from '../../godot/types.js'
-import { formatSuccess, GodotMCPError } from '../helpers/errors.js'
-import { safeResolve } from '../helpers/paths.js'
+import { formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
+import { pathExists, safeResolve } from '../helpers/paths.js'
 
-function resolveScene(projectPath: string | null | undefined, scenePath: string): string {
+async function resolveScene(projectPath: string | null | undefined, scenePath: string): Promise<string> {
   const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
-  if (!existsSync(fullPath))
+  if (!(await pathExists(fullPath)))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
   return fullPath
 }
@@ -33,13 +33,13 @@ export async function handleNavigation(action: string, args: Record<string, unkn
       const parent = (args.parent as string) || '.'
       const dimension = (args.dimension as string) || '3D'
 
-      const fullPath = resolveScene(projectPath, scenePath)
-      let content = readFileSync(fullPath, 'utf-8')
+      const fullPath = await resolveScene(projectPath, scenePath)
+      let content = await readFile(fullPath, 'utf-8')
 
       const nodeType = dimension === '2D' ? 'NavigationRegion2D' : 'NavigationRegion3D'
       content = appendNode(content, regionName, nodeType, parent)
 
-      writeFileSync(fullPath, content, 'utf-8')
+      await writeFile(fullPath, content, 'utf-8')
       return formatSuccess(`Created navigation region: ${regionName} (${nodeType})`)
     }
 
@@ -50,8 +50,8 @@ export async function handleNavigation(action: string, args: Record<string, unkn
       const parent = (args.parent as string) || '.'
       const dimension = (args.dimension as string) || '3D'
 
-      const fullPath = resolveScene(projectPath, scenePath)
-      let content = readFileSync(fullPath, 'utf-8')
+      const fullPath = await resolveScene(projectPath, scenePath)
+      let content = await readFile(fullPath, 'utf-8')
 
       const nodeType = dimension === '2D' ? 'NavigationAgent2D' : 'NavigationAgent3D'
       let extraProps = ''
@@ -62,7 +62,7 @@ export async function handleNavigation(action: string, args: Record<string, unkn
 
       content = appendNode(content, agentName, nodeType, parent, extraProps || undefined)
 
-      writeFileSync(fullPath, content, 'utf-8')
+      await writeFile(fullPath, content, 'utf-8')
       return formatSuccess(`Added navigation agent: ${agentName} (${nodeType})`)
     }
 
@@ -73,8 +73,8 @@ export async function handleNavigation(action: string, args: Record<string, unkn
       const parent = (args.parent as string) || '.'
       const dimension = (args.dimension as string) || '3D'
 
-      const fullPath = resolveScene(projectPath, scenePath)
-      let content = readFileSync(fullPath, 'utf-8')
+      const fullPath = await resolveScene(projectPath, scenePath)
+      let content = await readFile(fullPath, 'utf-8')
 
       const nodeType = dimension === '2D' ? 'NavigationObstacle2D' : 'NavigationObstacle3D'
       let extraProps = ''
@@ -83,15 +83,11 @@ export async function handleNavigation(action: string, args: Record<string, unkn
 
       content = appendNode(content, obstacleName, nodeType, parent, extraProps || undefined)
 
-      writeFileSync(fullPath, content, 'utf-8')
+      await writeFile(fullPath, content, 'utf-8')
       return formatSuccess(`Added navigation obstacle: ${obstacleName} (${nodeType})`)
     }
 
     default:
-      throw new GodotMCPError(
-        `Unknown action: ${action}`,
-        'INVALID_ACTION',
-        'Valid actions: create_region, add_agent, add_obstacle. Use help tool for full docs.',
-      )
+      throwUnknownAction(action, ['create_region', 'add_agent', 'add_obstacle'])
   }
 }

--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -3,10 +3,10 @@
  * Actions: add | remove | rename | list | set_property | get_property
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { readFile, writeFile } from 'node:fs/promises'
 import type { GodotConfig, SceneNode } from '../../godot/types.js'
-import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
-import { safeResolve } from '../helpers/paths.js'
+import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
+import { pathExists, safeResolve } from '../helpers/paths.js'
 import {
   getNodeProperty,
   parseSceneContent,
@@ -55,10 +55,10 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
       const parent = (args.parent as string) || '.'
 
       const fullPath = resolveScenePath(projectPath, scenePath)
-      if (!existsSync(fullPath))
+      if (!(await pathExists(fullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
 
-      const content = readFileSync(fullPath, 'utf-8')
+      const content = await readFile(fullPath, 'utf-8')
       const scene = parseSceneContent(content)
       const duplicate = scene.nodes.find((n) => n.name === nodeName && (n.parent || '.') === parent)
       if (duplicate) {
@@ -94,7 +94,7 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
       }
 
       const updated = `${content.trimEnd()}\n${nodeDecl}`
-      writeFileSync(fullPath, updated, 'utf-8')
+      await writeFile(fullPath, updated, 'utf-8')
 
       return formatSuccess(`Added node: ${nodeName} (${nodeType}) under ${parent}`)
     }
@@ -107,12 +107,12 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
         throw new GodotMCPError('No node name specified', 'INVALID_ARGS', 'Provide name of node to remove.')
 
       const fullPath = resolveScenePath(projectPath, scenePath)
-      if (!existsSync(fullPath))
+      if (!(await pathExists(fullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
 
-      const content = readFileSync(fullPath, 'utf-8')
+      const content = await readFile(fullPath, 'utf-8')
       const updated = removeNodeFromContent(content, nodeName)
-      writeFileSync(fullPath, updated, 'utf-8')
+      await writeFile(fullPath, updated, 'utf-8')
 
       return formatSuccess(`Removed node: ${nodeName} from ${scenePath}`)
     }
@@ -126,12 +126,12 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
         throw new GodotMCPError('Both name and new_name required', 'INVALID_ARGS', 'Provide name and new_name.')
 
       const fullPath = resolveScenePath(projectPath, scenePath)
-      if (!existsSync(fullPath))
+      if (!(await pathExists(fullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
 
-      const content = readFileSync(fullPath, 'utf-8')
+      const content = await readFile(fullPath, 'utf-8')
       const updated = renameNodeInContent(content, nodeName, newName)
-      writeFileSync(fullPath, updated, 'utf-8')
+      await writeFile(fullPath, updated, 'utf-8')
 
       return formatSuccess(`Renamed node: ${nodeName} -> ${newName} in ${scenePath}`)
     }
@@ -141,10 +141,10 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
       if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
 
       const fullPath = resolveScenePath(projectPath, scenePath)
-      if (!existsSync(fullPath))
+      if (!(await pathExists(fullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
 
-      const content = readFileSync(fullPath, 'utf-8')
+      const content = await readFile(fullPath, 'utf-8')
       const scene = parseSceneContent(content)
       const nodes = scene.nodes.map(mapToSceneNode)
 
@@ -175,12 +175,12 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
       }
 
       const fullPath = resolveScenePath(projectPath, scenePath)
-      if (!existsSync(fullPath))
+      if (!(await pathExists(fullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
 
-      const content = readFileSync(fullPath, 'utf-8')
+      const content = await readFile(fullPath, 'utf-8')
       const updated = setNodePropertyInContent(content, nodeName, property, value)
-      writeFileSync(fullPath, updated, 'utf-8')
+      await writeFile(fullPath, updated, 'utf-8')
 
       return formatSuccess(`Set ${property} = ${value} on node ${nodeName}`)
     }
@@ -195,10 +195,10 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
       }
 
       const fullPath = resolveScenePath(projectPath, scenePath)
-      if (!existsSync(fullPath))
+      if (!(await pathExists(fullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
 
-      const content = readFileSync(fullPath, 'utf-8')
+      const content = await readFile(fullPath, 'utf-8')
       const scene = parseSceneContent(content)
       const val = getNodeProperty(scene, nodeName, property)
 
@@ -206,10 +206,6 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
     }
 
     default:
-      throw new GodotMCPError(
-        `Unknown action: ${action}`,
-        'INVALID_ACTION',
-        'Valid actions: add, remove, rename, list, set_property, get_property. Use help tool for full docs.',
-      )
+      throwUnknownAction(action, ['add', 'remove', 'rename', 'list', 'set_property', 'get_property'])
   }
 }

--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -6,7 +6,7 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
-import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
 import { parseProjectSettings, setSettingInContent } from '../helpers/project-settings.js'
 import { escapeRegExp } from '../helpers/scene-parser.js'
@@ -121,10 +121,6 @@ export async function handlePhysics(action: string, args: Record<string, unknown
     }
 
     default:
-      throw new GodotMCPError(
-        `Unknown action: ${action}`,
-        'INVALID_ACTION',
-        'Valid actions: layers, collision_setup, body_config, set_layer_name. Use help tool for full docs.',
-      )
+      throwUnknownAction(action, ['layers', 'collision_setup', 'body_config', 'set_layer_name'])
   }
 }

--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -3,12 +3,11 @@
  * Actions: list | info | delete | import_config
  */
 
-import { existsSync, readFileSync, statSync, unlinkSync } from 'node:fs'
-import { readdir, stat } from 'node:fs/promises'
+import { readdir, readFile, stat, unlink } from 'node:fs/promises'
 import { extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
-import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
-import { safeResolve } from '../helpers/paths.js'
+import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
+import { pathExists, safeResolve } from '../helpers/paths.js'
 
 const RESOURCE_EXTENSIONS = new Set([
   '.tres',
@@ -99,21 +98,21 @@ export async function handleResources(action: string, args: Record<string, unkno
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
       const fullPath = safeResolve(projectPath || process.cwd(), resPath)
-      if (!existsSync(fullPath))
+      if (!(await pathExists(fullPath)))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
-      const stat = statSync(fullPath)
+      const fileStat = await stat(fullPath)
       const ext = extname(fullPath)
       const info: Record<string, unknown> = {
         path: resPath,
         extension: ext,
-        size: stat.size,
-        modified: stat.mtime.toISOString(),
+        size: fileStat.size,
+        modified: fileStat.mtime.toISOString(),
       }
 
       // Parse .tres/.import files for metadata
       if (ext === '.tres' || ext === '.import') {
-        const content = readFileSync(fullPath, 'utf-8')
+        const content = await readFile(fullPath, 'utf-8')
         const typeMatch = content.match(/type="([^"]*)"/)
         if (typeMatch) info.type = typeMatch[1]
         const pathMatch = content.match(/path="([^"]*)"/)
@@ -127,13 +126,13 @@ export async function handleResources(action: string, args: Record<string, unkno
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
       const fullPath = safeResolve(projectPath || process.cwd(), resPath)
-      if (!existsSync(fullPath))
+      if (!(await pathExists(fullPath)))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
-      unlinkSync(fullPath)
+      await unlink(fullPath)
       // Also delete .import file if exists
       const importFile = `${fullPath}.import`
-      if (existsSync(importFile)) unlinkSync(importFile)
+      if (await pathExists(importFile)) await unlink(importFile)
 
       return formatSuccess(`Deleted resource: ${resPath}`)
     }
@@ -144,19 +143,15 @@ export async function handleResources(action: string, args: Record<string, unkno
 
       const importPath = safeResolve(projectPath || process.cwd(), `${resPath}.import`)
 
-      if (!existsSync(importPath)) {
+      if (!(await pathExists(importPath))) {
         return formatJSON({ path: resPath, imported: false, message: 'No .import file found.' })
       }
 
-      const content = readFileSync(importPath, 'utf-8')
+      const content = await readFile(importPath, 'utf-8')
       return formatSuccess(`Import config for ${resPath}:\n\n${content}`)
     }
 
     default:
-      throw new GodotMCPError(
-        `Unknown action: ${action}`,
-        'INVALID_ACTION',
-        'Valid actions: list, info, delete, import_config. Use help tool for full docs.',
-      )
+      throwUnknownAction(action, ['list', 'info', 'delete', 'import_config'])
   }
 }

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -3,12 +3,11 @@
  * Actions: create | list | info | delete | duplicate | set_main
  */
 
-import { copyFileSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
-import { readdir, readFile } from 'node:fs/promises'
+import { copyFile, mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/promises'
 import { basename, dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig, SceneInfo, SceneNode } from '../../godot/types.js'
-import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
-import { safeResolve } from '../helpers/paths.js'
+import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
+import { pathExists, safeResolve } from '../helpers/paths.js'
 import { setSettingInContent } from '../helpers/project-settings.js'
 
 // Pre-compiled regex for parsing scene metadata without splitting lines
@@ -167,7 +166,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       const rootName = (args.root_name as string) || basename(scenePath, '.tscn')
 
       const fullPath = safeResolve(projectPath as string, scenePath)
-      if (existsSync(fullPath)) {
+      if (await pathExists(fullPath)) {
         throw new GodotMCPError(
           `Scene already exists: ${scenePath}`,
           'SCENE_ERROR',
@@ -176,8 +175,8 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       }
 
       const content = generateTscnContent(rootName, rootType)
-      mkdirSync(dirname(fullPath), { recursive: true })
-      writeFileSync(fullPath, content, 'utf-8')
+      await mkdir(dirname(fullPath), { recursive: true })
+      await writeFile(fullPath, content, 'utf-8')
 
       return formatSuccess(`Created scene: ${scenePath}\nRoot: ${rootName} (${rootType})`)
     }
@@ -198,7 +197,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
     case 'info': {
       // scenePath is guaranteed
       const fullPath = resolvePath(projectPath, scenePath)
-      if (!existsSync(fullPath)) {
+      if (!(await pathExists(fullPath))) {
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path and try again.')
       }
 
@@ -209,11 +208,11 @@ export async function handleScenes(action: string, args: Record<string, unknown>
     case 'delete': {
       // scenePath is guaranteed
       const fullPath = resolvePath(projectPath, scenePath)
-      if (!existsSync(fullPath)) {
+      if (!(await pathExists(fullPath))) {
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
       }
 
-      unlinkSync(fullPath)
+      await unlink(fullPath)
       return formatSuccess(`Deleted scene: ${scenePath}`)
     }
 
@@ -222,10 +221,10 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       const srcFull = resolvePath(projectPath, scenePath)
       const dstFull = resolvePath(projectPath, newPath as string)
 
-      if (!existsSync(srcFull)) {
+      if (!(await pathExists(srcFull))) {
         throw new GodotMCPError(`Source scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the source path.')
       }
-      if (existsSync(dstFull)) {
+      if (await pathExists(dstFull)) {
         throw new GodotMCPError(
           `Destination already exists: ${newPath}`,
           'SCENE_ERROR',
@@ -233,31 +232,27 @@ export async function handleScenes(action: string, args: Record<string, unknown>
         )
       }
 
-      mkdirSync(dirname(dstFull), { recursive: true })
-      copyFileSync(srcFull, dstFull)
+      await mkdir(dirname(dstFull), { recursive: true })
+      await copyFile(srcFull, dstFull)
       return formatSuccess(`Duplicated: ${scenePath} -> ${newPath}`)
     }
 
     case 'set_main': {
       // projectPath and scenePath are guaranteed
       const configPath = join(resolve(projectPath as string), 'project.godot')
-      if (!existsSync(configPath)) {
+      if (!(await pathExists(configPath))) {
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')
       }
 
       const resPath = `res://${scenePath.replace(/\\/g, '/')}`
-      const content = readFileSync(configPath, 'utf-8')
+      const content = await readFile(configPath, 'utf-8')
       const updated = setSettingInContent(content, 'application/run/main_scene', `"${resPath}"`)
-      writeFileSync(configPath, updated, 'utf-8')
+      await writeFile(configPath, updated, 'utf-8')
 
       return formatSuccess(`Set main scene: ${resPath}`)
     }
 
     default:
-      throw new GodotMCPError(
-        `Unknown action: ${action}`,
-        'INVALID_ACTION',
-        'Valid actions: create, list, info, delete, duplicate, set_main. Use help tool for full docs.',
-      )
+      throwUnknownAction(action, ['create', 'list', 'info', 'delete', 'duplicate', 'set_main'])
   }
 }

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -3,12 +3,11 @@
  * Actions: create | read | write | attach | list | delete
  */
 
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
-import { readdir } from 'node:fs/promises'
+import { mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/promises'
 import { dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
-import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
-import { safeResolve } from '../helpers/paths.js'
+import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
+import { pathExists, safeResolve } from '../helpers/paths.js'
 import { escapeRegExp } from '../helpers/scene-parser.js'
 
 const SCRIPT_TEMPLATES: Record<string, string> = {
@@ -150,7 +149,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       const content = (args.content as string) || getTemplate(extendsType)
 
       const fullPath = resolvePath(scriptPath)
-      if (existsSync(fullPath)) {
+      if (await pathExists(fullPath)) {
         throw new GodotMCPError(
           `Script already exists: ${scriptPath}`,
           'SCRIPT_ERROR',
@@ -158,8 +157,8 @@ export async function handleScripts(action: string, args: Record<string, unknown
         )
       }
 
-      mkdirSync(dirname(fullPath), { recursive: true })
-      writeFileSync(fullPath, content, 'utf-8')
+      await mkdir(dirname(fullPath), { recursive: true })
+      await writeFile(fullPath, content, 'utf-8')
       return formatSuccess(`Created script: ${scriptPath}\nExtends: ${extendsType}`)
     }
 
@@ -168,10 +167,10 @@ export async function handleScripts(action: string, args: Record<string, unknown
       if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path.')
 
       const fullPath = resolvePath(scriptPath)
-      if (!existsSync(fullPath))
+      if (!(await pathExists(fullPath)))
         throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
 
-      const content = readFileSync(fullPath, 'utf-8')
+      const content = await readFile(fullPath, 'utf-8')
       return formatSuccess(`File: ${scriptPath}\n\n${content}`)
     }
 
@@ -183,8 +182,8 @@ export async function handleScripts(action: string, args: Record<string, unknown
         throw new GodotMCPError('No content specified', 'INVALID_ARGS', 'Provide content to write.')
 
       const fullPath = resolvePath(scriptPath)
-      mkdirSync(dirname(fullPath), { recursive: true })
-      writeFileSync(fullPath, content, 'utf-8')
+      await mkdir(dirname(fullPath), { recursive: true })
+      await writeFile(fullPath, content, 'utf-8')
       return formatSuccess(`Written: ${scriptPath} (${content.length} chars)`)
     }
 
@@ -201,10 +200,10 @@ export async function handleScripts(action: string, args: Record<string, unknown
       }
 
       const sceneFullPath = resolvePath(scenePath)
-      if (!existsSync(sceneFullPath))
+      if (!(await pathExists(sceneFullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
 
-      let content = readFileSync(sceneFullPath, 'utf-8')
+      let content = await readFile(sceneFullPath, 'utf-8')
       const resPath = `res://${scriptPath.replace(/\\/g, '/')}`
 
       if (nodeName) {
@@ -221,7 +220,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
         content = content.replace(/(\[node [^\]]+\])/, `$1\nscript = ExtResource("${resPath}")`)
       }
 
-      writeFileSync(sceneFullPath, content, 'utf-8')
+      await writeFile(sceneFullPath, content, 'utf-8')
       return formatSuccess(`Attached script ${scriptPath} to ${nodeName || 'root node'} in ${scenePath}`)
     }
 
@@ -242,18 +241,14 @@ export async function handleScripts(action: string, args: Record<string, unknown
         throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path to delete.')
 
       const fullPath = resolvePath(scriptPath)
-      if (!existsSync(fullPath))
+      if (!(await pathExists(fullPath)))
         throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
 
-      unlinkSync(fullPath)
+      await unlink(fullPath)
       return formatSuccess(`Deleted script: ${scriptPath}`)
     }
 
     default:
-      throw new GodotMCPError(
-        `Unknown action: ${action}`,
-        'INVALID_ACTION',
-        'Valid actions: create, read, write, attach, list, delete. Use help tool for full docs.',
-      )
+      throwUnknownAction(action, ['create', 'read', 'write', 'attach', 'list', 'delete'])
   }
 }

--- a/src/tools/composite/setup.ts
+++ b/src/tools/composite/setup.ts
@@ -7,7 +7,7 @@ import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { detectGodot } from '../../godot/detector.js'
 import type { GodotConfig } from '../../godot/types.js'
-import { formatJSON, GodotMCPError } from '../helpers/errors.js'
+import { formatJSON, throwUnknownAction } from '../helpers/errors.js'
 
 export async function handleSetup(action: string, _args: Record<string, unknown>, config: GodotConfig) {
   switch (action) {
@@ -53,10 +53,6 @@ export async function handleSetup(action: string, _args: Record<string, unknown>
     }
 
     default:
-      throw new GodotMCPError(
-        `Unknown action: ${action}`,
-        'INVALID_ACTION',
-        'Valid actions: detect_godot, check. Use help tool for full docs.',
-      )
+      throwUnknownAction(action, ['detect_godot', 'check'])
   }
 }

--- a/src/tools/composite/shader.ts
+++ b/src/tools/composite/shader.ts
@@ -6,7 +6,7 @@
 import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, extname, join, relative, resolve } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
-import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
 
 const SHADER_TEMPLATES: Record<string, string> = {
@@ -180,10 +180,6 @@ export async function handleShader(action: string, args: Record<string, unknown>
     }
 
     default:
-      throw new GodotMCPError(
-        `Unknown action: ${action}`,
-        'INVALID_ACTION',
-        'Valid actions: create, read, write, get_params, list. Use help tool for full docs.',
-      )
+      throwUnknownAction(action, ['create', 'read', 'write', 'get_params', 'list'])
   }
 }

--- a/src/tools/composite/signals.ts
+++ b/src/tools/composite/signals.ts
@@ -5,7 +5,7 @@
 
 import { readFile, writeFile } from 'node:fs/promises'
 import type { GodotConfig } from '../../godot/types.js'
-import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
 import { parseSceneContent } from '../helpers/scene-parser.js'
 
@@ -123,10 +123,6 @@ export async function handleSignals(action: string, args: Record<string, unknown
     }
 
     default:
-      throw new GodotMCPError(
-        `Unknown action: ${action}`,
-        'INVALID_ACTION',
-        'Valid actions: list, connect, disconnect. Use help tool for full docs.',
-      )
+      throwUnknownAction(action, ['list', 'connect', 'disconnect'])
   }
 }

--- a/src/tools/composite/tilemap.ts
+++ b/src/tools/composite/tilemap.ts
@@ -7,7 +7,7 @@ import { constants } from 'node:fs'
 import { access, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
-import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
 
 /**
@@ -132,10 +132,6 @@ export async function handleTilemap(action: string, args: Record<string, unknown
     }
 
     default:
-      throw new GodotMCPError(
-        `Unknown action: ${action}`,
-        'INVALID_ACTION',
-        'Valid actions: create_tileset, add_source, set_tile, paint, list. Use help tool for full docs.',
-      )
+      throwUnknownAction(action, ['create_tileset', 'add_source', 'set_tile', 'paint', 'list'])
   }
 }

--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -3,11 +3,11 @@
  * Actions: create_control | set_theme | layout | list_controls
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
-import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
-import { safeResolve } from '../helpers/paths.js'
+import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
+import { pathExists, safeResolve } from '../helpers/paths.js'
 import { escapeRegExp, parseScene } from '../helpers/scene-parser.js'
 
 const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
@@ -31,9 +31,9 @@ const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
   GridContainer: { columns: '2' },
 }
 
-function resolveScene(projectPath: string | null | undefined, scenePath: string): string {
+async function resolveScene(projectPath: string | null | undefined, scenePath: string): Promise<string> {
   const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
-  if (!existsSync(fullPath))
+  if (!(await pathExists(fullPath)))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
   return fullPath
 }
@@ -51,8 +51,8 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
 
       if (!controlName) throw new GodotMCPError('No name specified', 'INVALID_ARGS', 'Provide control node name.')
 
-      const fullPath = resolveScene(projectPath, scenePath)
-      let content = readFileSync(fullPath, 'utf-8')
+      const fullPath = await resolveScene(projectPath, scenePath)
+      let content = await readFile(fullPath, 'utf-8')
 
       const parentAttr = parent === '.' ? '' : ` parent="${parent}"`
       let nodeDecl = `\n[node name="${controlName}" type="${controlType}"${parentAttr}]\n`
@@ -74,7 +74,7 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
       }
 
       content = `${content.trimEnd()}\n${nodeDecl}`
-      writeFileSync(fullPath, content, 'utf-8')
+      await writeFile(fullPath, content, 'utf-8')
 
       return formatSuccess(`Created UI control: ${controlName} (${controlType}) under ${parent}`)
     }
@@ -100,8 +100,8 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
         '',
       ].join('\n')
 
-      mkdirSync(dirname(fullPath), { recursive: true })
-      writeFileSync(fullPath, content, 'utf-8')
+      await mkdir(dirname(fullPath), { recursive: true })
+      await writeFile(fullPath, content, 'utf-8')
 
       return formatSuccess(`Created theme: ${themePath} (font size: ${fontSize})`)
     }
@@ -113,8 +113,8 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
       if (!nodeName) throw new GodotMCPError('No name specified', 'INVALID_ARGS', 'Provide node name.')
       const preset = (args.preset as string) || 'full_rect'
 
-      const fullPath = resolveScene(projectPath, scenePath)
-      let content = readFileSync(fullPath, 'utf-8')
+      const fullPath = await resolveScene(projectPath, scenePath)
+      let content = await readFile(fullPath, 'utf-8')
 
       const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
       const match = content.match(nodeRegex)
@@ -156,7 +156,7 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
         throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
       const insertPoint = match.index + match[0].length
       content = `${content.slice(0, insertPoint)}${layoutProps}${content.slice(insertPoint)}`
-      writeFileSync(fullPath, content, 'utf-8')
+      await writeFile(fullPath, content, 'utf-8')
 
       return formatSuccess(`Set layout preset "${preset}" on ${nodeName}`)
     }
@@ -165,8 +165,8 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
       const scenePath = args.scene_path as string
       if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
 
-      const fullPath = resolveScene(projectPath, scenePath)
-      const scene = parseScene(fullPath)
+      const fullPath = await resolveScene(projectPath, scenePath)
+      const scene = await parseScene(fullPath)
 
       const controlTypes = new Set([
         'Control',
@@ -215,10 +215,6 @@ export async function handleUI(action: string, args: Record<string, unknown>, co
     }
 
     default:
-      throw new GodotMCPError(
-        `Unknown action: ${action}`,
-        'INVALID_ACTION',
-        'Valid actions: create_control, set_theme, layout, list_controls. Use help tool for full docs.',
-      )
+      throwUnknownAction(action, ['create_control', 'set_theme', 'layout', 'list_controls'])
   }
 }

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -85,3 +85,14 @@ export function formatSuccess(text: string): { content: Array<{ type: 'text'; te
 export function formatJSON(data: unknown): { content: Array<{ type: 'text'; text: string }> } {
   return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] }
 }
+
+/**
+ * Throw a standardized "Unknown action" error with valid actions listed.
+ */
+export function throwUnknownAction(action: string, validActions: string[]): never {
+  throw new GodotMCPError(
+    `Unknown action: ${action}`,
+    'INVALID_ACTION',
+    `Valid actions: ${validActions.join(', ')}. Use help tool for full docs.`,
+  )
+}

--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -11,7 +11,7 @@
  * [connection signal="..." from="..." to="..." method="..."]
  */
 
-import { readFileSync, writeFileSync } from 'node:fs'
+import { readFile, writeFile } from 'node:fs/promises'
 
 // Pre-compiled regular expressions for parsing scene sections
 const rxGdSceneFormat = /format=(\d+)/
@@ -78,8 +78,8 @@ export interface ParsedScene {
 /**
  * Parse a .tscn file into structured data
  */
-export function parseScene(filePath: string): ParsedScene {
-  const raw = readFileSync(filePath, 'utf-8')
+export async function parseScene(filePath: string): Promise<ParsedScene> {
+  const raw = await readFile(filePath, 'utf-8')
   return parseSceneContent(raw)
 }
 
@@ -420,6 +420,6 @@ export function getNodeProperty(scene: ParsedScene, nodeName: string, property: 
 /**
  * Write a parsed scene back to file (using raw content)
  */
-export function writeScene(filePath: string, content: string): void {
-  writeFileSync(filePath, content, 'utf-8')
+export async function writeScene(filePath: string, content: string): Promise<void> {
+  await writeFile(filePath, content, 'utf-8')
 }

--- a/tests/composite/input-map.test.ts
+++ b/tests/composite/input-map.test.ts
@@ -249,7 +249,7 @@ describe('input-map', () => {
 
   it('should throw for unknown action', async () => {
     await expect(handleInputMap('invalid_action', {}, config)).rejects.toMatchObject({
-      message: 'Unknown input map action: invalid_action',
+      message: 'Unknown action: invalid_action',
       code: 'INVALID_ACTION',
     })
   })

--- a/tests/helpers/coverage-gaps.test.ts
+++ b/tests/helpers/coverage-gaps.test.ts
@@ -163,9 +163,9 @@ radius = 16.0`
   })
 
   describe('writeScene', () => {
-    it('should write scene content to file', () => {
+    it('should write scene content to file', async () => {
       const filePath = join(tmpDir, 'test.tscn')
-      writeScene(filePath, '[gd_scene format=3]\n[node name="Root" type="Node2D"]\n')
+      await writeScene(filePath, '[gd_scene format=3]\n[node name="Root" type="Node2D"]\n')
       const { readFileSync } = require('node:fs') as typeof import('node:fs')
       expect(readFileSync(filePath, 'utf-8')).toContain('name="Root"')
     })


### PR DESCRIPTION
## Summary
- Add `throwUnknownAction()` helper to `errors.ts` — replaces duplicated inline error throws in all 18 tool default cases
- Convert remaining sync file operations (`readFileSync`, `writeFileSync`, `existsSync`, `mkdirSync`, `unlinkSync`, `copyFileSync`) to async equivalents across all composite tools
- Convert `parseScene()` and `writeScene()` in `scene-parser.ts` to async
- Fix test for `writeScene` in `coverage-gaps.test.ts` to await async call

Consolidates changes from PRs #269, #277, #272, #271, #270, #266, #264, #263, #259, #253, #249.

## Test plan
- [x] `bun run check` passes (biome + tsc)
- [x] `bun run test` passes (635 pass, 1 skip, 0 fail)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)