### PR TITLE
feat: replace synchronous file I/O with asynchronous equivalents in project, help, and setup tools

### DIFF
--- a/src/tools/composite/help.ts
+++ b/src/tools/composite/help.ts
@@ -3,9 +3,10 @@
  * Loads docs from src/docs/*.md files
  */
 
-import { existsSync, readFileSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { formatSuccess, GodotMCPError } from '../helpers/errors.js'
+import { pathExists } from '../helpers/paths.js'
 
 const VALID_TOPICS = [
   'project',
@@ -32,7 +33,7 @@ type TopicName = (typeof VALID_TOPICS)[number]
 /**
  * Get the docs directory path
  */
-function getDocsDir(): string {
+async function getDocsDir(): Promise<string> {
   const candidates = [
     join(import.meta.dirname || '', '..', '..', 'docs'),
     // Bundled CLI at bin/cli.mjs -> ../src/docs/
@@ -42,7 +43,9 @@ function getDocsDir(): string {
   ]
 
   for (const candidate of candidates) {
-    if (existsSync(candidate)) return candidate
+    // Performance optimization: using async pathExists instead of existsSync
+    // to avoid blocking the Node.js event loop during I/O operations
+    if (await pathExists(candidate)) return candidate
   }
 
   return join(process.cwd(), 'src', 'docs')
@@ -51,12 +54,14 @@ function getDocsDir(): string {
 /**
  * Load documentation for a specific tool
  */
-function loadDoc(topic: string): string {
-  const docsDir = getDocsDir()
+async function loadDoc(topic: string): Promise<string> {
+  const docsDir = await getDocsDir()
   const docPath = join(docsDir, `${topic}.md`)
 
-  if (existsSync(docPath)) {
-    return readFileSync(docPath, 'utf-8')
+  // Performance optimization: using async file reading instead of sync
+  // to avoid blocking the Node.js event loop during I/O operations
+  if (await pathExists(docPath)) {
+    return await readFile(docPath, 'utf-8')
   }
 
   return `No documentation available for: ${topic}. This tool may not be implemented yet.`
@@ -69,6 +74,6 @@ export async function handleHelp(action: string, args: Record<string, unknown>) 
     throw new GodotMCPError(`Unknown tool: ${toolName}`, 'INVALID_ARGS', `Valid topics: ${VALID_TOPICS.join(', ')}`)
   }
 
-  const doc = loadDoc(toolName)
+  const doc = await loadDoc(toolName)
   return formatSuccess(doc)
 }

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -4,18 +4,19 @@
  */
 
 import { execFileSync } from 'node:child_process'
-import { existsSync } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { execGodotSync, runGodotProject } from '../../godot/headless.js'
 import type { GodotConfig, ProjectInfo } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
-import { safeResolve } from '../helpers/paths.js'
+import { pathExists, safeResolve } from '../helpers/paths.js'
 import { getSetting, parseProjectSettingsAsync, setSettingInContent } from '../helpers/project-settings.js'
 
 async function parseProjectGodot(projectPath: string): Promise<ProjectInfo> {
   const configPath = join(projectPath, 'project.godot')
-  if (!existsSync(configPath)) {
+  // Performance optimization: using async pathExists instead of existsSync
+  // to avoid blocking the Node.js event loop during I/O operations
+  if (!(await pathExists(configPath))) {
     throw new GodotMCPError(
       `No project.godot found at ${projectPath}`,
       'PROJECT_NOT_FOUND',
@@ -116,7 +117,9 @@ export async function handleProject(action: string, args: Record<string, unknown
         throw new GodotMCPError('No key specified', 'INVALID_ARGS', 'Provide key (e.g., "application/config/name").')
 
       const configPath = join(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
-      if (!existsSync(configPath))
+      // Performance optimization: using async pathExists instead of existsSync
+      // to avoid blocking the Node.js event loop during I/O operations
+      if (!(await pathExists(configPath)))
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')
 
       const settings = await parseProjectSettingsAsync(configPath)
@@ -134,7 +137,7 @@ export async function handleProject(action: string, args: Record<string, unknown
         throw new GodotMCPError('key and value required', 'INVALID_ARGS', 'Provide key and value.')
 
       const configPath = join(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
-      if (!existsSync(configPath))
+      if (!(await pathExists(configPath)))
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')
 
       const content = await readFile(configPath, 'utf-8')

--- a/src/tools/composite/setup.ts
+++ b/src/tools/composite/setup.ts
@@ -3,11 +3,11 @@
  * Actions: detect_godot | check
  */
 
-import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { detectGodot } from '../../godot/detector.js'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, throwUnknownAction } from '../helpers/errors.js'
+import { pathExists } from '../helpers/paths.js'
 
 export async function handleSetup(action: string, _args: Record<string, unknown>, config: GodotConfig) {
   switch (action) {
@@ -44,7 +44,9 @@ export async function handleSetup(action: string, _args: Record<string, unknown>
         project: projectPath
           ? {
               path: projectPath,
-              valid: existsSync(join(projectPath, 'project.godot')),
+              // Performance optimization: using async pathExists instead of existsSync
+              // to avoid blocking the Node.js event loop during I/O operations
+              valid: await pathExists(join(projectPath, 'project.godot')),
             }
           : { path: null },
       }

--- a/tests/composite/help.test.ts
+++ b/tests/composite/help.test.ts
@@ -1,15 +1,18 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { handleHelp } from '../../src/tools/composite/help.js'
 import { GodotMCPError } from '../../src/tools/helpers/errors.js'
+import { pathExists } from '../../src/tools/helpers/paths.js'
 
-// Mock node:fs
-vi.mock('node:fs', () => {
+// Mock node:fs/promises and paths helper
+vi.mock('node:fs/promises', () => {
   return {
-    existsSync: vi.fn(),
-    readFileSync: vi.fn(),
+    readFile: vi.fn(),
   }
 })
+vi.mock('../../src/tools/helpers/paths.js', () => ({
+  pathExists: vi.fn(),
+}))
 
 describe('handleHelp', () => {
   beforeEach(() => {
@@ -18,25 +21,25 @@ describe('handleHelp', () => {
 
   it('should return documentation for valid topic', async () => {
     // Mock valid documentation file
-    vi.mocked(existsSync).mockReturnValue(true)
-    vi.mocked(readFileSync).mockReturnValue('# Test Documentation')
+    vi.mocked(pathExists).mockResolvedValue(true)
+    vi.mocked(readFile).mockResolvedValue('# Test Documentation')
 
     const result = await handleHelp('project', {})
 
     expect(result.content[0].text).toContain('# Test Documentation')
-    expect(existsSync).toHaveBeenCalled()
-    expect(readFileSync).toHaveBeenCalled()
+    expect(pathExists).toHaveBeenCalled()
+    expect(readFile).toHaveBeenCalled()
   })
 
   it('should use tool_name from arguments if provided', async () => {
-    vi.mocked(existsSync).mockReturnValue(true)
-    vi.mocked(readFileSync).mockReturnValue('# Scenes Documentation')
+    vi.mocked(pathExists).mockResolvedValue(true)
+    vi.mocked(readFile).mockResolvedValue('# Scenes Documentation')
 
     const result = await handleHelp('help', { tool_name: 'scenes' })
 
     expect(result.content[0].text).toContain('# Scenes Documentation')
     // Verify it looked for scenes.md, not help.md
-    const calledPath = vi.mocked(readFileSync).mock.calls[0][0] as string
+    const calledPath = vi.mocked(readFile).mock.calls[0][0] as string
     expect(calledPath).toContain('scenes.md')
   })
 
@@ -47,7 +50,7 @@ describe('handleHelp', () => {
 
   it('should return fallback message if documentation file is missing', async () => {
     // Mock file not found
-    vi.mocked(existsSync).mockReturnValue(false)
+    vi.mocked(pathExists).mockResolvedValue(false)
 
     const result = await handleHelp('project', {})
 


### PR DESCRIPTION
💡 What: Replaced synchronous file system calls (`existsSync`, `readFileSync`) with their asynchronous counterparts (`await pathExists`, `await readFile`) in the `project`, `help`, and `setup` composite tools. Added a codebase-specific critical learning to `.jules/bolt.md`.

🎯 Why: To prevent operations in these heavily used tools from blocking the Node.js event loop. While micro-benchmarks show Promise overhead for small files, asynchronous I/O is necessary to maintain the overall responsiveness of the MCP server's event loop when handling concurrent client requests or when dealing with larger files and remote file systems. 

📊 Impact: Ensures the MCP server remains responsive to concurrent requests even during I/O operations from the `project`, `help`, and `setup` tools. 

🔬 Measurement: Verify that all tools continue to function correctly (passing tests) and that concurrent use cases aren't blocked by long-running file system reads.

---
*PR created automatically by Jules for task [9060766798377324499](https://jules.google.com/task/9060766798377324499) started by @n24q02m*