### PR TITLE
fix: fix path traversal in dynamically provided project paths

### DIFF
--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -117,7 +117,11 @@ function generateTscnContent(rootName: string, rootType: string): string {
 }
 
 function validateSceneArgs(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath || undefined
+  const baseDir = config.projectPath || process.cwd()
+  // Validate args.project_path against the trusted baseDir to prevent path traversal vulnerabilities
+  const projectPath = args.project_path
+    ? safeResolve(baseDir, args.project_path as string)
+    : config.projectPath || undefined
   const scenePath = args.scene_path as string
   const newPath = args.new_path as string
 

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -123,8 +123,9 @@ async function findScriptFiles(dir: string): Promise<string[]> {
 }
 
 export async function handleScripts(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath
   const baseDir = config.projectPath || process.cwd()
+  // Validate args.project_path against the trusted baseDir to prevent path traversal vulnerabilities
+  const projectPath = args.project_path ? safeResolve(baseDir, args.project_path as string) : config.projectPath
 
   if (!projectPath && action !== 'list') {
     // List handles missing projectPath internally, but others need it for safeResolve base


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Path traversal due to user-provided `args.project_path` being utilized as an unvalidated base path for resolving subsequent relative file paths in tools that can modify the file system (e.g., scripts, scenes). By providing an absolute path such as `/etc/` as `args.project_path`, a user could trick the tools into writing or reading arbitrary files outside the configured Godot project.
🎯 Impact: An attacker could perform arbitrary file read and write operations on the host filesystem.
🔧 Fix: Validated `args.project_path` against the trusted base directory (`config.projectPath || process.cwd()`) using `safeResolve` immediately when extracted.
✅ Verification: Ran `bun run test` and `bun run check`. Tests passed and behavior matches expected boundaries. Recorded findings to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [15929131040335692009](https://jules.google.com/task/15929131040335692009) started by @n24q02m*