### PR TITLE
fix: fix Overly Broad Process Termination

### DIFF
--- a/scripts/bench-scenes.ts
+++ b/scripts/bench-scenes.ts
@@ -10,7 +10,7 @@ async function runBench() {
   mkdirSync(tmpDir, { recursive: true })
 
   const scenePath = join(tmpDir, 'bench.tscn')
-  const config: GodotConfig = { projectPath: tmpDir, godotPath: 'godot', godotVersion: null }
+  const config: GodotConfig = { projectPath: tmpDir, godotPath: 'godot', godotVersion: null, activePids: [] }
 
   // Create a large scene file (10k nodes)
   const lines = ['[gd_scene format=3]', '[node name="Root" type="Node2D"]']

--- a/src/godot/types.ts
+++ b/src/godot/types.ts
@@ -20,6 +20,7 @@ export interface GodotConfig {
   godotPath: string | null
   godotVersion: GodotVersion | null
   projectPath: string | null
+  activePids: number[]
 }
 
 export interface HeadlessResult {

--- a/src/init-server.ts
+++ b/src/init-server.ts
@@ -49,6 +49,7 @@ export async function initServer(): Promise<void> {
     godotPath: detection?.path ?? null,
     godotVersion: detection?.version ?? null,
     projectPath: process.env.GODOT_PROJECT_PATH ?? null,
+    activePids: [],
   }
 
   // Create MCP server

--- a/src/tools/composite/editor.ts
+++ b/src/tools/composite/editor.ts
@@ -61,6 +61,9 @@ export async function handleEditor(action: string, args: Record<string, unknown>
       }
 
       const { pid } = launchGodotEditor(config.godotPath, safeResolve(config.projectPath || process.cwd(), projectPath))
+      if (pid) {
+        config.activePids.push(pid)
+      }
       return formatSuccess(`Godot editor launched (PID: ${pid})`)
     }
 

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -92,20 +92,33 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (!projectPath)
         throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
       const { pid } = runGodotProject(config.godotPath, safeResolve(config.projectPath || process.cwd(), projectPath))
+      if (pid) {
+        config.activePids.push(pid)
+      }
       return formatSuccess(`Godot project started (PID: ${pid})`)
     }
 
     case 'stop': {
-      try {
-        if (process.platform === 'win32') {
-          execFileSync('taskkill', ['/F', '/IM', 'godot.exe', '/T'], { stdio: 'pipe' })
-        } else {
-          execFileSync('pkill', ['-f', 'godot'], { stdio: 'pipe' })
-        }
-        return formatSuccess('Godot processes stopped')
-      } catch {
-        return formatSuccess('No running Godot processes found')
+      if (config.activePids.length === 0) {
+        return formatSuccess('No running Godot processes found (tracked by this server)')
       }
+
+      let stoppedCount = 0
+      for (const pid of config.activePids) {
+        try {
+          if (process.platform === 'win32') {
+            execFileSync('taskkill', ['/F', '/PID', pid.toString(), '/T'], { stdio: 'pipe' })
+          } else {
+            process.kill(pid, 'SIGTERM')
+          }
+          stoppedCount++
+        } catch {
+          // Process might have already terminated
+        }
+      }
+
+      config.activePids = []
+      return formatSuccess(`Godot processes stopped (Stopped ${stoppedCount} tracked processes)`)
     }
 
     case 'settings_get': {

--- a/tests/composite/project.test.ts
+++ b/tests/composite/project.test.ts
@@ -119,18 +119,24 @@ describe('project', () => {
   // ==========================================
   describe('stop', () => {
     it('should stop godot processes', async () => {
+      config.activePids = [1234]
+      const processKillSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+
       const result = await handleProject('stop', {}, config)
       expect(result.content[0].text).toContain('Godot processes stopped')
-      expect(execFileSync).toHaveBeenCalled()
+      if (process.platform === 'win32') {
+        expect(execFileSync).toHaveBeenCalled()
+      } else {
+        expect(processKillSpy).toHaveBeenCalledWith(1234, 'SIGTERM')
+      }
+      expect(config.activePids).toHaveLength(0)
+
+      processKillSpy.mockRestore()
     })
 
     it('should handle no running processes gracefully', async () => {
-      vi.mocked(execFileSync).mockImplementation(() => {
-        throw new Error('Command failed')
-      })
-
       const result = await handleProject('stop', {}, config)
-      expect(result.content[0].text).toContain('No running Godot processes found')
+      expect(result.content[0].text).toContain('No running Godot processes found (tracked by this server)')
     })
   })
 

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -170,6 +170,7 @@ export function makeConfig(overrides: Partial<GodotConfig> = {}): GodotConfig {
     godotPath: null,
     godotVersion: null,
     projectPath: null,
+    activePids: [],
     ...overrides,
   }
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `project stop` action uses `taskkill /IM godot.exe` (Windows) or `pkill -f godot` (Unix) to stop the project. This is a security vulnerability because it kills ALL Godot processes on the system, potentially terminating processes owned by other users or critical system services running under similar names.
🎯 Impact: Denial of Service (DoS) and potential data loss for users running other Godot instances or editors.
🔧 Fix: Added PID tracking to `GodotConfig` (`activePids: number[]`). PIDs are tracked when the server launches Godot via `runGodotProject` or `launchGodotEditor`. The `stop` action now iterates through `activePids` and selectively kills only those processes.
✅ Verification: Ran `bun run test` and `bun run check`. The tests for `project.test.ts` were updated to reflect the new targeted termination behavior and all tests pass.

---
*PR created automatically by Jules for task [5247921882967961753](https://jules.google.com/task/5247921882967961753) started by @n24q02m*