### PR TITLE
feat: testing improvement] Add tests for synchronous parseProjectSettings and writeProjectSettings

### DIFF
--- a/pr_desc.md
+++ b/pr_desc.md
@@ -1,0 +1,3 @@
+🎯 **What:** The testing gap for the synchronous `parseProjectSettings` and `writeProjectSettings` functions in `src/tools/helpers/project-settings.ts` has been addressed.
+📊 **Coverage:** Added tests utilizing `vi.mock('node:fs')` to mock file system reads and writes, verifying that the file paths and content encodings match expected behavior and correctly delegate to parsing.
+✨ **Result:** Enhanced test suite and coverage by catching errors during file I/O wrapper functions before moving into the actual `parseProjectSettingsContent` parser.

--- a/tests/helpers/project-settings-sync.test.ts
+++ b/tests/helpers/project-settings-sync.test.ts
@@ -1,0 +1,33 @@
+import * as fs from 'node:fs'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { parseProjectSettings, writeProjectSettings } from '../../src/tools/helpers/project-settings.js'
+
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}))
+
+describe('project-settings sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should parse project settings synchronously', () => {
+    const mockContent = '[application]\nconfig/name="Test"'
+    vi.mocked(fs.readFileSync).mockReturnValue(mockContent)
+
+    const settings = parseProjectSettings('project.godot')
+
+    expect(fs.readFileSync).toHaveBeenCalledWith('project.godot', 'utf-8')
+    expect(settings.sections.get('application')?.get('config/name')).toBe('"Test"')
+  })
+
+  it('should write project settings synchronously', () => {
+    const mockContent = 'some content'
+    vi.mocked(fs.writeFileSync).mockReturnValue(undefined)
+
+    writeProjectSettings('project.godot', mockContent)
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith('project.godot', mockContent, 'utf-8')
+  })
+})


### PR DESCRIPTION
🎯 **What:** The testing gap for the synchronous `parseProjectSettings` and `writeProjectSettings` functions in `src/tools/helpers/project-settings.ts` has been addressed.

📊 **Coverage:** Added tests utilizing `vi.mock('node:fs')` to mock file system reads and writes, verifying that the file paths and content encodings match expected behavior and correctly delegate to parsing.

✨ **Result:** Enhanced test suite and coverage by catching errors during file I/O wrapper functions before moving into the actual `parseProjectSettingsContent` parser.

---
*PR created automatically by Jules for task [11285460465344011928](https://jules.google.com/task/11285460465344011928) started by @n24q02m*