### PR TITLE
fix: high Fix Lack of Validation in Editor Process Query

### DIFF
--- a/src/tools/composite/editor.ts
+++ b/src/tools/composite/editor.ts
@@ -26,8 +26,13 @@ async function getGodotProcessesAsync(): Promise<Array<{ pid: string; name: stri
         .filter((line) => line.includes('godot'))
         .map((line) => {
           const parts = line.split(',').map((p) => p.replace(/"/g, '').trim())
-          return { pid: parts[1] || 'unknown', name: parts[0] || 'godot' }
+          const pidMatch = parts[1]?.match(/^\d+$/)
+          if (!pidMatch) return null
+
+          const name = parts[0] ? parts[0].replace(/[^\w.-]/g, '_') : 'godot'
+          return { pid: pidMatch[0], name }
         })
+        .filter((item): item is { pid: string; name: string } => item !== null)
     }
 
     const { stdout } = await execFileAsync('pgrep', ['-la', 'godot'], {
@@ -38,8 +43,17 @@ async function getGodotProcessesAsync(): Promise<Array<{ pid: string; name: stri
       .filter(Boolean)
       .map((line) => {
         const parts = line.trim().split(/\s+/)
-        return { pid: parts[0], name: parts.slice(1).join(' ') }
+        const pidMatch = parts[0]?.match(/^\d+$/)
+        if (!pidMatch) return null
+
+        const fullCmd = parts.slice(1).join(' ')
+        // Extract basic process name without path or arguments, sanitize to safe characters
+        const baseNameMatch = fullCmd.match(/([^/\\]+?)(?:\s|$)/)
+        const name = baseNameMatch ? baseNameMatch[1].replace(/[^\w.-]/g, '_') : 'godot'
+
+        return { pid: pidMatch[0], name }
       })
+      .filter((item): item is { pid: string; name: string } => item !== null)
   } catch {
     return []
   }


### PR DESCRIPTION
🎯 **What:** The output of `tasklist` and `pgrep` in the Editor `status` command lacked strict validation. If an attacker spun up a malicious process matching the "godot" filter, its unvalidated command-line representation could disrupt JSON serialization or spoof processes.
⚠️ **Risk:** Output Injection/Command Result Manipulation. Since the output JSON is read by the MCP client, malicious outputs could cause bugs or potentially arbitrary execution if the client improperly parses the response.
🛡️ **Solution:** Implemented regex strict matching for the PID `^\d+$` and character stripping for process names `[^\w.-]` to completely neutralize any potentially problematic process names before returning them via the status API.

---
*PR created automatically by Jules for task [13615559878481775340](https://jules.google.com/task/13615559878481775340) started by @n24q02m*