### PR TITLE
feat: non-blocking Godot execution in project actions

### DIFF
--- a/src/godot/headless.ts
+++ b/src/godot/headless.ts
@@ -2,10 +2,13 @@
  * Run Godot in headless mode for CLI operations
  */
 
-import { spawn, spawnSync } from 'node:child_process'
+import { execFile, spawn, spawnSync } from 'node:child_process'
+import { promisify } from 'node:util'
 import type { HeadlessResult } from './types.js'
 
 const DEFAULT_TIMEOUT_MS = 30_000
+
+const execFileAsync = promisify(execFile)
 
 /**
  * Execute a Godot command and capture output
@@ -38,6 +41,39 @@ export function execGodotSync(
     stdout: result.stdout?.trim() || '',
     stderr: result.stderr?.trim() || '',
     exitCode: 0,
+  }
+}
+
+/**
+ * Execute a Godot command asynchronously and capture output
+ */
+export async function execGodotAsync(
+  godotPath: string,
+  args: string[],
+  options?: { timeout?: number; cwd?: string },
+): Promise<HeadlessResult> {
+  const timeout = options?.timeout ?? DEFAULT_TIMEOUT_MS
+
+  try {
+    const { stdout, stderr } = await execFileAsync(godotPath, args, {
+      timeout,
+      cwd: options?.cwd,
+      encoding: 'utf-8',
+    })
+
+    return {
+      success: true,
+      stdout: stdout?.trim() || '',
+      stderr: stderr?.trim() || '',
+      exitCode: 0,
+    }
+  } catch (err: unknown) {
+    return {
+      success: false,
+      stdout: (err as { stdout?: string }).stdout?.trim() || '',
+      stderr: (err as { stderr?: string }).stderr?.trim() || (err as Error).message || 'Unknown error',
+      exitCode: (err as { code?: number }).code ?? 1,
+    }
   }
 }
 

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -7,7 +7,7 @@ import { execFileSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { execGodotSync, runGodotProject } from '../../godot/headless.js'
+import { execGodotAsync, runGodotProject } from '../../godot/headless.js'
 import type { GodotConfig, ProjectInfo } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
@@ -81,7 +81,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (!config.godotPath) {
         throw new GodotMCPError('Godot not found', 'GODOT_NOT_FOUND', 'Set GODOT_PATH env var or install Godot.')
       }
-      const result = execGodotSync(config.godotPath, ['--version'])
+      const result = await execGodotAsync(config.godotPath, ['--version'])
       return formatSuccess(`Godot version: ${result.stdout}`)
     }
 
@@ -160,7 +160,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       }
 
       const resolvedProjectPath = safeResolve(config.projectPath || process.cwd(), projectPath)
-      const result = execGodotSync(config.godotPath, [
+      const result = await execGodotAsync(config.godotPath, [
         '--headless',
         '--path',
         resolvedProjectPath,

--- a/tests/composite/project.test.ts
+++ b/tests/composite/project.test.ts
@@ -12,6 +12,7 @@ import { createTmpProject, makeConfig } from '../fixtures.js'
 
 // Mock headless execution
 vi.mock('../../src/godot/headless.js', () => ({
+  execGodotAsync: vi.fn().mockResolvedValue({ success: true, stdout: '', stderr: '', exitCode: 0 }),
   execGodotSync: vi.fn(),
   runGodotProject: vi.fn(),
 }))
@@ -21,7 +22,7 @@ vi.mock('node:child_process', () => ({
   execFileSync: vi.fn(),
 }))
 
-import { execGodotSync, runGodotProject } from '../../src/godot/headless.js'
+import { execGodotAsync, runGodotProject } from '../../src/godot/headless.js'
 
 describe('project', () => {
   let projectPath: string
@@ -78,11 +79,11 @@ describe('project', () => {
   // ==========================================
   describe('version', () => {
     it('should return godot version', async () => {
-      vi.mocked(execGodotSync).mockReturnValue({ stdout: '4.4.stable', stderr: '', exitCode: 0 })
+      vi.mocked(execGodotAsync).mockResolvedValue({ stdout: '4.4.stable', stderr: '', exitCode: 0 })
 
       const result = await handleProject('version', {}, config)
       expect(result.content[0].text).toContain('Godot version: 4.4.stable')
-      expect(execGodotSync).toHaveBeenCalledWith('/path/to/godot', ['--version'])
+      expect(execGodotAsync).toHaveBeenCalledWith('/path/to/godot', ['--version'])
     })
 
     it('should throw if godot not found', async () => {
@@ -230,7 +231,7 @@ describe('project', () => {
   // ==========================================
   describe('export', () => {
     it('should export project', async () => {
-      vi.mocked(execGodotSync).mockReturnValue({ stdout: 'Export successful', stderr: '', exitCode: 0 })
+      vi.mocked(execGodotAsync).mockResolvedValue({ stdout: 'Export successful', stderr: '', exitCode: 0 })
 
       const result = await handleProject(
         'export',
@@ -243,7 +244,7 @@ describe('project', () => {
       )
 
       expect(result.content[0].text).toContain('Export complete')
-      expect(execGodotSync).toHaveBeenCalledWith(
+      expect(execGodotAsync).toHaveBeenCalledWith(
         '/path/to/godot',
         expect.arrayContaining(['--export-release', 'Linux/X11']),
       )

--- a/tests/godot/headless-full.test.ts
+++ b/tests/godot/headless-full.test.ts
@@ -9,6 +9,7 @@ import { execGodotScript, execGodotSync, launchGodotEditor, runGodotProject } fr
 vi.mock('node:child_process', () => ({
   spawnSync: vi.fn(),
   spawn: vi.fn(),
+  execFile: vi.fn(),
 }))
 
 describe('headless', () => {

--- a/tests/godot/headless.test.ts
+++ b/tests/godot/headless.test.ts
@@ -7,6 +7,7 @@ vi.mock('node:child_process', () => {
   return {
     spawnSync: vi.fn(),
     spawn: vi.fn(),
+    execFile: vi.fn(),
   }
 })
 


### PR DESCRIPTION
💡 **What:** Implemented `execGodotAsync` in `src/godot/headless.ts` using `util.promisify(execFile)` and replaced blocking `execGodotSync` calls in `src/tools/composite/project.ts` (for `version` and `export` actions) with `await execGodotAsync`.

🎯 **Why:** To prevent the Node.js event loop from being blocked by long-running Godot CLI executions.

📊 **Measured Improvement:** Improved application responsiveness and concurrency by moving synchronous child process spawns to an asynchronous pattern. The event loop can now process other requests while Godot is executing.

---
*PR created automatically by Jules for task [14352624978652670151](https://jules.google.com/task/14352624978652670151) started by @n24q02m*