### PR TITLE
fix: add backslash to shell metacharacter blocklist

### DIFF
--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -39,12 +39,12 @@ export async function handleConfig(action: string, args: Record<string, unknown>
       // Validate paths don't contain shell metacharacters
       if (
         (key === 'project_path' || key === 'godot_path') &&
-        (typeof value !== 'string' || /[;&|`$(){}<>'"\0\n\r]/.test(value))
+        (typeof value !== 'string' || /[;&|`$(){}<>'"\\\0\n\r]/.test(value))
       ) {
         throw new GodotMCPError(
           `Invalid characters in ${key}`,
           'INVALID_ARGS',
-          'Path must not contain shell metacharacters: ; & | ` $ ( ) { } < > \' " \\0 \\n \\r',
+          'Path must not contain shell metacharacters: ; & | ` $ ( ) { } < > \' " \\ \\0 \\n \\r',
         )
       }
 

--- a/tests/composite/config.test.ts
+++ b/tests/composite/config.test.ts
@@ -139,6 +139,12 @@ describe('config', () => {
       ).rejects.toThrow('Invalid characters')
     })
 
+    it('should reject paths with backslash escape sequences', async () => {
+      await expect(
+        handleConfig('set', { key: 'godot_path', value: '/usr/bin/godot\\n--script' }, config),
+      ).rejects.toThrow('Invalid characters')
+    })
+
     it('should reject paths with newlines', async () => {
       await expect(
         handleConfig('set', { key: 'godot_path', value: '/usr/bin/godot\nrm -rf /' }, config),


### PR DESCRIPTION
## Summary
- Add backslash `\` to the shell metacharacter regex in `config.ts` path validation
- While the codebase uses `execFile`/`spawn` (not shell), this is defense-in-depth against escape sequence injection
- Add test case for backslash escape sequence in paths

Closes #299

## Test plan
- [x] Existing 646 tests pass
- [x] New test verifies backslash is rejected in path values
- [x] Pre-commit hooks (biome, tsc, vitest) all pass

Generated with [Claude Code](https://claude.com/claude-code)