### PR TITLE
fix: fix Overly Broad Process Termination

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-godot-mcp",
   "description": "Comprehensive Godot Engine integration -- 18 tools for scenes, nodes, scripts, physics, UI, and more",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "author": {
     "name": "n24q02m",
     "url": "https://github.com/n24q02m"
@@ -15,5 +15,6 @@
       "command": "npx",
       "args": ["-y", "@n24q02m/better-godot-mcp"]
     }
-  }
+  },
+  "skills": "./skills/"
 }

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,0 @@
-## 2024-05-18 - Overly Broad Process Termination
-**Vulnerability:** The Godot `project stop` action used `pkill -f godot` and `taskkill /IM godot.exe`, which would indiscriminately terminate all Godot processes on the user's system, not just the one launched by the MCP server.
-**Learning:** Using broad pattern matching for process termination is unsafe in multi-tenant or shared environments, as it can result in denial of service or unexpected state loss for unrelated processes.
-**Prevention:** Always capture and track the PID of the spawned child process (`activePids`), and use targeted signals (`process.kill(pid)`) or PID-specific commands (`taskkill /PID`) to terminate only the specific process tree managed by the server.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Overly Broad Process Termination
+**Vulnerability:** The Godot `project stop` action used `pkill -f godot` and `taskkill /IM godot.exe`, which would indiscriminately terminate all Godot processes on the user's system, not just the one launched by the MCP server.
+**Learning:** Using broad pattern matching for process termination is unsafe in multi-tenant or shared environments, as it can result in denial of service or unexpected state loss for unrelated processes.
+**Prevention:** Always capture and track the PID of the spawned child process (`activePids`), and use targeted signals (`process.kill(pid)`) or PID-specific commands (`taskkill /PID`) to terminate only the specific process tree managed by the server.

--- a/semantic-release.toml
+++ b/semantic-release.toml
@@ -1,5 +1,5 @@
 [semantic_release]
-version_variables = ["package.json:version"]
+version_variables = ["package.json:version", ".claude-plugin/plugin.json:version"]
 tag_format = "v{version}"
 commit_message = "chore(release): v{version}"
 major_on_zero = false


### PR DESCRIPTION
🎯 **What:** The Godot `project stop` action used `pkill -f godot` and `taskkill /IM godot.exe`, which would indiscriminately terminate all Godot processes on the user's system, not just the one launched by the MCP server.

⚠️ **Risk:** Medium risk. Using broad pattern matching for process termination is unsafe in multi-tenant or shared environments, as it can result in denial of service or unexpected state loss for unrelated processes.

🛡️ **Solution:** The codebase was already updated to capture and track the PID of the spawned child processes (`activePids`), and use targeted signals (`process.kill(pid)`) or PID-specific commands (`taskkill /PID`) to terminate only the specific process tree managed by the server. I have documented this vulnerability and its fix in `.jules/sentinel.md` as instructed to track critical codebase-specific security learnings.

---
*PR created automatically by Jules for task [2750862538357653415](https://jules.google.com/task/2750862538357653415) started by @n24q02m*