### PR TITLE
feat: code health] Refactor repetitive argument validation in navigation tool

### DIFF
--- a/src/tools/composite/navigation.ts
+++ b/src/tools/composite/navigation.ts
@@ -5,7 +5,7 @@
 
 import { readFile, writeFile } from 'node:fs/promises'
 import type { GodotConfig } from '../../godot/types.js'
-import { formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
+import { formatSuccess, GodotMCPError, requireArg, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
 
 async function resolveScene(projectPath: string | null | undefined, scenePath: string): Promise<string> {
@@ -27,8 +27,7 @@ export async function handleNavigation(action: string, args: Record<string, unkn
 
   switch (action) {
     case 'create_region': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const scenePath = requireArg(args, 'scene_path')
       const regionName = (args.name as string) || 'NavigationRegion3D'
       const parent = (args.parent as string) || '.'
       const dimension = (args.dimension as string) || '3D'
@@ -44,8 +43,7 @@ export async function handleNavigation(action: string, args: Record<string, unkn
     }
 
     case 'add_agent': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const scenePath = requireArg(args, 'scene_path')
       const agentName = (args.name as string) || 'NavigationAgent3D'
       const parent = (args.parent as string) || '.'
       const dimension = (args.dimension as string) || '3D'
@@ -67,8 +65,7 @@ export async function handleNavigation(action: string, args: Record<string, unkn
     }
 
     case 'add_obstacle': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      const scenePath = requireArg(args, 'scene_path')
       const obstacleName = (args.name as string) || 'NavigationObstacle3D'
       const parent = (args.parent as string) || '.'
       const dimension = (args.dimension as string) || '3D'

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -133,3 +133,15 @@ export function throwUnknownAction(action: string, validActions: string[]): neve
     `Valid actions: ${validActions.join(', ')}. Use help tool for full docs.`,
   )
 }
+
+/**
+ * Require a string argument from the provided arguments object.
+ * Throws a standardized INVALID_ARGS error if the argument is missing or not a string.
+ */
+export function requireArg(args: Record<string, unknown>, key: string): string {
+  const value = args[key]
+  if (!value || typeof value !== 'string') {
+    throw new GodotMCPError(`No ${key} specified`, 'INVALID_ARGS', `Provide ${key}.`)
+  }
+  return value
+}

--- a/tests/helpers/errors.test.ts
+++ b/tests/helpers/errors.test.ts
@@ -8,6 +8,7 @@ import {
   formatJSON,
   formatSuccess,
   GodotMCPError,
+  requireArg,
   withErrorHandling,
 } from '../../src/tools/helpers/errors.js'
 
@@ -138,5 +139,24 @@ describe('errors', () => {
       expect(result.isError).toBe(true)
       expect(result.content[0].text).toContain('EXECUTION_ERROR')
     })
+  })
+})
+
+describe('requireArg', () => {
+  it('should return the value if it is a string', () => {
+    const args = { foo: 'bar' }
+    expect(requireArg(args, 'foo')).toBe('bar')
+  })
+
+  it('should throw GodotMCPError if the argument is missing', () => {
+    const args = {}
+    expect(() => requireArg(args, 'foo')).toThrow(GodotMCPError)
+    expect(() => requireArg(args, 'foo')).toThrow('No foo specified')
+  })
+
+  it('should throw GodotMCPError if the argument is not a string', () => {
+    const args = { foo: 123 }
+    expect(() => requireArg(args, 'foo')).toThrow(GodotMCPError)
+    expect(() => requireArg(args, 'foo')).toThrow('No foo specified')
   })
 })


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was repeated argument validation logic in `src/tools/composite/navigation.ts`. I created a generic `requireArg` helper function in `src/tools/helpers/errors.ts` and refactored the `navigation` tool to use it for `scene_path` validation. I also included robust tests for `requireArg` in `tests/helpers/errors.test.ts`.

💡 **Why:** This improves maintainability and readability by abstracting boilerplate string argument validation out of tool action handlers, centralizing error formatting logic, and reducing code duplication.

✅ **Verification:** I ran code quality checks (`bun run check`), tests locally and on the full suite using `bun run test`, and everything passes. Test coverage was extended in `errors.test.ts` to fully cover the new `requireArg` function.

✨ **Result:** A more readable navigation tool handler codebase with a reusable helper argument checker that can optionally be adopted into other standard tools.

---
*PR created automatically by Jules for task [9941621953395521123](https://jules.google.com/task/9941621953395521123) started by @n24q02m*