### PR TITLE
feat: zero-env-config relay setup via mcp-relay-core

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@n24q02m/better-godot-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@n24q02m/mcp-relay-core": "file:../mcp-relay-core/packages/core-ts",
+        "@n24q02m/mcp-relay-core": "^0.1.0",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -120,7 +120,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
-    "@n24q02m/mcp-relay-core": ["@n24q02m/mcp-relay-core@file:../mcp-relay-core/packages/core-ts", { "dependencies": { "env-paths": "^3.0.0" }, "devDependencies": { "@biomejs/biome": "^2.4.8", "@types/node": "^24.12.0", "@vitest/coverage-v8": "^4.1.0", "typescript": "^5.9.3", "vitest": "^4.1.0" } }],
+    "@n24q02m/mcp-relay-core": ["@n24q02m/mcp-relay-core@0.1.0", "", { "dependencies": { "env-paths": "^3.0.0" } }, "sha512-uRo0q/VLtCMuK6qcOdM/ZvpyIVBnE4a9tAfdwjbV+f8aWTtB0dpPj0DHcsDI8gWTTTllOQ73akHbCFm0JuPPCg=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
@@ -481,9 +481,5 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
-
-    "@n24q02m/mcp-relay-core/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
-
-    "@n24q02m/mcp-relay-core/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@n24q02m/better-godot-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@n24q02m/mcp-relay-core": "file:../mcp-relay-core/packages/core-ts",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -119,6 +120,8 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
+    "@n24q02m/mcp-relay-core": ["@n24q02m/mcp-relay-core@file:../mcp-relay-core/packages/core-ts", { "dependencies": { "env-paths": "^3.0.0" }, "devDependencies": { "@biomejs/biome": "^2.4.8", "@types/node": "^24.12.0", "@vitest/coverage-v8": "^4.1.0", "typescript": "^5.9.3", "vitest": "^4.1.0" } }],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.120.0", "", {}, "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg=="],
@@ -228,6 +231,8 @@
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "env-paths": ["env-paths@3.0.0", "", {}, "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -476,5 +481,9 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+
+    "@n24q02m/mcp-relay-core/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
+
+    "@n24q02m/mcp-relay-core/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@n24q02m/mcp-relay-core": "file:../mcp-relay-core/packages/core-ts",
+    "@n24q02m/mcp-relay-core": "^0.1.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "@n24q02m/mcp-relay-core": "file:../mcp-relay-core/packages/core-ts",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/init-server.ts
+++ b/src/init-server.ts
@@ -15,6 +15,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { detectGodot } from './godot/detector.js'
 import type { GodotConfig } from './godot/types.js'
+import { ensureConfig } from './relay-setup.js'
 import { registerTools } from './tools/registry.js'
 
 const SERVER_NAME = 'better-godot-mcp'
@@ -44,11 +45,23 @@ export async function initServer(): Promise<void> {
     console.error(`[${SERVER_NAME}] Set GODOT_PATH env var or install Godot.`)
   }
 
-  // Build config
+  // Resolve project path: env var first, then relay config
+  let projectPath = process.env.GODOT_PROJECT_PATH ?? null
+  let godotPathOverride: string | null = null
+
+  if (!projectPath) {
+    const relayConfig = await ensureConfig()
+    if (relayConfig) {
+      projectPath = relayConfig.projectPath
+      godotPathOverride = relayConfig.godotPath
+    }
+  }
+
+  // Build config (relay godotPath override takes lowest priority vs detection)
   const config: GodotConfig = {
-    godotPath: detection?.path ?? null,
+    godotPath: detection?.path ?? godotPathOverride,
     godotVersion: detection?.version ?? null,
-    projectPath: process.env.GODOT_PROJECT_PATH ?? null,
+    projectPath,
     activePids: [],
   }
 

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -1,0 +1,33 @@
+/**
+ * Config schema for relay page setup.
+ *
+ * Defines fields for Godot MCP credential collection:
+ * - GODOT_PROJECT_PATH (required): path to Godot project directory
+ * - GODOT_PATH (optional): path to Godot binary (auto-detected if empty)
+ */
+
+import type { RelayConfigSchema } from '@n24q02m/mcp-relay-core/schema'
+
+export const RELAY_SCHEMA: RelayConfigSchema = {
+  server: 'better-godot-mcp',
+  displayName: 'Godot MCP',
+  fields: [
+    {
+      key: 'project_path',
+      label: 'Godot Project Path',
+      type: 'text',
+      placeholder: '/path/to/project',
+      helpText: 'Absolute path to your Godot project directory (containing project.godot)',
+      required: true,
+    },
+  ],
+  optional: [
+    {
+      key: 'godot_path',
+      label: 'Godot Binary Path',
+      type: 'text',
+      placeholder: '/usr/bin/godot4',
+      helpText: 'Leave empty for auto-detection. Only set if Godot is not on your PATH.',
+    },
+  ],
+}

--- a/src/relay-setup.test.ts
+++ b/src/relay-setup.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ensureConfig, parseRelayConfig } from './relay-setup.js'
+
+// Mock mcp-relay-core modules
+vi.mock('@n24q02m/mcp-relay-core/storage', () => ({
+  resolveConfig: vi.fn(),
+}))
+vi.mock('@n24q02m/mcp-relay-core/relay', () => ({
+  createSession: vi.fn(),
+  pollForResult: vi.fn(),
+}))
+vi.mock('@n24q02m/mcp-relay-core', () => ({
+  writeConfig: vi.fn(),
+}))
+
+import { writeConfig } from '@n24q02m/mcp-relay-core'
+import { createSession, pollForResult } from '@n24q02m/mcp-relay-core/relay'
+import { resolveConfig } from '@n24q02m/mcp-relay-core/storage'
+
+describe('parseRelayConfig', () => {
+  it('parses project_path only', () => {
+    const result = parseRelayConfig({ project_path: '/home/user/my-game' })
+    expect(result).toEqual({
+      projectPath: '/home/user/my-game',
+      godotPath: null,
+    })
+  })
+
+  it('parses project_path and godot_path', () => {
+    const result = parseRelayConfig({
+      project_path: '/home/user/my-game',
+      godot_path: '/usr/bin/godot4',
+    })
+    expect(result).toEqual({
+      projectPath: '/home/user/my-game',
+      godotPath: '/usr/bin/godot4',
+    })
+  })
+
+  it('treats empty godot_path as null', () => {
+    const result = parseRelayConfig({ project_path: '/path', godot_path: '' })
+    expect(result.godotPath).toBeNull()
+  })
+
+  it('throws when project_path is missing', () => {
+    expect(() => parseRelayConfig({ godot_path: '/usr/bin/godot4' })).toThrow('missing required field: project_path')
+  })
+
+  it('throws when project_path is empty', () => {
+    expect(() => parseRelayConfig({ project_path: '' })).toThrow('missing required field: project_path')
+  })
+})
+
+describe('ensureConfig', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns config from config file', async () => {
+    vi.mocked(resolveConfig).mockResolvedValue({
+      config: { project_path: '/home/user/game' },
+      source: 'file',
+    })
+
+    const result = await ensureConfig()
+
+    expect(result).toEqual({ projectPath: '/home/user/game', godotPath: null })
+    expect(resolveConfig).toHaveBeenCalledWith('better-godot-mcp', ['project_path'])
+    expect(createSession).not.toHaveBeenCalled()
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('loaded from file'))
+  })
+
+  it('returns config with godot_path from config file', async () => {
+    vi.mocked(resolveConfig).mockResolvedValue({
+      config: { project_path: '/home/user/game', godot_path: '/opt/godot/bin' },
+      source: 'file',
+    })
+
+    const result = await ensureConfig()
+
+    expect(result).toEqual({ projectPath: '/home/user/game', godotPath: '/opt/godot/bin' })
+  })
+
+  it('triggers relay when no config found and returns config', async () => {
+    vi.mocked(resolveConfig).mockResolvedValue({ config: null, source: null })
+    vi.mocked(createSession).mockResolvedValue({
+      sessionId: 'test-session',
+      keyPair: {} as unknown as CryptoKeyPair,
+      passphrase: 'word1-word2-word3-word4',
+      relayUrl: 'https://better-godot-mcp.n24q02m.com/setup?s=test-session#k=key&p=pass',
+    })
+    vi.mocked(pollForResult).mockResolvedValue({
+      project_path: '/home/user/new-game',
+    })
+
+    const result = await ensureConfig()
+
+    expect(result).toEqual({ projectPath: '/home/user/new-game', godotPath: null })
+    expect(createSession).toHaveBeenCalledWith(
+      'https://better-godot-mcp.n24q02m.com',
+      'better-godot-mcp',
+      expect.objectContaining({ server: 'better-godot-mcp' }),
+    )
+    expect(writeConfig).toHaveBeenCalledWith('better-godot-mcp', {
+      project_path: '/home/user/new-game',
+    })
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('saved successfully'))
+  })
+
+  it('returns null when relay server is unreachable', async () => {
+    vi.mocked(resolveConfig).mockResolvedValue({ config: null, source: null })
+    vi.mocked(createSession).mockRejectedValue(new Error('Connection refused'))
+
+    const result = await ensureConfig()
+
+    expect(result).toBeNull()
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Cannot reach relay server'))
+  })
+
+  it('returns null when relay setup times out', async () => {
+    vi.mocked(resolveConfig).mockResolvedValue({ config: null, source: null })
+    vi.mocked(createSession).mockResolvedValue({
+      sessionId: 'test-session',
+      keyPair: {} as unknown as CryptoKeyPair,
+      passphrase: 'word1-word2-word3-word4',
+      relayUrl: 'https://better-godot-mcp.n24q02m.com/setup?s=test',
+    })
+    vi.mocked(pollForResult).mockRejectedValue(new Error('Relay setup timed out'))
+
+    const result = await ensureConfig()
+
+    expect(result).toBeNull()
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('timed out'))
+  })
+
+  it('logs relay URL to stderr for user visibility', async () => {
+    vi.mocked(resolveConfig).mockResolvedValue({ config: null, source: null })
+    const relayUrl = 'https://better-godot-mcp.n24q02m.com/setup?s=abc#k=key&p=pass'
+    vi.mocked(createSession).mockResolvedValue({
+      sessionId: 'abc',
+      keyPair: {} as unknown as CryptoKeyPair,
+      passphrase: 'test',
+      relayUrl,
+    })
+    vi.mocked(pollForResult).mockResolvedValue({
+      project_path: '/tmp/game',
+    })
+
+    await ensureConfig()
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(relayUrl))
+  })
+})

--- a/src/relay-setup.ts
+++ b/src/relay-setup.ts
@@ -1,0 +1,93 @@
+/**
+ * Zero-env-config relay setup flow.
+ *
+ * When GODOT_PROJECT_PATH is not set, this module resolves config from the
+ * encrypted config file or triggers the relay page setup to collect the
+ * project path from the user via a browser-based form.
+ *
+ * Godot binary auto-detection is handled separately by detector.ts,
+ * so the relay primarily collects the project path.
+ */
+
+import { writeConfig } from '@n24q02m/mcp-relay-core'
+import { createSession, pollForResult } from '@n24q02m/mcp-relay-core/relay'
+import { resolveConfig } from '@n24q02m/mcp-relay-core/storage'
+import { RELAY_SCHEMA } from './relay-schema.js'
+
+const SERVER_NAME = 'better-godot-mcp'
+const DEFAULT_RELAY_URL = 'https://better-godot-mcp.n24q02m.com'
+const REQUIRED_FIELDS = ['project_path']
+
+export interface GodotRelayConfig {
+  projectPath: string
+  godotPath: string | null
+}
+
+/**
+ * Parse relay config into GodotRelayConfig.
+ *
+ * The relay returns { project_path, godot_path? }.
+ * This normalizes them for consumption by init-server.ts.
+ */
+export function parseRelayConfig(config: Record<string, string>): GodotRelayConfig {
+  const { project_path, godot_path } = config
+  if (!project_path) {
+    throw new Error('Relay config missing required field: project_path')
+  }
+  return {
+    projectPath: project_path,
+    godotPath: godot_path || null,
+  }
+}
+
+/**
+ * Resolve config or trigger relay setup.
+ *
+ * Resolution order:
+ * 1. Encrypted config file (~/.config/mcp/config.enc)
+ * 2. Relay setup (browser-based form via relay server)
+ *
+ * Returns GodotRelayConfig, or null if setup fails/times out.
+ *
+ * Note: Environment variables (GODOT_PROJECT_PATH, GODOT_PATH) are checked
+ * in init-server.ts before calling this function. This is only called when
+ * GODOT_PROJECT_PATH is not set via env.
+ */
+export async function ensureConfig(): Promise<GodotRelayConfig | null> {
+  // Check config file
+  const result = await resolveConfig(SERVER_NAME, REQUIRED_FIELDS)
+  if (result.config !== null) {
+    console.error(`[${SERVER_NAME}] Project config loaded from ${result.source}`)
+    return parseRelayConfig(result.config)
+  }
+
+  // No config found -- trigger relay setup
+  console.error(`[${SERVER_NAME}] No project path configured. Starting relay setup...`)
+
+  const relayUrl = DEFAULT_RELAY_URL
+  let session: Awaited<ReturnType<typeof createSession>>
+  try {
+    session = await createSession(relayUrl, SERVER_NAME, RELAY_SCHEMA)
+  } catch {
+    console.error(`[${SERVER_NAME}] Cannot reach relay server at ${relayUrl}. Set GODOT_PROJECT_PATH manually.`)
+    return null
+  }
+
+  // Log URL to stderr (visible to user in MCP client)
+  console.error(`\n[${SERVER_NAME}] Setup required. Open this URL to configure:\n${session.relayUrl}\n`)
+
+  // Poll for result
+  let config: Record<string, string>
+  try {
+    config = await pollForResult(relayUrl, session)
+  } catch {
+    console.error(`[${SERVER_NAME}] Relay setup timed out or session expired`)
+    return null
+  }
+
+  // Save to config file for future use
+  await writeConfig(SERVER_NAME, config)
+  console.error(`[${SERVER_NAME}] Project config saved successfully`)
+
+  return parseRelayConfig(config)
+}


### PR DESCRIPTION
## Summary

- Add `mcp-relay-core` dependency for zero-env-config credential setup
- When no credentials configured, server displays relay URL for browser-based setup
- Credentials encrypted E2E (ECDH P-256 + AES-256-GCM) -- relay never sees plaintext
- Config stored in `~/.config/mcp/config.enc` (encrypted at rest)
- Backward compatible: env vars still work as highest priority

## Changes

- `relay_schema.py` -- Config schema for relay page form
- `relay_setup.py` -- Config resolution + relay flow orchestration
- Modified server startup to integrate relay fallback
- Tests for all new code

## Related

- Core library: https://github.com/n24q02m/mcp-relay-core
- Design spec: https://github.com/n24q02m/mcp-relay-core/blob/main/docs/deployment-http.md

## Test plan

- [x] Existing tests pass
- [x] New relay setup tests pass
- [ ] Server starts normally with env vars (backward compat)
- [ ] Server starts without env vars -> shows relay URL

Generated with [Claude Code](https://claude.com/claude-code)