### PR TITLE
⚡ Bolt: Remove synchronous project settings file I/O

### DIFF
--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -8,7 +8,7 @@ import { join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
-import { parseProjectSettings, setSettingInContent } from '../helpers/project-settings.js'
+import { parseProjectSettingsAsync, setSettingInContent } from '../helpers/project-settings.js'
 import { escapeRegExp } from '../helpers/scene-parser.js'
 
 export async function handlePhysics(action: string, args: Record<string, unknown>, config: GodotConfig) {
@@ -21,7 +21,9 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       if (!(await pathExists(configPath)))
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify project path.')
 
-      const settings = parseProjectSettings(configPath)
+      // Performance optimization: using async file reading instead of sync
+      // to avoid blocking the Node.js event loop during I/O operations
+      const settings = await parseProjectSettingsAsync(configPath)
       const layers2d: Record<string, string> = {}
       const layers3d: Record<string, string> = {}
 

--- a/src/tools/helpers/project-settings.ts
+++ b/src/tools/helpers/project-settings.ts
@@ -7,20 +7,11 @@
  * key/subkey=value
  */
 
-import { readFileSync, writeFileSync } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
 
 export interface ProjectSettings {
   sections: Map<string, Map<string, string>>
   raw: string
-}
-
-/**
- * Parse project.godot file
- */
-export function parseProjectSettings(filePath: string): ProjectSettings {
-  const raw = readFileSync(filePath, 'utf-8')
-  return parseProjectSettingsContent(raw)
 }
 
 /**
@@ -160,13 +151,6 @@ export function setSettingInContent(content: string, path: string, value: string
   }
 
   return result.join('\n')
-}
-
-/**
- * Write project settings back to file
- */
-export function writeProjectSettings(filePath: string, content: string): void {
-  writeFileSync(filePath, content, 'utf-8')
 }
 
 /**

--- a/tests/helpers/coverage-gaps.test.ts
+++ b/tests/helpers/coverage-gaps.test.ts
@@ -6,10 +6,7 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import {
-  parseProjectSettingsContent,
-  setSettingInContent,
-} from '../../src/tools/helpers/project-settings.js'
+import { parseProjectSettingsContent, setSettingInContent } from '../../src/tools/helpers/project-settings.js'
 import { parseSceneContent, setNodePropertyInContent, writeScene } from '../../src/tools/helpers/scene-parser.js'
 
 describe('project-settings additional coverage', () => {
@@ -64,7 +61,6 @@ describe('project-settings additional coverage', () => {
       expect(result).toBe(content)
     })
   })
-
 
   describe('parseProjectSettingsContent edge cases', () => {
     it('should skip lines without equals sign', () => {

--- a/tests/helpers/coverage-gaps.test.ts
+++ b/tests/helpers/coverage-gaps.test.ts
@@ -9,7 +9,6 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   parseProjectSettingsContent,
   setSettingInContent,
-  writeProjectSettings,
 } from '../../src/tools/helpers/project-settings.js'
 import { parseSceneContent, setNodePropertyInContent, writeScene } from '../../src/tools/helpers/scene-parser.js'
 
@@ -66,14 +65,6 @@ describe('project-settings additional coverage', () => {
     })
   })
 
-  describe('writeProjectSettings', () => {
-    it('should write content to file', () => {
-      const filePath = join(tmpDir, 'project.godot')
-      writeProjectSettings(filePath, '[application]\nconfig/name="Test"\n')
-      const { readFileSync } = require('node:fs') as typeof import('node:fs')
-      expect(readFileSync(filePath, 'utf-8')).toContain('config/name="Test"')
-    })
-  })
 
   describe('parseProjectSettingsContent edge cases', () => {
     it('should skip lines without equals sign', () => {

--- a/tests/helpers/project-settings.test.ts
+++ b/tests/helpers/project-settings.test.ts
@@ -2,22 +2,14 @@
  * Tests for project.godot settings parser and manipulation
  */
 
-import * as fs from 'node:fs'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   getInputActions,
   getSetting,
-  parseProjectSettings,
   parseProjectSettingsContent,
   setSettingInContent,
-  writeProjectSettings,
 } from '../../src/tools/helpers/project-settings.js'
 import { SAMPLE_PROJECT_GODOT } from '../fixtures.js'
-
-vi.mock('node:fs', () => ({
-  readFileSync: vi.fn(),
-  writeFileSync: vi.fn(),
-}))
 
 describe('project-settings', () => {
   beforeEach(() => {
@@ -191,35 +183,6 @@ describe('project-settings', () => {
       const settings = parseProjectSettingsContent('[application]\nconfig/name="Test"\n')
       const actions = getInputActions(settings)
       expect(actions.size).toBe(0)
-    })
-  })
-
-  // ==========================================
-  // parseProjectSettings
-  // ==========================================
-  describe('parseProjectSettings', () => {
-    it('should parse project settings synchronously', () => {
-      const mockContent = '[application]\nconfig/name="Test"'
-      vi.mocked(fs.readFileSync).mockReturnValue(mockContent)
-
-      const settings = parseProjectSettings('project.godot')
-
-      expect(fs.readFileSync).toHaveBeenCalledWith('project.godot', 'utf-8')
-      expect(settings.sections.get('application')?.get('config/name')).toBe('"Test"')
-    })
-  })
-
-  // ==========================================
-  // writeProjectSettings
-  // ==========================================
-  describe('writeProjectSettings', () => {
-    it('should write project settings synchronously', () => {
-      const mockContent = 'some content'
-      vi.mocked(fs.writeFileSync).mockReturnValue(undefined)
-
-      writeProjectSettings('project.godot', mockContent)
-
-      expect(fs.writeFileSync).toHaveBeenCalledWith('project.godot', mockContent, 'utf-8')
     })
   })
 })


### PR DESCRIPTION
💡 What: Removed synchronous `readFileSync` and `writeFileSync` implementations for `project.godot` parsing (`parseProjectSettings` and `writeProjectSettings`) and migrated remaining callers to use asynchronous counterparts (`parseProjectSettingsAsync`).

🎯 Why: Reading and writing the `project.godot` file synchronously blocks the Node.js main event loop. For large Godot projects with extensive settings or under heavy concurrent request load from the MCP server, this can cause significant latency spikes.

📊 Impact: Eliminates a major source of main-thread blocking during physics tool operations. Improves overall MCP server responsiveness and concurrency by allowing other requests to process while file I/O occurs.

🔬 Measurement: Verify by running concurrent `physics` tool calls or handling large `project.godot` files. The event loop should no longer stall during the `parseProjectSettings` phase. Tests passing confirms no functional regression.

---
*PR created automatically by Jules for task [14646697695601216647](https://jules.google.com/task/14646697695601216647) started by @n24q02m*