### PR TITLE
[CLEANUP] Unused Function: getInputActions

### DIFF
--- a/src/tools/helpers/project-settings.ts
+++ b/src/tools/helpers/project-settings.ts
@@ -159,17 +159,3 @@ export function setSettingInContent(content: string, path: string, value: string
 export async function writeProjectSettingsAsync(filePath: string, content: string): Promise<void> {
   await writeFile(filePath, content, 'utf-8')
 }
-
-/**
- * Get all input actions from project settings
- */
-export function getInputActions(settings: ProjectSettings): Map<string, string> {
-  const actions = new Map<string, string>()
-  const inputSection = settings.sections.get('input')
-  if (inputSection) {
-    for (const [key, value] of inputSection) {
-      actions.set(key, value)
-    }
-  }
-  return actions
-}

--- a/tests/helpers/project-settings.test.ts
+++ b/tests/helpers/project-settings.test.ts
@@ -4,7 +4,6 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
-  getInputActions,
   getSetting,
   parseProjectSettingsContent,
   setSettingInContent,
@@ -166,23 +165,6 @@ describe('project-settings', () => {
       const original = SAMPLE_PROJECT_GODOT
       const result = setSettingInContent(original, 'noslash', 'value')
       expect(result).toBe(original)
-    })
-  })
-
-  // ==========================================
-  // getInputActions
-  // ==========================================
-  describe('getInputActions', () => {
-    it('should extract input actions', () => {
-      const settings = parseProjectSettingsContent(SAMPLE_PROJECT_GODOT)
-      const actions = getInputActions(settings)
-      expect(actions.size).toBeGreaterThan(0)
-    })
-
-    it('should return empty map when no input section', () => {
-      const settings = parseProjectSettingsContent('[application]\nconfig/name="Test"\n')
-      const actions = getInputActions(settings)
-      expect(actions.size).toBe(0)
     })
   })
 })


### PR DESCRIPTION
Removed the unused `getInputActions` function from `src/tools/helpers/project-settings.ts` and its associated tests in `tests/helpers/project-settings.test.ts`. The function was redundant as more specific parsing is implemented in `src/tools/composite/input-map.ts`. Verified the changes by running `bun run check` and the full test suite.

---
*PR created automatically by Jules for task [18010305885544668420](https://jules.google.com/task/18010305885544668420) started by @n24q02m*