### PR TITLE
🧹 [CLEANUP] Unused Function: writeProjectSettingsAsync

### DIFF
--- a/src/tools/helpers/project-settings.ts
+++ b/src/tools/helpers/project-settings.ts
@@ -7,7 +7,7 @@
  * key/subkey=value
  */
 
-import { readFile, writeFile } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 
 export interface ProjectSettings {
   sections: Map<string, Map<string, string>>
@@ -151,13 +151,6 @@ export function setSettingInContent(content: string, path: string, value: string
   }
 
   return result.join('\n')
-}
-
-/**
- * Write project settings back to file asynchronously
- */
-export async function writeProjectSettingsAsync(filePath: string, content: string): Promise<void> {
-  await writeFile(filePath, content, 'utf-8')
 }
 
 /**

--- a/tests/helpers/project-settings-async.test.ts
+++ b/tests/helpers/project-settings-async.test.ts
@@ -1,10 +1,9 @@
 import * as fsPromises from 'node:fs/promises'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { parseProjectSettingsAsync, writeProjectSettingsAsync } from '../../src/tools/helpers/project-settings.js'
+import { parseProjectSettingsAsync } from '../../src/tools/helpers/project-settings.js'
 
 vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
-  writeFile: vi.fn(),
 }))
 
 describe('project-settings async', () => {
@@ -22,26 +21,10 @@ describe('project-settings async', () => {
     expect(settings.sections.get('application')?.get('config/name')).toBe('"Test"')
   })
 
-  it('should write project settings asynchronously', async () => {
-    const mockContent = 'some content'
-    vi.mocked(fsPromises.writeFile).mockResolvedValue(undefined)
-
-    await writeProjectSettingsAsync('project.godot', mockContent)
-
-    expect(fsPromises.writeFile).toHaveBeenCalledWith('project.godot', mockContent, 'utf-8')
-  })
-
   it('should propagate readFile errors', async () => {
     const error = new Error('File not found')
     vi.mocked(fsPromises.readFile).mockRejectedValue(error)
 
     await expect(parseProjectSettingsAsync('missing.godot')).rejects.toThrow('File not found')
-  })
-
-  it('should propagate writeFile errors', async () => {
-    const error = new Error('Permission denied')
-    vi.mocked(fsPromises.writeFile).mockRejectedValue(error)
-
-    await expect(writeProjectSettingsAsync('readonly.godot', 'content')).rejects.toThrow('Permission denied')
   })
 })


### PR DESCRIPTION
Removed the unused `writeProjectSettingsAsync` function and its associated `writeFile` import from `src/tools/helpers/project-settings.ts`.
Also removed corresponding unit tests and unused mocks from `tests/helpers/project-settings-async.test.ts`.

🎯 What: Removed unused code and tests.
💡 Why: Maintainability improvement and code cleanup.
✅ Verification: Ran full test suite (`bun run test`) and project checks (`bun run check`). All 648 tests passed.
✨ Result: Cleaner codebase with no unused utilities.

---
*PR created automatically by Jules for task [15971822865638654196](https://jules.google.com/task/15971822865638654196) started by @n24q02m*