### PR TITLE
🧹 [CLEANUP] Unused Function: execGodotScript

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,11 @@
 **Vulnerability:** The `editor status` action used raw shell commands (`pgrep` and `tasklist`) through `execFile` to find Godot processes. It parsed the untrusted string output using regular expressions to extract PIDs.
 **Learning:** Using system tools to globally query processes and manually parsing string output is brittle and exposes the system to potential injection or parsing bugs, especially if malicious process names are introduced or if regexes are loosely bounded.
 **Prevention:** Instead of querying global system state via shell commands, track process lifecycles internally (e.g., `config.activePids`) when launched by the tool. To verify their existence, use safe OS-level APIs like `process.kill(pid, 0)`, which tests process existence synchronously without relying on parsing string output or shelling out to external commands.
+## 2026-04-02 - [CLEANUP] Unused Function: execGodotScript
+**Vulnerability:** Code bloat/maintenance overhead.
+**Learning:**  was a thin wrapper over  that constructed specific Godot arguments for headless script execution, but it was not used anywhere in the codebase (except in some documentation/plans and its own tests).
+**Prevention:** Regularly audit exports and remove unused functions to keep the codebase lean and reduce the surface area for bugs and security issues.
+## 2026-04-02 - [CLEANUP] Unused Function: execGodotScript
+**Vulnerability:** Maintenance overhead.
+**Learning:** Unused internal helpers can be safely removed to simplify the codebase.
+**Prevention:** Regular code cleanup.

--- a/docs/superpowers/plans/2026-03-31-stable-release.md
+++ b/docs/superpowers/plans/2026-03-31-stable-release.md
@@ -182,7 +182,7 @@ Add these tests to `tests/godot/headless-full.test.ts` inside the existing `desc
 
 ```typescript
 // Add to imports at top of file:
-import { execGodotAsync, execGodotScript, execGodotSync, launchGodotEditor, runGodotProject } from '../../src/godot/headless.js'
+import { execGodotAsync, execGodotSync, launchGodotEditor, runGodotProject } from '../../src/godot/headless.js'
 
 // Add new describe block after the existing launchGodotEditor describe:
 
@@ -300,7 +300,7 @@ Expected: New tests should fail because `execGodotAsync` is not yet imported in 
 The import line in `tests/godot/headless-full.test.ts` at line 7 already imports `execGodotSync` but not `execGodotAsync`. Update it:
 
 ```typescript
-import { execGodotAsync, execGodotScript, execGodotSync, launchGodotEditor, runGodotProject } from '../../src/godot/headless.js'
+import { execGodotAsync, execGodotSync, launchGodotEditor, runGodotProject } from '../../src/godot/headless.js'
 ```
 
 Also ensure `execFile` is in the mock at line 9-13:

--- a/src/godot/headless.ts
+++ b/src/godot/headless.ts
@@ -78,24 +78,6 @@ export async function execGodotAsync(
 }
 
 /**
- * Execute a Godot headless script and capture JSON output
- */
-export function execGodotScript(
-  godotPath: string,
-  scriptPath: string,
-  projectPath: string,
-  args?: string[],
-  options?: { timeout?: number },
-): HeadlessResult {
-  const godotArgs = ['--headless', '--path', projectPath, '--script', scriptPath]
-  if (args) {
-    godotArgs.push('--', ...args)
-  }
-
-  return execGodotSync(godotPath, godotArgs, options)
-}
-
-/**
  * Run Godot project (non-blocking)
  */
 export function runGodotProject(godotPath: string, projectPath: string): { pid: number | undefined } {

--- a/tests/godot/headless-full.test.ts
+++ b/tests/godot/headless-full.test.ts
@@ -1,16 +1,10 @@
 /**
- * Tests for headless.ts - execGodotScript, runGodotProject, launchGodotEditor
+ * Tests for headless.ts - runGodotProject, launchGodotEditor
  */
 
 import * as child_process from 'node:child_process'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import {
-  execGodotAsync,
-  execGodotScript,
-  execGodotSync,
-  launchGodotEditor,
-  runGodotProject,
-} from '../../src/godot/headless.js'
+import { execGodotAsync, execGodotSync, launchGodotEditor, runGodotProject } from '../../src/godot/headless.js'
 
 // execFileAsyncMock is hoisted so it is available inside the vi.mock factory.
 // We attach it as [promisify.custom] on execFile so that promisify(execFile)
@@ -42,7 +36,14 @@ describe('headless', () => {
   // ==========================================
   describe('execGodotSync', () => {
     it('should use default timeout when not specified', () => {
-      vi.mocked(child_process.spawnSync).mockReturnValue({ stdout: 'output', stderr: '', status: 0 })
+      vi.mocked(child_process.spawnSync).mockReturnValue({
+        stdout: 'output',
+        stderr: '',
+        status: 0,
+        output: [],
+        pid: 0,
+        signal: null,
+      })
       const result = execGodotSync('/usr/bin/godot', ['--version'])
       expect(result.success).toBe(true)
       expect(child_process.spawnSync).toHaveBeenCalledWith(
@@ -53,12 +54,15 @@ describe('headless', () => {
     })
 
     it('should handle error without status (fallback to 1)', () => {
-      const error = new Error('Timeout')
+      const error = new Error('Timeout') as Error & { status?: number; stdout?: string; stderr?: string }
       vi.mocked(child_process.spawnSync).mockReturnValue({
         error,
         status: error.status ?? 1,
         stdout: error.stdout ?? '',
         stderr: error.stderr ?? '',
+        output: [],
+        pid: 0,
+        signal: null,
       })
       const result = execGodotSync('/usr/bin/godot', ['--version'])
       expect(result.success).toBe(false)
@@ -67,70 +71,22 @@ describe('headless', () => {
     })
 
     it('should handle error with empty stdout/stderr', () => {
-      const error = new Error('fail')
+      const error = new Error('fail') as Error & { status?: number; stdout?: string; stderr?: string }
       Object.assign(error, { status: 2, stdout: '', stderr: '' })
       vi.mocked(child_process.spawnSync).mockReturnValue({
         error,
         status: error.status ?? 1,
         stdout: error.stdout ?? '',
         stderr: error.stderr ?? '',
+        output: [],
+        pid: 0,
+        signal: null,
       })
       const result = execGodotSync('/usr/bin/godot', ['--version'])
       expect(result.success).toBe(false)
       expect(result.stdout).toBe('')
       expect(result.stderr).toBe('fail')
       expect(result.exitCode).toBe(2)
-    })
-  })
-
-  // ==========================================
-  // execGodotScript
-  // ==========================================
-  describe('execGodotScript', () => {
-    it('should construct correct args for headless script execution', () => {
-      vi.mocked(child_process.spawnSync).mockReturnValue({ stdout: 'script output', stderr: '', status: 0 })
-      const result = execGodotScript('/usr/bin/godot', '/tmp/script.gd', '/tmp/project')
-      expect(result.success).toBe(true)
-      expect(result.stdout).toBe('script output')
-      expect(child_process.spawnSync).toHaveBeenCalledWith(
-        '/usr/bin/godot',
-        ['--headless', '--path', '/tmp/project', '--script', '/tmp/script.gd'],
-        expect.anything(),
-      )
-    })
-
-    it('should append extra args after -- separator', () => {
-      vi.mocked(child_process.spawnSync).mockReturnValue({ stdout: 'result', stderr: '', status: 0 })
-      execGodotScript('/usr/bin/godot', '/tmp/script.gd', '/tmp/project', ['--arg1', '--arg2'])
-      expect(child_process.spawnSync).toHaveBeenCalledWith(
-        '/usr/bin/godot',
-        ['--headless', '--path', '/tmp/project', '--script', '/tmp/script.gd', '--', '--arg1', '--arg2'],
-        expect.anything(),
-      )
-    })
-
-    it('should pass timeout option', () => {
-      vi.mocked(child_process.spawnSync).mockReturnValue({ stdout: 'result', stderr: '', status: 0 })
-      execGodotScript('/usr/bin/godot', '/tmp/script.gd', '/tmp/project', undefined, { timeout: 5000 })
-      expect(child_process.spawnSync).toHaveBeenCalledWith(
-        '/usr/bin/godot',
-        ['--headless', '--path', '/tmp/project', '--script', '/tmp/script.gd'],
-        expect.objectContaining({ timeout: 5000 }),
-      )
-    })
-
-    it('should handle script execution errors', () => {
-      const error = new Error('Script error')
-      Object.assign(error, { status: 1, stdout: '', stderr: 'GDScript error' })
-      vi.mocked(child_process.spawnSync).mockReturnValue({
-        error,
-        status: error.status ?? 1,
-        stdout: error.stdout ?? '',
-        stderr: error.stderr ?? '',
-      })
-      const result = execGodotScript('/usr/bin/godot', '/tmp/script.gd', '/tmp/project')
-      expect(result.success).toBe(false)
-      expect(result.stderr).toBe('GDScript error')
     })
   })
 


### PR DESCRIPTION
🎯 What: Removed the unused `execGodotScript` function from `src/godot/headless.ts` and its associated unit tests in `tests/godot/headless-full.test.ts`. Also updated `docs/superpowers/plans/2026-03-31-stable-release.md` which had some historical code snippets importing it.

💡 Why: This function was a thin wrapper over `execGodotSync` for headless script execution, but it was not used anywhere in the actual server codebase. Removing it reduces maintenance overhead and simplifies the `headless.ts` module.

✅ Verification: 
1. Ran `bun run check` to verify formatting (Biome), linting, and TypeScript type checks.
2. Ran `bun run test` to execute the full test suite (646 tests passed).
3. Verified that `tests/godot/headless-full.test.ts` still passes and now uses safer type casting to satisfy Biome's `noExplicitAny` rule.

✨ Result: Cleaner codebase with no unused exported functions in the Godot execution module.

---
*PR created automatically by Jules for task [5573549147079445118](https://jules.google.com/task/5573549147079445118) started by @n24q02m*