### PR TITLE
[CLEANUP] Unused Function: getNodePath

### DIFF
--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -253,15 +253,6 @@ export function findNode(scene: ParsedScene, name: string): SceneNodeInfo | unde
 }
 
 /**
- * Get the full node path for a node
- */
-export function getNodePath(_scene: ParsedScene, node: SceneNodeInfo): string {
-  if (!node.parent) return node.name // Root node
-  if (node.parent === '.') return node.name
-  return `${node.parent}/${node.name}`
-}
-
-/**
  * Remove a node from scene content by name
  */
 export function removeNodeFromContent(content: string, nodeName: string): string {

--- a/tests/helpers/scene-parser.test.ts
+++ b/tests/helpers/scene-parser.test.ts
@@ -5,7 +5,6 @@
 import { describe, expect, it } from 'vitest'
 import {
   findNode,
-  getNodePath,
   getNodeProperty,
   parseSceneContent,
   removeNodeFromContent,
@@ -152,31 +151,6 @@ describe('scene-parser', () => {
     it('should return undefined for missing node', () => {
       const scene = parseSceneContent(COMPLEX_TSCN)
       expect(findNode(scene, 'NonExistent')).toBeUndefined()
-    })
-  })
-
-  // ==========================================
-  // getNodePath
-  // ==========================================
-  describe('getNodePath', () => {
-    it('should return name for root node (no parent)', () => {
-      const scene = parseSceneContent(COMPLEX_TSCN)
-      const root = scene.nodes[0]
-      expect(getNodePath(scene, root)).toBe('Player')
-    })
-
-    it('should return name for direct child (parent=".")', () => {
-      const scene = parseSceneContent(COMPLEX_TSCN)
-      const sprite = scene.nodes.find((n) => n.name === 'Sprite')
-      if (!sprite) throw new Error('Sprite node not found')
-      expect(getNodePath(scene, sprite)).toBe('Sprite')
-    })
-
-    it('should return full path for nested node', () => {
-      const scene = parseSceneContent(COMPLEX_TSCN)
-      const label = scene.nodes.find((n) => n.name === 'Label')
-      if (!label) throw new Error('Label node not found')
-      expect(getNodePath(scene, label)).toBe('UI/Label')
     })
   })
 


### PR DESCRIPTION
Removed the unused \`getNodePath\` function and its associated JSDoc from \`src/tools/helpers/scene-parser.ts\`. Also removed the corresponding tests from \`tests/helpers/scene-parser.test.ts\`. Verified with \`bun run check\` and \`bun run test\`.

---
*PR created automatically by Jules for task [17490046637943219298](https://jules.google.com/task/17490046637943219298) started by @n24q02m*