### PR TITLE
[CLEANUP] Unused Function: writeScene

### DIFF
--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -11,7 +11,7 @@
  * [connection signal="..." from="..." to="..." method="..."]
  */
 
-import { readFile, writeFile } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 
 // Pre-compiled regular expressions for parsing scene sections
 const rxGdSceneFormat = /format=(\d+)/
@@ -415,11 +415,4 @@ export function setNodePropertyInContent(content: string, nodeName: string, prop
 export function getNodeProperty(scene: ParsedScene, nodeName: string, property: string): string | undefined {
   const node = findNode(scene, nodeName)
   return node?.properties[property]
-}
-
-/**
- * Write a parsed scene back to file (using raw content)
- */
-export async function writeScene(filePath: string, content: string): Promise<void> {
-  await writeFile(filePath, content, 'utf-8')
 }

--- a/tests/helpers/coverage-gaps.test.ts
+++ b/tests/helpers/coverage-gaps.test.ts
@@ -7,7 +7,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { parseProjectSettingsContent, setSettingInContent } from '../../src/tools/helpers/project-settings.js'
-import { parseSceneContent, setNodePropertyInContent, writeScene } from '../../src/tools/helpers/scene-parser.js'
+import { parseSceneContent, setNodePropertyInContent } from '../../src/tools/helpers/scene-parser.js'
 
 describe('project-settings additional coverage', () => {
   let tmpDir: string
@@ -146,15 +146,6 @@ radius = 16.0`
       const content = `[gd_scene format=3]\n[node name="Root" type="Node2D"]\n`
       const result = setNodePropertyInContent(content, 'Root', 'visible', 'false')
       expect(result).toContain('visible = false')
-    })
-  })
-
-  describe('writeScene', () => {
-    it('should write scene content to file', async () => {
-      const filePath = join(tmpDir, 'test.tscn')
-      await writeScene(filePath, '[gd_scene format=3]\n[node name="Root" type="Node2D"]\n')
-      const { readFileSync } = require('node:fs') as typeof import('node:fs')
-      expect(readFileSync(filePath, 'utf-8')).toContain('name="Root"')
     })
   })
 })


### PR DESCRIPTION
This PR removes the unused writeScene helper function from src/tools/helpers/scene-parser.ts and its associated tests in tests/helpers/coverage-gaps.test.ts. This cleanup improves code maintainability by removing dead code.

Verification:
- Grepped for any remaining usage of writeScene: None found.
- Grepped for writeFile in src/tools/helpers/scene-parser.ts: Confirmed removed.
- Ran bun run check: All linting and type checks passed.
- Ran bun run test: All 649 tests passed.

---
*PR created automatically by Jules for task [1895412475678328434](https://jules.google.com/task/1895412475678328434) started by @n24q02m*