### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix INI injection vulnerabilities

### DIFF
--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -149,6 +149,10 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (!key || value === undefined)
         throw new GodotMCPError('key and value required', 'INVALID_ARGS', 'Provide key and value.')
 
+      if (typeof value === 'string' && (value.includes('\n') || value.includes('\r'))) {
+        throw new GodotMCPError('Invalid value format', 'INVALID_ARGS', 'Value must not contain newlines.')
+      }
+
       const configPath = join(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
       if (!(await pathExists(configPath)))
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -255,6 +255,10 @@ export async function handleScenes(action: string, args: Record<string, unknown>
 
     case 'set_main': {
       // projectPath and scenePath are guaranteed
+      if (scenePath.includes('"')) {
+        throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain quotes.')
+      }
+
       const configPath = join(safeResolve(baseDir, projectPath as string), 'project.godot')
       if (!(await pathExists(configPath))) {
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unvalidated values in `settings_set` and `set_main` allowed attackers/users to inject newlines or quotes to modify the `.godot` config structure, creating new INI sections and modifying unrelated configuration parameters.
🎯 **Impact:** Arbitrary injection of engine settings via `project.godot`.
🔧 **Fix:**
- Added validation in `settings_set` (`project.ts`) to throw an error if the value is a string and contains `\n` or `\r`.
- Added validation in `set_main` (`scenes.ts`) to throw an error if `scenePath` contains double quotes (`"`).
✅ **Verification:** Verified via `bun run test` that all 650 tests still pass, including those passing non-string values to settings.

---
*PR created automatically by Jules for task [333024563496150986](https://jules.google.com/task/333024563496150986) started by @n24q02m*