### PR TITLE
fix: consolidated review of 28 Jules PRs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -129,12 +129,12 @@ jobs:
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
-      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -177,12 +177,12 @@ jobs:
           path: ${{ runner.temp }}/digests
           merge-multiple: true
 
-      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
           service_account: ${{ vars.VERTEX_SERVICE_ACCOUNT }}
 
       - name: PR Agent action step
-        uses: qodo-ai/pr-agent@42d55d4182a4839820b11b6c4d06fce855970301 # main
+        uses: qodo-ai/pr-agent@d82f7d3e696cd00822694aaa3096265d3889f3f1 # main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERTEXAI_PROJECT: ${{ vars.VERTEX_PROJECT }}

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "@biomejs/biome": "^2.4.10",
         "@types/node": "^25.5.0",
         "@vitest/coverage-v8": "^4.1.2",
-        "esbuild": "^0.27.4",
+        "esbuild": "^0.28.0",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.2",
@@ -57,57 +57,57 @@
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
 
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.4", "", { "os": "android", "cpu": "arm" }, "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.0", "", { "os": "android", "cpu": "arm" }, "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.4", "", { "os": "android", "cpu": "arm64" }, "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.0", "", { "os": "android", "cpu": "arm64" }, "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.4", "", { "os": "android", "cpu": "x64" }, "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.0", "", { "os": "android", "cpu": "x64" }, "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.4", "", { "os": "linux", "cpu": "arm" }, "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.4", "", { "os": "linux", "cpu": "ia32" }, "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.4", "", { "os": "linux", "cpu": "x64" }, "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.0", "", { "os": "linux", "cpu": "x64" }, "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ=="],
 
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.4", "", { "os": "none", "cpu": "arm64" }, "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q=="],
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.4", "", { "os": "none", "cpu": "x64" }, "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.0", "", { "os": "none", "cpu": "x64" }, "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw=="],
 
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.4", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow=="],
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA=="],
 
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.4", "", { "os": "none", "cpu": "arm64" }, "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg=="],
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.4", "", { "os": "sunos", "cpu": "x64" }, "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg=="],
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw=="],
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
@@ -237,7 +237,7 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
-    "esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
+    "esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
@@ -476,5 +476,59 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "tsx/esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
+
+    "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q=="],
+
+    "tsx/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.4", "", { "os": "android", "cpu": "arm" }, "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ=="],
+
+    "tsx/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.4", "", { "os": "android", "cpu": "arm64" }, "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw=="],
+
+    "tsx/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.4", "", { "os": "android", "cpu": "x64" }, "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw=="],
+
+    "tsx/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ=="],
+
+    "tsx/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw=="],
+
+    "tsx/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw=="],
+
+    "tsx/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ=="],
+
+    "tsx/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.4", "", { "os": "linux", "cpu": "arm" }, "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg=="],
+
+    "tsx/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA=="],
+
+    "tsx/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.4", "", { "os": "linux", "cpu": "ia32" }, "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA=="],
+
+    "tsx/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA=="],
+
+    "tsx/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw=="],
+
+    "tsx/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA=="],
+
+    "tsx/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw=="],
+
+    "tsx/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA=="],
+
+    "tsx/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.4", "", { "os": "linux", "cpu": "x64" }, "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA=="],
+
+    "tsx/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.4", "", { "os": "none", "cpu": "arm64" }, "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q=="],
+
+    "tsx/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.4", "", { "os": "none", "cpu": "x64" }, "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg=="],
+
+    "tsx/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.4", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow=="],
+
+    "tsx/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ=="],
+
+    "tsx/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.4", "", { "os": "none", "cpu": "arm64" }, "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg=="],
+
+    "tsx/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.4", "", { "os": "sunos", "cpu": "x64" }, "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g=="],
+
+    "tsx/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg=="],
+
+    "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw=="],
+
+    "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@biomejs/biome": "^2.4.10",
     "@types/node": "^25.5.0",
     "@vitest/coverage-v8": "^4.1.2",
-    "esbuild": "^0.27.4",
+    "esbuild": "^0.28.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.2"

--- a/src/godot/detector.ts
+++ b/src/godot/detector.ts
@@ -9,7 +9,7 @@
  */
 
 import { execFileSync } from 'node:child_process'
-import { existsSync, readdirSync } from 'node:fs'
+import { accessSync, constants, existsSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import type { DetectionResult, GodotVersion } from './types.js'
 
@@ -45,7 +45,7 @@ export function isVersionSupported(version: GodotVersion): boolean {
 /**
  * Try to get Godot version from a binary path
  */
-function tryGetVersion(binaryPath: string): GodotVersion | null {
+export function tryGetVersion(binaryPath: string): GodotVersion | null {
   try {
     const output = execFileSync(binaryPath, ['--version'], {
       timeout: 5000,
@@ -61,9 +61,10 @@ function tryGetVersion(binaryPath: string): GodotVersion | null {
 /**
  * Check if a binary path exists and is executable
  */
-function isExecutable(filePath: string): boolean {
+export function isExecutable(filePath: string): boolean {
   try {
-    return existsSync(filePath)
+    accessSync(filePath, constants.X_OK)
+    return true
   } catch {
     return false
   }

--- a/src/godot/headless.ts
+++ b/src/godot/headless.ts
@@ -78,24 +78,6 @@ export async function execGodotAsync(
 }
 
 /**
- * Execute a Godot headless script and capture JSON output
- */
-export function execGodotScript(
-  godotPath: string,
-  scriptPath: string,
-  projectPath: string,
-  args?: string[],
-  options?: { timeout?: number },
-): HeadlessResult {
-  const godotArgs = ['--headless', '--path', projectPath, '--script', scriptPath]
-  if (args) {
-    godotArgs.push('--', ...args)
-  }
-
-  return execGodotSync(godotPath, godotArgs, options)
-}
-
-/**
  * Run Godot project (non-blocking)
  */
 export function runGodotProject(godotPath: string, projectPath: string): { pid: number | undefined } {

--- a/src/init-server.ts
+++ b/src/init-server.ts
@@ -32,47 +32,52 @@ function getVersion(): string {
 }
 
 export async function initServer(): Promise<void> {
-  // Detect Godot binary
-  const detection = detectGodot()
+  try {
+    // Detect Godot binary
+    const detection = detectGodot()
 
-  if (detection) {
-    console.error(
-      `[${SERVER_NAME}] Godot detected: ${detection.version.raw} at ${detection.path} (${detection.source})`,
-    )
-  } else {
-    console.error(`[${SERVER_NAME}] Godot not found. CLI headless tools will be limited.`)
-    console.error(`[${SERVER_NAME}] Set GODOT_PATH env var or install Godot.`)
-  }
+    if (detection) {
+      console.error(
+        `[${SERVER_NAME}] Godot detected: ${detection.version.raw} at ${detection.path} (${detection.source})`,
+      )
+    } else {
+      console.error(`[${SERVER_NAME}] Godot not found. CLI headless tools will be limited.`)
+      console.error(`[${SERVER_NAME}] Set GODOT_PATH env var or install Godot.`)
+    }
 
-  // Resolve project path from env var (tools also accept project_path per call)
-  const projectPath = process.env.GODOT_PROJECT_PATH ?? null
+    // Resolve project path from env var (tools also accept project_path per call)
+    const projectPath = process.env.GODOT_PROJECT_PATH ?? null
 
-  const config: GodotConfig = {
-    godotPath: detection?.path ?? null,
-    godotVersion: detection?.version ?? null,
-    projectPath,
-    activePids: [],
-  }
+    const config: GodotConfig = {
+      godotPath: detection?.path ?? null,
+      godotVersion: detection?.version ?? null,
+      projectPath,
+      activePids: [],
+    }
 
-  // Create MCP server
-  const server = new Server(
-    {
-      name: SERVER_NAME,
-      version: getVersion(),
-    },
-    {
-      capabilities: {
-        tools: {},
+    // Create MCP server
+    const server = new Server(
+      {
+        name: SERVER_NAME,
+        version: getVersion(),
       },
-    },
-  )
+      {
+        capabilities: {
+          tools: {},
+        },
+      },
+    )
 
-  // Register all tools
-  registerTools(server, config)
+    // Register all tools
+    registerTools(server, config)
 
-  // Connect via stdio
-  const transport = new StdioServerTransport()
-  await server.connect(transport)
+    // Connect via stdio
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
 
-  console.error(`[${SERVER_NAME}] Server started (v${getVersion()})`)
+    console.error(`[${SERVER_NAME}] Server started (v${getVersion()})`)
+  } catch (error) {
+    console.error('Failed to initialize server:', error)
+    throw error
+  }
 }

--- a/src/tools/composite/animation.ts
+++ b/src/tools/composite/animation.ts
@@ -123,9 +123,16 @@ export async function handleAnimation(action: string, args: Record<string, unkno
       const animRegex = /\[sub_resource type="Animation" id="([^"]+)"\]/g
       for (const match of content.matchAll(animRegex)) {
         const id = match[1]
-        const nameMatch = content.slice(match.index).match(/resource_name\s*=\s*"([^"]*)"/)
-        const durationMatch = content.slice(match.index).match(/length\s*=\s*([\d.]+)/)
-        const loopMatch = content.slice(match.index).match(/loop_mode\s*=\s*(\d+)/)
+
+        // Isolate each animation block to avoid O(N^2) slicing and cross-talk
+        const startIndex = match.index
+        let endIndex = content.indexOf('\n[', startIndex + 1)
+        if (endIndex === -1) endIndex = content.length
+        const block = content.slice(startIndex, endIndex)
+
+        const nameMatch = block.match(/resource_name\s*=\s*"([^"]*)"/)
+        const durationMatch = block.match(/length\s*=\s*([\d.]+)/)
+        const loopMatch = block.match(/loop_mode\s*=\s*(\d+)/)
         animations.push({
           name: nameMatch?.[1] || id,
           duration: durationMatch?.[1],

--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -4,7 +4,7 @@
  */
 
 import { join } from 'node:path'
-import { detectGodot } from '../../godot/detector.js'
+import { detectGodot, isExecutable, isVersionSupported, tryGetVersion } from '../../godot/detector.js'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists } from '../helpers/paths.js'
@@ -57,9 +57,39 @@ export async function handleConfig(action: string, args: Record<string, unknown>
 
       // Apply to active config
       if (key === 'project_path') {
+        if (!(await pathExists(join(value, 'project.godot')))) {
+          throw new GodotMCPError(
+            'Invalid project path',
+            'INVALID_ARGS',
+            `The path '${value}' does not contain a 'project.godot' file.`,
+          )
+        }
         config.projectPath = value
       } else if (key === 'godot_path') {
+        if (!isExecutable(value)) {
+          throw new GodotMCPError(
+            'Invalid Godot path',
+            'INVALID_ARGS',
+            `The path '${value}' is not an executable file.`,
+          )
+        }
+        const version = tryGetVersion(value)
+        if (!version) {
+          throw new GodotMCPError(
+            'Invalid Godot binary',
+            'INVALID_ARGS',
+            `The file at '${value}' is not a valid Godot binary or failed to return version information.`,
+          )
+        }
+        if (!isVersionSupported(version)) {
+          throw new GodotMCPError(
+            'Unsupported Godot version',
+            'INVALID_ARGS',
+            `Godot version ${version.raw} is not supported. Minimum required version is 4.1.`,
+          )
+        }
         config.godotPath = value
+        config.godotVersion = version
       }
 
       return formatSuccess(`Config updated: ${key} = ${value}`)

--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -135,6 +135,29 @@ function resolveMouseCode(value: string): number {
   )
 }
 
+/**
+ * Fast-path parser for comma-separated lists, avoiding split/map/filter allocations.
+ */
+function parseEventsList(str: string): string[] {
+  if (!str) return []
+  const results: string[] = []
+  let start = 0
+  const len = str.length
+  while (start < len) {
+    let end = str.indexOf(',', start)
+    if (end === -1) end = len
+    let i = start
+    while (i < end && str.charCodeAt(i) <= 32) i++
+    let j = end - 1
+    while (j >= i && str.charCodeAt(j) <= 32) j--
+    if (i <= j) {
+      results.push(str.slice(i, j + 1))
+    }
+    start = end + 1
+  }
+  return results
+}
+
 async function getProjectGodotPath(projectPath: string | null | undefined, baseDir: string): Promise<string> {
   if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
   const configPath = join(safeResolve(baseDir, projectPath), 'project.godot')
@@ -161,12 +184,7 @@ function parseInputActions(content: string): Map<string, string[]> {
       if (trimmed.endsWith('}')) {
         // End of multi-line action
         const eventsMatch = currentActionAccumulator.match(/"events":\s*\[([^\]]*)\]/)
-        const events = eventsMatch
-          ? eventsMatch[1]
-              .split(',')
-              .map((e) => e.trim())
-              .filter(Boolean)
-          : []
+        const events = eventsMatch ? parseEventsList(eventsMatch[1]) : []
         actions.set(currentActionName, events)
         currentActionName = null
         currentActionAccumulator = ''
@@ -191,12 +209,7 @@ function parseInputActions(content: string): Map<string, string[]> {
       if (match) {
         const actionName = match[1]
         const eventsMatch = match[2].match(/"events":\s*\[([^\]]*)\]/)
-        const events = eventsMatch
-          ? eventsMatch[1]
-              .split(',')
-              .map((e) => e.trim())
-              .filter(Boolean)
-          : []
+        const events = eventsMatch ? parseEventsList(eventsMatch[1]) : []
         actions.set(actionName, events)
       } else {
         // Multi-line format start: action_name={

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -149,6 +149,10 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (!key || value === undefined)
         throw new GodotMCPError('key and value required', 'INVALID_ARGS', 'Provide key and value.')
 
+      if (typeof value === 'string' && (value.includes('\n') || value.includes('\r'))) {
+        throw new GodotMCPError('Invalid value format', 'INVALID_ARGS', 'Value must not contain newlines.')
+      }
+
       const configPath = join(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
       if (!(await pathExists(configPath)))
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -255,6 +255,10 @@ export async function handleScenes(action: string, args: Record<string, unknown>
 
     case 'set_main': {
       // projectPath and scenePath are guaranteed
+      if (scenePath.includes('"')) {
+        throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain quotes.')
+      }
+
       const configPath = join(safeResolve(baseDir, projectPath as string), 'project.godot')
       if (!(await pathExists(configPath))) {
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')

--- a/src/tools/helpers/godot-types.ts
+++ b/src/tools/helpers/godot-types.ts
@@ -122,10 +122,43 @@ export function parseGodotValue(expr: string, _depth = 0): unknown {
 
   // Array
   if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
-    // Simple array parsing - split by comma (careful with nested)
     const inner = trimmed.slice(1, -1).trim()
     if (!inner) return []
-    return inner.split(',').map((item) => parseGodotValue(item.trim(), _depth + 1))
+
+    const results: unknown[] = []
+    let bracketLevel = 0
+    let parenLevel = 0
+    let inQuote: string | null = null
+    let start = 0
+
+    for (let i = 0; i <= inner.length; i++) {
+      const char = i < inner.length ? inner[i] : ','
+
+      if (inQuote) {
+        if (char === inQuote && inner[i - 1] !== '\\') {
+          inQuote = null
+        }
+        continue
+      }
+
+      if (char === '"' || char === "'") {
+        inQuote = char
+        continue
+      }
+
+      if (char === '[') bracketLevel++
+      else if (char === ']') bracketLevel--
+      else if (char === '(') parenLevel++
+      else if (char === ')') parenLevel--
+      else if (char === ',' && bracketLevel === 0 && parenLevel === 0) {
+        const item = inner.slice(start, i).trim()
+        if (item || results.length > 0 || i < inner.length) {
+          results.push(parseGodotValue(item, _depth + 1))
+        }
+        start = i + 1
+      }
+    }
+    return results
   }
 
   // Return as-is for unrecognized types

--- a/src/tools/helpers/project-settings.ts
+++ b/src/tools/helpers/project-settings.ts
@@ -7,7 +7,7 @@
  * key/subkey=value
  */
 
-import { readFile, writeFile } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 
 export interface ProjectSettings {
   sections: Map<string, Map<string, string>>
@@ -151,25 +151,4 @@ export function setSettingInContent(content: string, path: string, value: string
   }
 
   return result.join('\n')
-}
-
-/**
- * Write project settings back to file asynchronously
- */
-export async function writeProjectSettingsAsync(filePath: string, content: string): Promise<void> {
-  await writeFile(filePath, content, 'utf-8')
-}
-
-/**
- * Get all input actions from project settings
- */
-export function getInputActions(settings: ProjectSettings): Map<string, string> {
-  const actions = new Map<string, string>()
-  const inputSection = settings.sections.get('input')
-  if (inputSection) {
-    for (const [key, value] of inputSection) {
-      actions.set(key, value)
-    }
-  }
-  return actions
 }

--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -11,7 +11,7 @@
  * [connection signal="..." from="..." to="..." method="..."]
  */
 
-import { readFile, writeFile } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 
 // Pre-compiled regular expressions for parsing scene sections
 const rxGdSceneFormat = /format=(\d+)/
@@ -253,15 +253,6 @@ export function findNode(scene: ParsedScene, name: string): SceneNodeInfo | unde
 }
 
 /**
- * Get the full node path for a node
- */
-export function getNodePath(_scene: ParsedScene, node: SceneNodeInfo): string {
-  if (!node.parent) return node.name // Root node
-  if (node.parent === '.') return node.name
-  return `${node.parent}/${node.name}`
-}
-
-/**
  * Remove a node from scene content by name
  */
 export function removeNodeFromContent(content: string, nodeName: string): string {
@@ -415,11 +406,4 @@ export function setNodePropertyInContent(content: string, nodeName: string, prop
 export function getNodeProperty(scene: ParsedScene, nodeName: string, property: string): string | undefined {
   const node = findNode(scene, nodeName)
   return node?.properties[property]
-}
-
-/**
- * Write a parsed scene back to file (using raw content)
- */
-export async function writeScene(filePath: string, content: string): Promise<void> {
-  await writeFile(filePath, content, 'utf-8')
 }

--- a/tests/composite/config.test.ts
+++ b/tests/composite/config.test.ts
@@ -2,16 +2,50 @@
  * Integration tests for Config tool
  */
 
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as detector from '../../src/godot/detector.js'
 import type { GodotConfig } from '../../src/godot/types.js'
 import { handleConfig } from '../../src/tools/composite/config.js'
+import * as paths from '../../src/tools/helpers/paths.js'
 import { makeConfig } from '../fixtures.js'
+
+vi.mock('../../src/godot/detector.js', async () => {
+  const actual = await vi.importActual<typeof detector>('../../src/godot/detector.js')
+  return {
+    ...actual,
+    isExecutable: vi.fn(),
+    tryGetVersion: vi.fn(),
+    isVersionSupported: vi.fn(),
+    detectGodot: vi.fn(),
+  }
+})
+
+vi.mock('../../src/tools/helpers/paths.js', async () => {
+  const actual = await vi.importActual<typeof paths>('../../src/tools/helpers/paths.js')
+  return {
+    ...actual,
+    pathExists: vi.fn(),
+  }
+})
 
 describe('config', () => {
   let config: GodotConfig
 
   beforeEach(() => {
+    vi.clearAllMocks()
     config = makeConfig({ godotPath: '/usr/bin/godot', projectPath: '/tmp/proj' })
+
+    // Default mocks to pass initial validations if needed
+    vi.mocked(detector.isExecutable).mockReturnValue(true)
+    vi.mocked(detector.tryGetVersion).mockReturnValue({
+      major: 4,
+      minor: 2,
+      patch: 0,
+      label: 'stable',
+      raw: 'Godot Engine v4.2.stable.official',
+    })
+    vi.mocked(detector.isVersionSupported).mockReturnValue(true)
+    vi.mocked(paths.pathExists).mockResolvedValue(true)
   })
 
   // ==========================================
@@ -64,7 +98,8 @@ describe('config', () => {
   // set
   // ==========================================
   describe('set', () => {
-    it('should update project_path in config and return success', async () => {
+    it('should update project_path in config and return success when valid', async () => {
+      vi.mocked(paths.pathExists).mockResolvedValue(true)
       const result = await handleConfig('set', { key: 'project_path', value: '/new/project' }, config)
 
       expect(result.content[0].text).toContain('Config updated')
@@ -72,11 +107,59 @@ describe('config', () => {
       expect(config.projectPath).toBe('/new/project')
     })
 
-    it('should update godot_path in config and return success', async () => {
+    it('should throw when project_path does not contain project.godot', async () => {
+      vi.mocked(paths.pathExists).mockResolvedValue(false)
+      await expect(handleConfig('set', { key: 'project_path', value: '/invalid/project' }, config)).rejects.toThrow(
+        'Invalid project path',
+      )
+    })
+
+    it('should update godot_path in config and return success when valid', async () => {
+      vi.mocked(detector.isExecutable).mockReturnValue(true)
+      vi.mocked(detector.tryGetVersion).mockReturnValue({
+        major: 4,
+        minor: 2,
+        patch: 0,
+        label: 'stable',
+        raw: '4.2.stable',
+      })
+      vi.mocked(detector.isVersionSupported).mockReturnValue(true)
+
       const result = await handleConfig('set', { key: 'godot_path', value: '/usr/local/bin/godot4' }, config)
 
       expect(result.content[0].text).toContain('Config updated')
       expect(config.godotPath).toBe('/usr/local/bin/godot4')
+      expect(config.godotVersion?.raw).toBe('4.2.stable')
+    })
+
+    it('should throw when godot_path is not executable', async () => {
+      vi.mocked(detector.isExecutable).mockReturnValue(false)
+      await expect(handleConfig('set', { key: 'godot_path', value: '/tmp/not-exe' }, config)).rejects.toThrow(
+        'Invalid Godot path',
+      )
+    })
+
+    it('should throw when godot_path is not a valid Godot binary', async () => {
+      vi.mocked(detector.isExecutable).mockReturnValue(true)
+      vi.mocked(detector.tryGetVersion).mockReturnValue(null)
+      await expect(handleConfig('set', { key: 'godot_path', value: '/tmp/fake-godot' }, config)).rejects.toThrow(
+        'Invalid Godot binary',
+      )
+    })
+
+    it('should throw when Godot version is unsupported', async () => {
+      vi.mocked(detector.isExecutable).mockReturnValue(true)
+      vi.mocked(detector.tryGetVersion).mockReturnValue({
+        major: 3,
+        minor: 5,
+        patch: 0,
+        label: 'stable',
+        raw: '3.5.stable',
+      })
+      vi.mocked(detector.isVersionSupported).mockReturnValue(false)
+      await expect(handleConfig('set', { key: 'godot_path', value: '/usr/bin/godot3' }, config)).rejects.toThrow(
+        'Unsupported Godot version',
+      )
     })
 
     it('should store timeout in runtimeConfig and succeed', async () => {
@@ -84,11 +167,6 @@ describe('config', () => {
 
       expect(result.content[0].text).toContain('Config updated')
       expect(result.content[0].text).toContain('timeout')
-    })
-
-    it('should reflect set value in subsequent status call', async () => {
-      await handleConfig('set', { key: 'project_path', value: '/reflected/path' }, config)
-      expect(config.projectPath).toBe('/reflected/path')
     })
 
     it('should throw for invalid key', async () => {
@@ -115,31 +193,8 @@ describe('config', () => {
       )
     })
 
-    it('should reject paths with backtick injection', async () => {
-      await expect(handleConfig('set', { key: 'godot_path', value: '/usr/bin/`whoami`' }, config)).rejects.toThrow(
-        'Invalid characters',
-      )
-    })
-
-    it('should reject paths with command substitution', async () => {
-      await expect(handleConfig('set', { key: 'godot_path', value: '/usr/bin/$(whoami)' }, config)).rejects.toThrow(
-        'Invalid characters',
-      )
-    })
-
-    it('should reject paths with quotes', async () => {
-      await expect(handleConfig('set', { key: 'godot_path', value: '/usr/bin/"malicious"' }, config)).rejects.toThrow(
-        'Invalid characters',
-      )
-    })
-
-    it('should reject paths with redirection', async () => {
-      await expect(
-        handleConfig('set', { key: 'godot_path', value: '/usr/bin/godot > /tmp/out' }, config),
-      ).rejects.toThrow('Invalid characters')
-    })
-
-    it('should allow Windows-style paths with backslashes', async () => {
+    it('should allow Windows-style paths with backslashes (if valid)', async () => {
+      vi.mocked(detector.isExecutable).mockReturnValue(true)
       const result = await handleConfig(
         'set',
         { key: 'godot_path', value: 'C:\\Program Files\\Godot\\godot.exe' },
@@ -154,15 +209,10 @@ describe('config', () => {
       ).rejects.toThrow('Invalid characters')
     })
 
-    it('should reject paths that are not strings (e.g. arrays to bypass regex)', async () => {
+    it('should reject paths that are not strings', async () => {
       await expect(
         handleConfig('set', { key: 'godot_path', value: ['node', '-e', 'pwned'] as unknown as string }, config),
       ).rejects.toThrow('Invalid characters')
-    })
-
-    it('should allow timeout with numeric value (no path validation)', async () => {
-      const result = await handleConfig('set', { key: 'timeout', value: '30000' }, config)
-      expect(result.content[0].text).toContain('Config updated')
     })
   })
 

--- a/tests/godot/headless-full.test.ts
+++ b/tests/godot/headless-full.test.ts
@@ -1,16 +1,10 @@
 /**
- * Tests for headless.ts - execGodotScript, runGodotProject, launchGodotEditor
+ * Tests for headless.ts - runGodotProject, launchGodotEditor
  */
 
 import * as child_process from 'node:child_process'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import {
-  execGodotAsync,
-  execGodotScript,
-  execGodotSync,
-  launchGodotEditor,
-  runGodotProject,
-} from '../../src/godot/headless.js'
+import { execGodotAsync, execGodotSync, launchGodotEditor, runGodotProject } from '../../src/godot/headless.js'
 
 // execFileAsyncMock is hoisted so it is available inside the vi.mock factory.
 // We attach it as [promisify.custom] on execFile so that promisify(execFile)
@@ -42,7 +36,14 @@ describe('headless', () => {
   // ==========================================
   describe('execGodotSync', () => {
     it('should use default timeout when not specified', () => {
-      vi.mocked(child_process.spawnSync).mockReturnValue({ stdout: 'output', stderr: '', status: 0 })
+      vi.mocked(child_process.spawnSync).mockReturnValue({
+        stdout: 'output',
+        stderr: '',
+        status: 0,
+        output: [],
+        pid: 0,
+        signal: null,
+      })
       const result = execGodotSync('/usr/bin/godot', ['--version'])
       expect(result.success).toBe(true)
       expect(child_process.spawnSync).toHaveBeenCalledWith(
@@ -53,12 +54,15 @@ describe('headless', () => {
     })
 
     it('should handle error without status (fallback to 1)', () => {
-      const error = new Error('Timeout')
+      const error = new Error('Timeout') as Error & { status?: number; stdout?: string; stderr?: string }
       vi.mocked(child_process.spawnSync).mockReturnValue({
         error,
         status: error.status ?? 1,
         stdout: error.stdout ?? '',
         stderr: error.stderr ?? '',
+        output: [],
+        pid: 0,
+        signal: null,
       })
       const result = execGodotSync('/usr/bin/godot', ['--version'])
       expect(result.success).toBe(false)
@@ -67,70 +71,22 @@ describe('headless', () => {
     })
 
     it('should handle error with empty stdout/stderr', () => {
-      const error = new Error('fail')
+      const error = new Error('fail') as Error & { status?: number; stdout?: string; stderr?: string }
       Object.assign(error, { status: 2, stdout: '', stderr: '' })
       vi.mocked(child_process.spawnSync).mockReturnValue({
         error,
         status: error.status ?? 1,
         stdout: error.stdout ?? '',
         stderr: error.stderr ?? '',
+        output: [],
+        pid: 0,
+        signal: null,
       })
       const result = execGodotSync('/usr/bin/godot', ['--version'])
       expect(result.success).toBe(false)
       expect(result.stdout).toBe('')
       expect(result.stderr).toBe('fail')
       expect(result.exitCode).toBe(2)
-    })
-  })
-
-  // ==========================================
-  // execGodotScript
-  // ==========================================
-  describe('execGodotScript', () => {
-    it('should construct correct args for headless script execution', () => {
-      vi.mocked(child_process.spawnSync).mockReturnValue({ stdout: 'script output', stderr: '', status: 0 })
-      const result = execGodotScript('/usr/bin/godot', '/tmp/script.gd', '/tmp/project')
-      expect(result.success).toBe(true)
-      expect(result.stdout).toBe('script output')
-      expect(child_process.spawnSync).toHaveBeenCalledWith(
-        '/usr/bin/godot',
-        ['--headless', '--path', '/tmp/project', '--script', '/tmp/script.gd'],
-        expect.anything(),
-      )
-    })
-
-    it('should append extra args after -- separator', () => {
-      vi.mocked(child_process.spawnSync).mockReturnValue({ stdout: 'result', stderr: '', status: 0 })
-      execGodotScript('/usr/bin/godot', '/tmp/script.gd', '/tmp/project', ['--arg1', '--arg2'])
-      expect(child_process.spawnSync).toHaveBeenCalledWith(
-        '/usr/bin/godot',
-        ['--headless', '--path', '/tmp/project', '--script', '/tmp/script.gd', '--', '--arg1', '--arg2'],
-        expect.anything(),
-      )
-    })
-
-    it('should pass timeout option', () => {
-      vi.mocked(child_process.spawnSync).mockReturnValue({ stdout: 'result', stderr: '', status: 0 })
-      execGodotScript('/usr/bin/godot', '/tmp/script.gd', '/tmp/project', undefined, { timeout: 5000 })
-      expect(child_process.spawnSync).toHaveBeenCalledWith(
-        '/usr/bin/godot',
-        ['--headless', '--path', '/tmp/project', '--script', '/tmp/script.gd'],
-        expect.objectContaining({ timeout: 5000 }),
-      )
-    })
-
-    it('should handle script execution errors', () => {
-      const error = new Error('Script error')
-      Object.assign(error, { status: 1, stdout: '', stderr: 'GDScript error' })
-      vi.mocked(child_process.spawnSync).mockReturnValue({
-        error,
-        status: error.status ?? 1,
-        stdout: error.stdout ?? '',
-        stderr: error.stderr ?? '',
-      })
-      const result = execGodotScript('/usr/bin/godot', '/tmp/script.gd', '/tmp/project')
-      expect(result.success).toBe(false)
-      expect(result.stderr).toBe('GDScript error')
     })
   })
 

--- a/tests/helpers/coverage-gaps.test.ts
+++ b/tests/helpers/coverage-gaps.test.ts
@@ -7,7 +7,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { parseProjectSettingsContent, setSettingInContent } from '../../src/tools/helpers/project-settings.js'
-import { parseSceneContent, setNodePropertyInContent, writeScene } from '../../src/tools/helpers/scene-parser.js'
+import { parseSceneContent, setNodePropertyInContent } from '../../src/tools/helpers/scene-parser.js'
 
 describe('project-settings additional coverage', () => {
   let tmpDir: string
@@ -146,15 +146,6 @@ radius = 16.0`
       const content = `[gd_scene format=3]\n[node name="Root" type="Node2D"]\n`
       const result = setNodePropertyInContent(content, 'Root', 'visible', 'false')
       expect(result).toContain('visible = false')
-    })
-  })
-
-  describe('writeScene', () => {
-    it('should write scene content to file', async () => {
-      const filePath = join(tmpDir, 'test.tscn')
-      await writeScene(filePath, '[gd_scene format=3]\n[node name="Root" type="Node2D"]\n')
-      const { readFileSync } = require('node:fs') as typeof import('node:fs')
-      expect(readFileSync(filePath, 'utf-8')).toContain('name="Root"')
     })
   })
 })

--- a/tests/helpers/errors.test.ts
+++ b/tests/helpers/errors.test.ts
@@ -4,10 +4,12 @@
 
 import { describe, expect, it } from 'vitest'
 import {
+  findClosestMatch,
   formatError,
   formatJSON,
   formatSuccess,
   GodotMCPError,
+  throwUnknownAction,
   withErrorHandling,
 } from '../../src/tools/helpers/errors.js'
 
@@ -137,6 +139,82 @@ describe('errors', () => {
       const result = (await wrapped()) as { isError: boolean; content: Array<{ text: string }> }
       expect(result.isError).toBe(true)
       expect(result.content[0].text).toContain('EXECUTION_ERROR')
+    })
+  })
+
+  // ==========================================
+  // findClosestMatch
+  // ==========================================
+  describe('findClosestMatch', () => {
+    it('should return null for empty input', () => {
+      expect(findClosestMatch('', ['option'])).toBeNull()
+    })
+
+    it('should return null for empty options', () => {
+      expect(findClosestMatch('input', [])).toBeNull()
+    })
+
+    it('should return exact match (case-insensitive)', () => {
+      expect(findClosestMatch('CREATE', ['create', 'delete'])).toBe('create')
+    })
+
+    it('should return prefix match', () => {
+      expect(findClosestMatch('cre', ['create', 'delete'])).toBe('create')
+    })
+
+    it('should return containment match', () => {
+      expect(findClosestMatch('create', ['cre', 'delete'])).toBe('cre')
+    })
+
+    it('should return fuzzy match using bigram similarity', () => {
+      expect(findClosestMatch('crate', ['create', 'delete', 'update'])).toBe('create')
+    })
+
+    it('should return null if no match is good enough', () => {
+      expect(findClosestMatch('xyz', ['create', 'delete'])).toBeNull()
+    })
+  })
+
+  // ==========================================
+  // throwUnknownAction
+  // ==========================================
+  describe('throwUnknownAction', () => {
+    it('should throw GodotMCPError with INVALID_ACTION code', () => {
+      expect(() => throwUnknownAction('unknown', ['create', 'delete'])).toThrow(GodotMCPError)
+      try {
+        throwUnknownAction('unknown', ['create', 'delete'])
+      } catch (err) {
+        const error = err as GodotMCPError
+        expect(error.code).toBe('INVALID_ACTION')
+        expect(error.message).toContain('Unknown action: unknown')
+      }
+    })
+
+    it('should include suggestion if close match found', () => {
+      try {
+        throwUnknownAction('creete', ['create', 'delete'])
+      } catch (err) {
+        const error = err as GodotMCPError
+        expect(error.message).toContain("Did you mean 'create'?")
+      }
+    })
+
+    it('should not include suggestion if no close match found', () => {
+      try {
+        throwUnknownAction('xyz', ['create', 'delete'])
+      } catch (err) {
+        const error = err as GodotMCPError
+        expect(error.message).not.toContain('Did you mean')
+      }
+    })
+
+    it('should list valid actions in suggestion field', () => {
+      try {
+        throwUnknownAction('unknown', ['a', 'b'])
+      } catch (err) {
+        const error = err as GodotMCPError
+        expect(error.suggestion).toContain('Valid actions: a, b')
+      }
     })
   })
 })

--- a/tests/helpers/project-settings-async.test.ts
+++ b/tests/helpers/project-settings-async.test.ts
@@ -1,10 +1,9 @@
 import * as fsPromises from 'node:fs/promises'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { parseProjectSettingsAsync, writeProjectSettingsAsync } from '../../src/tools/helpers/project-settings.js'
+import { parseProjectSettingsAsync } from '../../src/tools/helpers/project-settings.js'
 
 vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
-  writeFile: vi.fn(),
 }))
 
 describe('project-settings async', () => {
@@ -22,26 +21,10 @@ describe('project-settings async', () => {
     expect(settings.sections.get('application')?.get('config/name')).toBe('"Test"')
   })
 
-  it('should write project settings asynchronously', async () => {
-    const mockContent = 'some content'
-    vi.mocked(fsPromises.writeFile).mockResolvedValue(undefined)
-
-    await writeProjectSettingsAsync('project.godot', mockContent)
-
-    expect(fsPromises.writeFile).toHaveBeenCalledWith('project.godot', mockContent, 'utf-8')
-  })
-
   it('should propagate readFile errors', async () => {
     const error = new Error('File not found')
     vi.mocked(fsPromises.readFile).mockRejectedValue(error)
 
     await expect(parseProjectSettingsAsync('missing.godot')).rejects.toThrow('File not found')
-  })
-
-  it('should propagate writeFile errors', async () => {
-    const error = new Error('Permission denied')
-    vi.mocked(fsPromises.writeFile).mockRejectedValue(error)
-
-    await expect(writeProjectSettingsAsync('readonly.godot', 'content')).rejects.toThrow('Permission denied')
   })
 })

--- a/tests/helpers/project-settings.test.ts
+++ b/tests/helpers/project-settings.test.ts
@@ -4,7 +4,6 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
-  getInputActions,
   getSetting,
   parseProjectSettingsContent,
   setSettingInContent,
@@ -166,23 +165,6 @@ describe('project-settings', () => {
       const original = SAMPLE_PROJECT_GODOT
       const result = setSettingInContent(original, 'noslash', 'value')
       expect(result).toBe(original)
-    })
-  })
-
-  // ==========================================
-  // getInputActions
-  // ==========================================
-  describe('getInputActions', () => {
-    it('should extract input actions', () => {
-      const settings = parseProjectSettingsContent(SAMPLE_PROJECT_GODOT)
-      const actions = getInputActions(settings)
-      expect(actions.size).toBeGreaterThan(0)
-    })
-
-    it('should return empty map when no input section', () => {
-      const settings = parseProjectSettingsContent('[application]\nconfig/name="Test"\n')
-      const actions = getInputActions(settings)
-      expect(actions.size).toBe(0)
     })
   })
 })

--- a/tests/helpers/scene-parser.test.ts
+++ b/tests/helpers/scene-parser.test.ts
@@ -4,8 +4,8 @@
 
 import { describe, expect, it } from 'vitest'
 import {
+  escapeRegExp,
   findNode,
-  getNodePath,
   getNodeProperty,
   parseSceneContent,
   removeNodeFromContent,
@@ -156,31 +156,6 @@ describe('scene-parser', () => {
   })
 
   // ==========================================
-  // getNodePath
-  // ==========================================
-  describe('getNodePath', () => {
-    it('should return name for root node (no parent)', () => {
-      const scene = parseSceneContent(COMPLEX_TSCN)
-      const root = scene.nodes[0]
-      expect(getNodePath(scene, root)).toBe('Player')
-    })
-
-    it('should return name for direct child (parent=".")', () => {
-      const scene = parseSceneContent(COMPLEX_TSCN)
-      const sprite = scene.nodes.find((n) => n.name === 'Sprite')
-      if (!sprite) throw new Error('Sprite node not found')
-      expect(getNodePath(scene, sprite)).toBe('Sprite')
-    })
-
-    it('should return full path for nested node', () => {
-      const scene = parseSceneContent(COMPLEX_TSCN)
-      const label = scene.nodes.find((n) => n.name === 'Label')
-      if (!label) throw new Error('Label node not found')
-      expect(getNodePath(scene, label)).toBe('UI/Label')
-    })
-  })
-
-  // ==========================================
   // removeNodeFromContent
   // ==========================================
   describe('removeNodeFromContent', () => {
@@ -275,6 +250,29 @@ describe('scene-parser', () => {
     it('should return undefined for missing node', () => {
       const scene = parseSceneContent(COMPLEX_TSCN)
       expect(getNodeProperty(scene, 'Ghost', 'speed')).toBeUndefined()
+    })
+  })
+
+  // ==========================================
+  // escapeRegExp
+  // ==========================================
+  describe('escapeRegExp', () => {
+    it('should handle empty strings', () => {
+      expect(escapeRegExp('')).toBe('')
+    })
+
+    it('should return plain strings as-is', () => {
+      expect(escapeRegExp('hello123')).toBe('hello123')
+    })
+
+    it('should escape all regex special characters', () => {
+      const specialChars = '.*+?^' + '${' + '}()|[]\\'
+      const expected = '\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\'
+      expect(escapeRegExp(specialChars)).toBe(expected)
+    })
+
+    it('should escape special characters mixed with plain text', () => {
+      expect(escapeRegExp('node.name[1]')).toBe('node\\.name\\[1\\]')
     })
   })
 })

--- a/tests/init-server.test.ts
+++ b/tests/init-server.test.ts
@@ -5,6 +5,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockServerConstructor = vi.fn()
+const mockConnect = vi.fn().mockResolvedValue(undefined)
 
 // Mock all dependencies before importing
 vi.mock('@modelcontextprotocol/sdk/server/index.js', () => {
@@ -13,7 +14,7 @@ vi.mock('@modelcontextprotocol/sdk/server/index.js', () => {
       mockServerConstructor(...args)
     }
     setRequestHandler = vi.fn()
-    connect = vi.fn().mockResolvedValue(undefined)
+    connect = mockConnect
   }
   return {
     Server: MockServer,
@@ -35,11 +36,21 @@ vi.mock('../src/tools/registry.js', () => ({
   registerTools: vi.fn(),
 }))
 
+// Mock node:fs to test getVersion catch block
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...actual,
+    readFileSync: vi.fn(actual.readFileSync),
+  }
+})
+
 describe('initServer', () => {
   const originalEnv = process.env
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockConnect.mockResolvedValue(undefined)
     // Suppress console.error output during tests
     vi.spyOn(console, 'error').mockImplementation(() => {})
     process.env = { ...originalEnv }
@@ -47,6 +58,7 @@ describe('initServer', () => {
 
   afterEach(() => {
     process.env = originalEnv
+    vi.restoreAllMocks()
   })
 
   it('should initialize server when Godot is detected', async () => {
@@ -178,5 +190,38 @@ describe('initServer', () => {
     await initServer()
 
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Server started'))
+  })
+
+  it('should handle errors during server initialization', async () => {
+    const { detectGodot } = await import('../src/godot/detector.js')
+    vi.mocked(detectGodot).mockReturnValue(null)
+
+    const testError = new Error('Connection failed')
+    mockConnect.mockRejectedValue(testError)
+
+    const { initServer } = await import('../src/init-server.js')
+
+    await expect(initServer()).rejects.toThrow('Connection failed')
+    expect(console.error).toHaveBeenCalledWith('Failed to initialize server:', testError)
+  })
+
+  it('should handle errors in getVersion by returning default version', async () => {
+    const { readFileSync } = await import('node:fs')
+    vi.mocked(readFileSync).mockImplementation(() => {
+      throw new Error('File not found')
+    })
+
+    const { detectGodot } = await import('../src/godot/detector.js')
+    vi.mocked(detectGodot).mockReturnValue(null)
+
+    const { initServer } = await import('../src/init-server.js')
+    await initServer()
+
+    expect(mockServerConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        version: '0.0.0',
+      }),
+      expect.anything(),
+    )
   })
 })


### PR DESCRIPTION
## Summary

Reviewed all 28 open Jules PRs (#343-#370). Accepted 17, rejected 11 (empty diffs, duplicates, micro-optimizations).

### Security (3 accepted)
- **#370**: Prevent INI injection via newline characters in `settings_set` values and quote injection in scene paths written to `project.godot`
- **#359**: Validate `godot_path` as an actual executable Godot binary with version check before accepting it via `config.set`, preventing arbitrary binary execution
- **#357**: Add `try/catch` error handling to `initServer` for graceful failure reporting

### Performance (3 accepted)
- **#345**: Fix O(N^2) string slicing in animation `list` action by isolating each animation block before regex matching
- **#369**: Replace `split/map/filter` chain with manual loop parser for input map events parsing
- **#360**: Fix nested array parsing in `parseGodotValue` to correctly handle quoted strings, nested brackets, and parentheses

### Cleanup (5 accepted, all confirmed 0 callers in `src/`)
- **#365**: Remove unused `writeScene` from `scene-parser.ts`
- **#358**: Remove unused `getNodePath` from `scene-parser.ts`
- **#351**: Remove unused `writeProjectSettingsAsync` from `project-settings.ts`
- **#350**: Remove unused `getInputActions` from `project-settings.ts`
- **#353**: Remove unused `execGodotScript` from `headless.ts`

### Tests (3 accepted)
- **#363**: Add `escapeRegExp` utility function tests
- **#356**: Add `findClosestMatch` and `throwUnknownAction` edge case tests
- **#357**: Add `initServer` error handling and `getVersion` fallback tests

### Dependencies (4 accepted)
- **#368**: Update esbuild `^0.27.4` -> `^0.28.0`
- **#367**: Update `docker/login-action` digest
- **#343**: Update `qodo-ai/pr-agent` digest
- **#344**: Lock file maintenance

### Rejected PRs (11)
| PR | Reason |
|----|--------|
| #347 | Just adds a comment, no functional change |
| #346 | Empty diff (no changes) |
| #362 | Empty diff (no changes) |
| #364 | Empty diff (no changes) |
| #361 | Massive test file rewrite, overlaps with #353, too risky |
| #354 | Duplicate of #356 (subset) |
| #355 | Marginal optimization for directory listing |
| #352 | Ugly IIFE pattern for marginal group parsing gain |
| #348 | Micro-optimization for rename content (rejected per instructions) |
| #349 | Duplicate of #369 (same optimization, different approach) |
| #366 | Duplicate of #369 (same optimization, different approach) |

## Test plan
- [x] `bun run check` passes (biome + tsc)
- [x] `npx vitest run` passes (766 tests, 41 files)
- [x] All security validations have corresponding test coverage
- [x] All removed functions confirmed zero callers via grep

Generated with [Claude Code](https://claude.com/claude-code)