### PR TITLE
⚡ Bolt: [PERF] Redundant Array Traversals and Regex in File Search

### DIFF
--- a/src/godot/detector.ts
+++ b/src/godot/detector.ts
@@ -15,6 +15,8 @@ import type { DetectionResult, GodotVersion } from './types.js'
 
 const GODOT_BINARY_NAMES = ['godot', 'godot4', 'Godot_v4']
 const MIN_VERSION = { major: 4, minor: 1 }
+const GODOT_WIN64_EXE_RE = /^Godot_v[\d.]+-\w+_win64\.exe$/i
+const GODOT_WIN64_CONSOLE_EXE_RE = /^Godot_v[\d.]+-\w+_win64_console\.exe$/i
 
 /**
  * Parse Godot version string (e.g., "Godot Engine v4.6.stable.official")
@@ -108,10 +110,19 @@ function findWinGetGodotBinaries(localAppData: string): string[] {
       const pkgDir = join(packagesDir, dir.name)
       try {
         const files = readdirSync(pkgDir)
-        // Prefer GUI version (has actual editor window), then console as fallback
-        const regularExe = files.find((f) => /^Godot_v[\d.]+-\w+_win64\.exe$/i.test(f) && !f.includes('console'))
+        let regularExe: string | undefined
+        let consoleExe: string | undefined
+
+        for (const file of files) {
+          if (!regularExe && GODOT_WIN64_EXE_RE.test(file) && !file.includes('console')) {
+            regularExe = file
+          } else if (!consoleExe && GODOT_WIN64_CONSOLE_EXE_RE.test(file)) {
+            consoleExe = file
+          }
+          if (regularExe && consoleExe) break
+        }
+
         if (regularExe) results.push(join(pkgDir, regularExe))
-        const consoleExe = files.find((f) => /^Godot_v[\d.]+-\w+_win64_console\.exe$/i.test(f))
         if (consoleExe) results.push(join(pkgDir, consoleExe))
       } catch {
         // Skip unreadable package directories


### PR DESCRIPTION
## Summary
This PR optimizes the Godot binary detection logic for WinGet-installed packages on Windows.

## Changes
- **Optimized Loop:** Replaced multiple `.find()` calls in `findWinGetGodotBinaries` with a single `for...of` loop.
- **Early Exit:** Added an early `break` once both the GUI and console executables are found in a package directory.
- **Pre-compiled Regex:** Moved regular expressions to module-level constants (`GODOT_WIN64_EXE_RE` and `GODOT_WIN64_CONSOLE_EXE_RE`) to avoid recompilation on every call.

## Rationale
The previous implementation performed two complete traversals of the file list for every Godot package directory found. By combining these into a single pass and exiting early when both targets are found, we reduce unnecessary CPU cycles, especially in directories with many files.

## Verification Results
- All tests in `tests/godot/detector.test.ts` passed (30/30).
- Full test suite passed (653/653).
- Lint and type checks (`bun run check`) passed.

---
*PR created automatically by Jules for task [5851355218507093398](https://jules.google.com/task/5851355218507093398) started by @n24q02m*