### PR TITLE
[TEST] Missing error test in init-server.ts

### DIFF
--- a/tests/init-server.test.ts
+++ b/tests/init-server.test.ts
@@ -224,4 +224,49 @@ describe('initServer', () => {
       expect.anything(),
     )
   })
+
+  it('should handle missing version in package.json', async () => {
+    const { readFileSync } = await import('node:fs')
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({}))
+
+    const { detectGodot } = await import('../src/godot/detector.js')
+    vi.mocked(detectGodot).mockReturnValue(null)
+
+    const { initServer } = await import('../src/init-server.js')
+    await initServer()
+
+    expect(mockServerConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        version: '0.0.0',
+      }),
+      expect.anything(),
+    )
+  })
+
+  it('should handle errors when registerTools fails', async () => {
+    const { detectGodot } = await import('../src/godot/detector.js')
+    vi.mocked(detectGodot).mockReturnValue(null)
+
+    const { registerTools } = await import('../src/tools/registry.js')
+    const testError = new Error('Registration failed')
+    vi.mocked(registerTools).mockImplementation(() => {
+      throw testError
+    })
+
+    const { initServer } = await import('../src/init-server.js')
+    await expect(initServer()).rejects.toThrow('Registration failed')
+    expect(console.error).toHaveBeenCalledWith('Failed to initialize server:', testError)
+  })
+
+  it('should handle errors when detectGodot fails', async () => {
+    const { detectGodot } = await import('../src/godot/detector.js')
+    const testError = new Error('Detection failed')
+    vi.mocked(detectGodot).mockImplementation(() => {
+      throw testError
+    })
+
+    const { initServer } = await import('../src/init-server.js')
+    await expect(initServer()).rejects.toThrow('Detection failed')
+    expect(console.error).toHaveBeenCalledWith('Failed to initialize server:', testError)
+  })
 })


### PR DESCRIPTION
This PR addresses the missing error test in `src/init-server.ts` and achieves 100% branch coverage by adding test cases for:
- Missing `version` field in `package.json` (covers nullish coalescing branch).
- Failure during `registerTools` call (covers error handling in the main `try-catch` block).
- Failure during `detectGodot` call (covers early initialization error scenario).

All existing tests pass, and `src/init-server.ts` now has 100% statement, branch, and line coverage. No changes were made to the source code, only to the test suite.

---
*PR created automatically by Jules for task [16129651120568215210](https://jules.google.com/task/16129651120568215210) started by @n24q02m*