### PR TITLE
[FIX] Fix strict type checks for readdirSync mock

### DIFF
--- a/tests/godot/detector.test.ts
+++ b/tests/godot/detector.test.ts
@@ -301,21 +301,23 @@ describe('detector', () => {
         return false
       })
 
-      vi.mocked(readdirSync).mockImplementation(((path: PathLike, _options?: unknown) => {
-        if (path === packagesDir) {
-          return [
-            {
-              isDirectory: () => true,
-              name: 'GodotEngine.GodotEngine_Microsoft.Winget.Source_8wekyb3d8bbwe',
-            } as Dirent,
-          ]
+      vi.mocked(readdirSync).mockImplementation(((path: PathLike, options?: string | { withFileTypes?: boolean }) => {
+        if (options && typeof options === 'object' && 'withFileTypes' in options && options.withFileTypes) {
+          if (path === packagesDir) {
+            return [
+              {
+                isDirectory: () => true,
+                name: 'GodotEngine.GodotEngine_Microsoft.Winget.Source_8wekyb3d8bbwe',
+              } as Dirent,
+            ]
+          }
+          return []
         }
         if (path === pkgDir) {
           return ['Godot_v4.3-stable_win64.exe', 'Godot_v4.3-stable_win64_console.exe']
         }
         return []
       }) as typeof readdirSync)
-
       vi.mocked(execFileSync).mockImplementation((cmd) => {
         if (typeof cmd === 'string' && cmd.includes('Godot_v4.3-stable_win64.exe'))
           return 'Godot Engine v4.3.stable.official'


### PR DESCRIPTION
Improved the type safety of the `readdirSync` mock in `tests/godot/detector.test.ts` by explicitly handling the `withFileTypes` option and returning the correct types (`Dirent[]` or `string[]`), removing the need for `any` or `unknown` casts. Verified with `bun run check` and `bun run test`.

---
*PR created automatically by Jules for task [7449415500215169719](https://jules.google.com/task/7449415500215169719) started by @n24q02m*