### PR TITLE
fix: consolidate Jules Round 2 -- security, DoS, parsing, tests

### DIFF
--- a/src/godot/detector.ts
+++ b/src/godot/detector.ts
@@ -9,7 +9,7 @@
  */
 
 import { execFileSync } from 'node:child_process'
-import { accessSync, constants, existsSync, readdirSync } from 'node:fs'
+import { accessSync, constants, existsSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import type { DetectionResult, GodotVersion } from './types.js'
 
@@ -59,10 +59,13 @@ export function tryGetVersion(binaryPath: string): GodotVersion | null {
 }
 
 /**
- * Check if a binary path exists and is executable
+ * Check if a binary path exists, is a regular file, and is executable.
+ * Rejects directories and other non-file entries to prevent arbitrary binary execution.
  */
 export function isExecutable(filePath: string): boolean {
   try {
+    const stats = statSync(filePath)
+    if (!stats.isFile()) return false
     accessSync(filePath, constants.X_OK)
     return true
   } catch {

--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -53,9 +53,7 @@ export async function handleConfig(action: string, args: Record<string, unknown>
         )
       }
 
-      runtimeConfig[key] = value
-
-      // Apply to active config
+      // Validate before updating runtimeConfig to avoid storing invalid values
       if (key === 'project_path') {
         if (!(await pathExists(join(value, 'project.godot')))) {
           throw new GodotMCPError(
@@ -91,6 +89,9 @@ export async function handleConfig(action: string, args: Record<string, unknown>
         config.godotPath = value
         config.godotVersion = version
       }
+
+      // Only persist to runtimeConfig after all validation passes
+      runtimeConfig[key] = value
 
       return formatSuccess(`Config updated: ${key} = ${value}`)
     }

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -11,6 +11,7 @@ import type { GodotConfig, ProjectInfo } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
 import { getSetting, parseProjectSettingsAsync, setSettingInContent } from '../helpers/project-settings.js'
+import { parseCommaSeparatedList } from '../helpers/strings.js'
 
 async function parseProjectGodot(projectPath: string): Promise<ProjectInfo> {
   const configPath = join(projectPath, 'project.godot')
@@ -51,7 +52,7 @@ async function parseProjectGodot(projectPath: string): Promise<ProjectInfo> {
       if (key === 'config/features') {
         const featMatch = rawValue.match(/PackedStringArray\((.+)\)/)
         if (featMatch) {
-          info.features = featMatch[1].split(',').map((f) => f.trim().replace(/"/g, ''))
+          info.features = parseCommaSeparatedList(featMatch[1])
         }
       }
     }

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -93,7 +93,9 @@ export function formatJSON(data: unknown): { content: Array<{ type: 'text'; text
 export function findClosestMatch(input: string, validOptions: string[]): string | null {
   if (!input || validOptions.length === 0) return null
 
-  const lower = input.toLowerCase()
+  // Truncate to prevent CPU exhaustion from excessively long inputs during bigram generation
+  const safeInput = input.length > 100 ? input.slice(0, 100) : input
+  const lower = safeInput.toLowerCase()
   let bestMatch: string | null = null
   let bestScore = 0
 
@@ -125,10 +127,12 @@ export function findClosestMatch(input: string, validOptions: string[]): string 
  * Throw a standardized "Unknown action" error with valid actions listed.
  */
 export function throwUnknownAction(action: string, validActions: string[]): never {
-  const closest = findClosestMatch(action, validActions)
+  // Truncate to prevent log bloat and memory issues from excessively long inputs
+  const safeAction = action.length > 100 ? `${action.slice(0, 100)}...` : action
+  const closest = findClosestMatch(safeAction, validActions)
   const suggestion = closest ? ` Did you mean '${closest}'?` : ''
   throw new GodotMCPError(
-    `Unknown action: ${action}.${suggestion}`,
+    `Unknown action: ${safeAction}.${suggestion}`,
     'INVALID_ACTION',
     `Valid actions: ${validActions.join(', ')}. Use help tool for full docs.`,
   )

--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -12,6 +12,7 @@
  */
 
 import { readFile } from 'node:fs/promises'
+import { parseCommaSeparatedList } from './strings.js'
 
 // Pre-compiled regular expressions for parsing scene sections
 const rxGdSceneFormat = /format=(\d+)/
@@ -180,12 +181,7 @@ export function parseSceneContent(content: string): ParsedScene {
                 parent: parentMatch?.[1],
                 instance: instanceMatch?.[1],
                 properties: {},
-                groups: groupsMatch
-                  ? groupsMatch[1]
-                      .split(',')
-                      .map((g) => g.trim().replace(/"/g, ''))
-                      .filter(Boolean)
-                  : undefined,
+                groups: groupsMatch ? parseCommaSeparatedList(groupsMatch[1]) : undefined,
               }
             }
           } else if (secondChar === 99) {

--- a/src/tools/helpers/strings.ts
+++ b/src/tools/helpers/strings.ts
@@ -1,0 +1,35 @@
+/**
+ * String parsing utilities
+ */
+
+/**
+ * Fast-path parser for comma-separated lists, avoiding split/map/filter allocations.
+ * Uses a single-pass loop to find delimiters, trimming whitespace and quotes in-place.
+ */
+export function parseCommaSeparatedList(str: string): string[] {
+  if (!str) return []
+  const result: string[] = []
+  let start = 0
+  const len = str.length
+
+  while (start < len) {
+    const commaIdx = str.indexOf(',', start)
+    const end = commaIdx === -1 ? len : commaIdx
+
+    // Trim leading whitespace and quotes
+    let i = start
+    let j = end - 1
+
+    while (i <= j && (str.charCodeAt(i) <= 32 || str[i] === '"')) i++
+    while (j >= i && (str.charCodeAt(j) <= 32 || str[j] === '"')) j--
+
+    if (i <= j) {
+      result.push(str.slice(i, j + 1))
+    }
+
+    if (commaIdx === -1) break
+    start = commaIdx + 1
+  }
+
+  return result
+}

--- a/tests/godot/detector.test.ts
+++ b/tests/godot/detector.test.ts
@@ -1,21 +1,14 @@
 import { execFileSync } from 'node:child_process'
-import { type Dirent, existsSync, type PathLike, readdirSync } from 'node:fs'
+import type { Dirent, PathLike } from 'node:fs'
+import { accessSync, existsSync, readdirSync, statSync } from 'node:fs'
 /**
  * Tests for Godot binary detector
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { detectGodot, isVersionSupported, parseGodotVersion } from '../../src/godot/detector.js'
+import { detectGodot, isExecutable, isVersionSupported, parseGodotVersion } from '../../src/godot/detector.js'
 
 vi.mock('node:child_process')
 vi.mock('node:fs')
-vi.mock('node:path', () => ({
-  join: (...args: string[]) => {
-    if (process.platform === 'win32') {
-      return args.join('\\')
-    }
-    return args.join('/')
-  },
-}))
 
 describe('detector', () => {
   // ==========================================
@@ -169,6 +162,37 @@ describe('detector', () => {
   })
 
   // ==========================================
+  // isExecutable
+  // ==========================================
+  describe('isExecutable', () => {
+    it('should return true for a regular executable file', () => {
+      vi.mocked(statSync).mockReturnValue({ isFile: () => true } as unknown as import('node:fs').Stats)
+      vi.mocked(accessSync).mockReturnValue(undefined)
+      expect(isExecutable('/usr/bin/godot')).toBe(true)
+    })
+
+    it('should return false for a directory', () => {
+      vi.mocked(statSync).mockReturnValue({ isFile: () => false } as unknown as import('node:fs').Stats)
+      expect(isExecutable('/usr/bin/')).toBe(false)
+    })
+
+    it('should return false when file does not exist', () => {
+      vi.mocked(statSync).mockImplementation(() => {
+        throw new Error('ENOENT')
+      })
+      expect(isExecutable('/nonexistent')).toBe(false)
+    })
+
+    it('should return false when file exists but is not executable', () => {
+      vi.mocked(statSync).mockReturnValue({ isFile: () => true } as unknown as import('node:fs').Stats)
+      vi.mocked(accessSync).mockImplementation(() => {
+        throw new Error('EACCES')
+      })
+      expect(isExecutable('/usr/bin/readme.txt')).toBe(false)
+    })
+  })
+
+  // ==========================================
   // detectGodot
   // ==========================================
   describe('detectGodot', () => {
@@ -178,6 +202,9 @@ describe('detector', () => {
     beforeEach(() => {
       vi.clearAllMocks()
       process.env = { ...originalEnv }
+      // Default: statSync returns a file, accessSync succeeds (isExecutable passes)
+      vi.mocked(statSync).mockReturnValue({ isFile: () => true } as unknown as import('node:fs').Stats)
+      vi.mocked(accessSync).mockReturnValue(undefined)
     })
 
     afterEach(() => {
@@ -335,6 +362,9 @@ describe('detector', () => {
         throw new Error('not found')
       })
       vi.mocked(existsSync).mockReturnValue(false)
+      vi.mocked(statSync).mockImplementation(() => {
+        throw new Error('ENOENT')
+      })
       vi.mocked(readdirSync).mockImplementation(((_path: PathLike, _options?: unknown) => []) as typeof readdirSync)
 
       expect(detectGodot()).toBeNull()

--- a/tests/helpers/errors.test.ts
+++ b/tests/helpers/errors.test.ts
@@ -173,6 +173,38 @@ describe('errors', () => {
     it('should return null if no match is good enough', () => {
       expect(findClosestMatch('xyz', ['create', 'delete'])).toBeNull()
     })
+
+    it('should truncate input to 100 characters to prevent DoS', () => {
+      const longInput = 'a'.repeat(200)
+      const validOptions = ['a'.repeat(100), 'b'.repeat(100)]
+      expect(findClosestMatch(longInput, validOptions)).toBe('a'.repeat(100))
+    })
+
+    it('should return the best fuzzy match when multiple options match', () => {
+      expect(findClosestMatch('typescript', ['javascript', 'coffeescript'])).toBe('coffeescript')
+    })
+
+    it('should handle single character inputs (no bigrams)', () => {
+      expect(findClosestMatch('a', ['abc', 'def'])).toBe('abc')
+      expect(findClosestMatch('x', ['abc', 'def'])).toBeNull()
+    })
+
+    it('should handle single character options (no bigrams)', () => {
+      expect(findClosestMatch('abc', ['a', 'z'])).toBe('a')
+      expect(findClosestMatch('uvw', ['a', 'z'])).toBeNull()
+    })
+
+    it('should return the first match in case of a score tie', () => {
+      expect(findClosestMatch('abcd', ['abce', 'abcf'])).toBe('abce')
+    })
+
+    it('should respect the 0.4 similarity threshold', () => {
+      // 0.4 exactly: (2 * 2) / (5 + 5) = 0.4. Should NOT match (> 0.4 required).
+      expect(findClosestMatch('123456', ['123xyz'])).toBeNull()
+
+      // 0.5: (2 * 2) / (4 + 4) = 0.5. Should match.
+      expect(findClosestMatch('12345', ['123xy'])).toBe('123xy')
+    })
   })
 
   // ==========================================
@@ -214,6 +246,17 @@ describe('errors', () => {
       } catch (err) {
         const error = err as GodotMCPError
         expect(error.suggestion).toContain('Valid actions: a, b')
+      }
+    })
+
+    it('should truncate overly long action names in the error message', () => {
+      const longAction = 'a'.repeat(200)
+      try {
+        throwUnknownAction(longAction, ['create', 'delete'])
+      } catch (err) {
+        const error = err as GodotMCPError
+        expect(error.message).toContain(`Unknown action: ${'a'.repeat(100)}...`)
+        expect(error.message.length).toBeLessThan(250)
       }
     })
   })

--- a/tests/helpers/strings.test.ts
+++ b/tests/helpers/strings.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { parseCommaSeparatedList } from '../../src/tools/helpers/strings.js'
+
+describe('strings helpers', () => {
+  describe('parseCommaSeparatedList', () => {
+    it('should parse a simple comma-separated list', () => {
+      expect(parseCommaSeparatedList('a,b,c')).toEqual(['a', 'b', 'c'])
+    })
+
+    it('should trim whitespace', () => {
+      expect(parseCommaSeparatedList(' a , b , c ')).toEqual(['a', 'b', 'c'])
+    })
+
+    it('should trim quotes', () => {
+      expect(parseCommaSeparatedList('"a","b","c"')).toEqual(['a', 'b', 'c'])
+    })
+
+    it('should trim whitespace and quotes combined', () => {
+      expect(parseCommaSeparatedList(' "a" , "b" , "c" ')).toEqual(['a', 'b', 'c'])
+    })
+
+    it('should skip empty items', () => {
+      expect(parseCommaSeparatedList(' , , ')).toEqual([])
+    })
+
+    it('should handle single item', () => {
+      expect(parseCommaSeparatedList('"GroupA"')).toEqual(['GroupA'])
+    })
+
+    it('should handle empty string', () => {
+      expect(parseCommaSeparatedList('')).toEqual([])
+    })
+
+    it('should handle items with inner spaces', () => {
+      expect(parseCommaSeparatedList('word1 word2, word3 word4')).toEqual(['word1 word2', 'word3 word4'])
+    })
+  })
+})

--- a/tests/init-server.test.ts
+++ b/tests/init-server.test.ts
@@ -49,7 +49,7 @@ describe('initServer', () => {
   const originalEnv = process.env
 
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.resetAllMocks()
     mockConnect.mockResolvedValue(undefined)
     // Suppress console.error output during tests
     vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -192,7 +192,7 @@ describe('initServer', () => {
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Server started'))
   })
 
-  it('should handle errors during server initialization', async () => {
+  it('should handle errors during server initialization (connect failure)', async () => {
     const { detectGodot } = await import('../src/godot/detector.js')
     vi.mocked(detectGodot).mockReturnValue(null)
 
@@ -203,6 +203,51 @@ describe('initServer', () => {
 
     await expect(initServer()).rejects.toThrow('Connection failed')
     expect(console.error).toHaveBeenCalledWith('Failed to initialize server:', testError)
+  })
+
+  it('should handle errors when registerTools fails', async () => {
+    const { detectGodot } = await import('../src/godot/detector.js')
+    vi.mocked(detectGodot).mockReturnValue(null)
+
+    const { registerTools } = await import('../src/tools/registry.js')
+    const testError = new Error('Registration failed')
+    vi.mocked(registerTools).mockImplementation(() => {
+      throw testError
+    })
+
+    const { initServer } = await import('../src/init-server.js')
+    await expect(initServer()).rejects.toThrow('Registration failed')
+    expect(console.error).toHaveBeenCalledWith('Failed to initialize server:', testError)
+  })
+
+  it('should handle errors when detectGodot fails', async () => {
+    const { detectGodot } = await import('../src/godot/detector.js')
+    const testError = new Error('Detection failed')
+    vi.mocked(detectGodot).mockImplementation(() => {
+      throw testError
+    })
+
+    const { initServer } = await import('../src/init-server.js')
+    await expect(initServer()).rejects.toThrow('Detection failed')
+    expect(console.error).toHaveBeenCalledWith('Failed to initialize server:', testError)
+  })
+
+  it('should handle missing version in package.json', async () => {
+    const { readFileSync } = await import('node:fs')
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({}))
+
+    const { detectGodot } = await import('../src/godot/detector.js')
+    vi.mocked(detectGodot).mockReturnValue(null)
+
+    const { initServer } = await import('../src/init-server.js')
+    await initServer()
+
+    expect(mockServerConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        version: '0.0.0',
+      }),
+      expect.anything(),
+    )
   })
 
   it('should handle errors in getVersion by returning default version', async () => {


### PR DESCRIPTION
## Summary
Consolidates 5 accepted Jules PRs (#382, #389, #390, #376, #373) into a single PR, implementing changes on main branch. Closes 13 other Jules PRs that were superseded by #371 or each other.

### Security (#382)
- `isExecutable` now validates `statSync().isFile()` to reject directories
- Config `set` action validates before persisting to `runtimeConfig` (prevents storing invalid values on validation failure)

### DoS Prevention (#390)
- `findClosestMatch` truncates input to 100 chars before bigram generation (prevents CPU exhaustion)
- `throwUnknownAction` truncates action name to 100 chars in error messages (prevents log bloat)

### Parsing Optimization (#389)
- New `parseCommaSeparatedList` utility in `src/tools/helpers/strings.ts` -- single-pass parser replaces `.split(',').map().filter()` chains in scene-parser groups and project features parsing

### Test Coverage (#373, #376)
- `isExecutable`: directory rejection, missing file, non-executable file
- `findClosestMatch`: DoS truncation, score ties, threshold boundary, single-char inputs
- `throwUnknownAction`: long action name truncation
- `initServer`: registerTools failure, detectGodot failure, missing package.json version

### Closed PRs (13 total)
- **Already fixed by #371**: #372, #377, #380, #385, #386 (unused function removals -- empty diffs)
- **Superseded**: #383, #384 (comma-list parsing -- consolidated into #389 approach), #378 (headless test consolidation -- done by #382), #381 (readdirSync mock fix -- done by #382)
- **No value**: #379, #374 (already-tested functions), #375 (negligible micro-optimization)
- **Renovate**: #388 (lock file maintenance)

## Test plan
- [x] `bun x vitest run` -- 788 tests pass
- [x] `bun run check` -- biome + tsc clean