### PR TITLE
feat: migrate code review from Qodo to CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,23 @@
+language: "en-US"
+reviews:
+  auto_review:
+    enabled: true
+    drafts: false
+    ignore_usernames:
+      - "n24q02m"
+      - "dependabot[bot]"
+      - "renovate[bot]"
+      - "github-actions[bot]"
+      - "devin-ai-integration[bot]"
+      - "google-labs-jules[bot]"
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  auto_incremental_review: true
+issue_enrichment:
+  auto_enrich:
+    enabled: true
+  planning:
+    enabled: true
+chat:
+  auto_reply: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,6 @@ on:
       - ready_for_review
   push:
     branches: [main]
-  issue_comment:
-    types:
-      - created
-      - edited
   issues:
     types:
       - opened
@@ -92,60 +88,6 @@ jobs:
           fail-on-severity: moderate
           comment-summary-in-pr: always
 
-  ai_pr_review:
-    name: Qodo AI Code Review
-    if: >-
-      (
-        github.event_name == 'issue_comment'
-        && github.event.sender.type != 'Bot'
-      ) || (
-        github.event_name == 'pull_request_target'
-        && github.event.sender.type != 'Bot'
-        && github.event.pull_request.user.login != 'n24q02m'
-      )
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Load custom instructions
-        run: |
-          if [ -f ".github/best_practices.md" ]; then
-            INSTRUCTIONS=$(cat .github/best_practices.md)
-            RANDOM_EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-            echo "CUSTOM_INSTRUCTIONS<<$RANDOM_EOF" >> "$GITHUB_ENV"
-            echo "$INSTRUCTIONS" >> "$GITHUB_ENV"
-            echo "$RANDOM_EOF" >> "$GITHUB_ENV"
-          fi
-
-      - name: Authenticate to GCP (Vertex AI)
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-        with:
-          workload_identity_provider: ${{ vars.VERTEX_WIF_PROVIDER }}
-          service_account: ${{ vars.VERTEX_SERVICE_ACCOUNT }}
-
-      - name: PR Agent action step
-        uses: qodo-ai/pr-agent@d82f7d3e696cd00822694aaa3096265d3889f3f1 # main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERTEXAI_PROJECT: ${{ vars.VERTEX_PROJECT }}
-          VERTEXAI_LOCATION: global
-          PR_REVIEWER__EXTRA_INSTRUCTIONS: ${{ env.CUSTOM_INSTRUCTIONS }}
-          PR_CODE_SUGGESTIONS__EXTRA_INSTRUCTIONS: ${{ env.CUSTOM_INSTRUCTIONS }}
-          PR_DESCRIPTION__EXTRA_INSTRUCTIONS: ${{ env.CUSTOM_INSTRUCTIONS }}
-          GITHUB_ACTION_CONFIG__AUTO_REVIEW: "true"
-          GITHUB_ACTION_CONFIG__AUTO_DESCRIBE: "true"
-          GITHUB_ACTION_CONFIG__AUTO_IMPROVE: "true"
-          GITHUB_ACTION_CONFIG__HANDLE_PR_ACTIONS: '["opened", "reopened", "ready_for_review", "synchronize"]'
-
-  # ============================================================================
-  # Email Notification (External Contributors)
-  # ============================================================================
   email-notify:
     name: Email Notification
     if: >-

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,3 +1,0 @@
-[config]
-model = "vertex_ai/gemini-3-flash-preview"
-fallback_models = ["vertex_ai/gemini-2.5-flash"]


### PR DESCRIPTION
## Summary

- Remove `ai_pr_review` job (Qodo/pr-agent + Vertex AI WIF) from `ci.yml`
- Remove `issue_comment` trigger from `ci.yml` (CodeRabbit uses its own webhook)
- Delete `.pr_agent.toml`
- Add `.coderabbit.yaml`: contributor-only review (owner + 5 bot accounts excluded), issue enrichment enabled, chat disabled

## Test plan

- [ ] CI runs pass without `ai_pr_review` job
- [ ] CodeRabbit reviews new PRs from external contributors
- [ ] CodeRabbit does NOT review PRs/comments from `n24q02m` or bots
- [ ] CodeRabbit enriches new issues automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)