### PR TITLE
[PERF] Redundant Array Traversals and Regex in File Search

### DIFF
--- a/src/godot/detector.ts
+++ b/src/godot/detector.ts
@@ -13,6 +13,9 @@ import { accessSync, constants, existsSync, readdirSync, statSync } from 'node:f
 import { join } from 'node:path'
 import type { DetectionResult, GodotVersion } from './types.js'
 
+const GODOT_WIN64_GUI_RE = /^Godot_v[\d.]+-\w+_win64\.exe$/i
+const GODOT_WIN64_CONSOLE_RE = /^Godot_v[\d.]+-\w+_win64_console\.exe$/i
+
 const GODOT_BINARY_NAMES = ['godot', 'godot4', 'Godot_v4']
 const MIN_VERSION = { major: 4, minor: 1 }
 
@@ -111,10 +114,20 @@ function findWinGetGodotBinaries(localAppData: string): string[] {
       const pkgDir = join(packagesDir, dir.name)
       try {
         const files = readdirSync(pkgDir)
-        // Prefer GUI version (has actual editor window), then console as fallback
-        const regularExe = files.find((f) => /^Godot_v[\d.]+-\w+_win64\.exe$/i.test(f) && !f.includes('console'))
+        let regularExe: string | undefined
+        let consoleExe: string | undefined
+
+        for (const file of files) {
+          if (!regularExe && GODOT_WIN64_GUI_RE.test(file) && !file.includes('console')) {
+            regularExe = file
+          } else if (!consoleExe && GODOT_WIN64_CONSOLE_RE.test(file)) {
+            consoleExe = file
+          }
+
+          if (regularExe && consoleExe) break
+        }
+
         if (regularExe) results.push(join(pkgDir, regularExe))
-        const consoleExe = files.find((f) => /^Godot_v[\d.]+-\w+_win64_console\.exe$/i.test(f))
         if (consoleExe) results.push(join(pkgDir, consoleExe))
       } catch {
         // Skip unreadable package directories


### PR DESCRIPTION
### 💡 What
Optimized the `findWinGetGodotBinaries` function in `src/godot/detector.ts` by:
- Replacing redundant `files.find` calls with a single `for...of` loop.
- Using pre-compiled regex constants (`GODOT_WIN64_GUI_RE` and `GODOT_WIN64_CONSOLE_RE`) to avoid re-parsing overhead.
- Adding an early `break` when both GUI and console binaries are found.

### 🎯 Why
Redundant array traversals and regex creation in directory searches can impact performance, especially when scanning multiple package directories.

### 📊 Impact
Reduced time complexity and memory allocations during Godot binary detection on Windows.

### 🔬 Measurement
Verified with `bun x vitest run tests/godot/detector.test.ts` (all 34 tests pass).
Confirmed formatting and import sorting with `bun run check`.

---
*PR created automatically by Jules for task [14569972896058360662](https://jules.google.com/task/14569972896058360662) started by @n24q02m*