### PR TITLE
🧹 [CLEANUP] Unused Function: execGodotScript

### DIFF
--- a/docs/superpowers/plans/2026-03-31-stable-release.md
+++ b/docs/superpowers/plans/2026-03-31-stable-release.md
@@ -182,7 +182,7 @@ Add these tests to `tests/godot/headless-full.test.ts` inside the existing `desc
 
 ```typescript
 // Add to imports at top of file:
-import { execGodotAsync, execGodotScript, execGodotSync, launchGodotEditor, runGodotProject } from '../../src/godot/headless.js'
+import { execGodotAsync, execGodotSync, launchGodotEditor, runGodotProject } from '../../src/godot/headless.js'
 
 // Add new describe block after the existing launchGodotEditor describe:
 
@@ -300,7 +300,7 @@ Expected: New tests should fail because `execGodotAsync` is not yet imported in 
 The import line in `tests/godot/headless-full.test.ts` at line 7 already imports `execGodotSync` but not `execGodotAsync`. Update it:
 
 ```typescript
-import { execGodotAsync, execGodotScript, execGodotSync, launchGodotEditor, runGodotProject } from '../../src/godot/headless.js'
+import { execGodotAsync, execGodotSync, launchGodotEditor, runGodotProject } from '../../src/godot/headless.js'
 ```
 
 Also ensure `execFile` is in the mock at line 9-13:


### PR DESCRIPTION
### 🧹 [CLEANUP] Unused Function: execGodotScript

#### 🎯 Why
The `execGodotScript` function was identified as an unused function in `src/godot/headless.ts`. Although it was already removed from the source file in the current state of the repository, stale references remained in the documentation.

#### 💡 What
- Removed stale `execGodotScript` import and documentation references from `docs/superpowers/plans/2026-03-31-stable-release.md`.
- Verified that no other occurrences of `execGodotScript` exist in the repository.

#### ✅ Verification
- Ran `grep -r "execGodotScript" .` to ensure zero remaining references.
- Executed `bun run check` and `bun run test` to verify project integrity. All 675 tests passed.

#### ✨ Result
Improved code health by removing dead documentation and ensuring no stale references remain for a deleted function.

---
*PR created automatically by Jules for task [482046591549278528](https://jules.google.com/task/482046591549278528) started by @n24q02m*