### PR TITLE
[SECURITY] Arbitrary Binary Execution via godot_path Configuration

### DIFF
--- a/src/godot/detector.ts
+++ b/src/godot/detector.ts
@@ -17,19 +17,44 @@ const GODOT_BINARY_NAMES = ['godot', 'godot4', 'Godot_v4']
 const MIN_VERSION = { major: 4, minor: 1 }
 
 /**
- * Parse Godot version string (e.g., "Godot Engine v4.6.stable.official")
+ * Parse Godot version string (e.g., "Godot Engine v4.3.stable.official")
+ *
+ * Security: Uses strict regex with anchors and Godot-specific heuristics
+ * to prevent arbitrary binaries (like ls or node) from spoofing Godot.
  */
 export function parseGodotVersion(versionOutput: string): GodotVersion | null {
-  // Match patterns like "Godot Engine v4.6.stable" or "4.6.1.stable"
-  const match = versionOutput.match(/v?(\d+)\.(\d+)(?:\.(\d+))?(?:[.\s-]+([^\s.-]\S*))?/)
+  const trimmed = versionOutput.trim()
+  if (!trimmed) return null
+
+  // Match patterns like "Godot Engine v4.6.stable", "4.6.1.stable", or "Godot_v4.3-stable"
+  // Using ^ and $ anchors is critical for security to ensure we match the whole
+  // output and not just a version number hidden inside a different tool's output.
+  const match = trimmed.match(/^(?:Godot[ _](?:Engine[ _])?)?v?(\d+)\.(\d+)(?:\.(\d+))?(?:[.\s-]+([^\s.-]\S*))?$/i)
   if (!match) return null
 
+  const major = Number.parseInt(match[1], 10)
+  const minor = Number.parseInt(match[2], 10)
+  const patch = match[3] ? Number.parseInt(match[3], 10) : 0
+  const labelRaw = match[4]?.replace(/\.$/, '')
+
+  // Security Heuristic: Ensure this is actually a Godot binary.
+  // Godot versions typically include "Godot" or common labels (stable, official, etc.).
+  // Generic binaries (like node) that just return "vX.Y.Z" are rejected.
+  const isLikelyGodot =
+    trimmed.toLowerCase().includes('godot') ||
+    (labelRaw && /stable|dev|beta|rc|alpha|mono|official/i.test(labelRaw)) ||
+    // Fallback for custom builds: expect a reasonable Godot 4.x version range
+    // if no other markers are present.
+    (major === 4 && minor >= 0 && minor < 10)
+
+  if (!isLikelyGodot) return null
+
   return {
-    major: Number.parseInt(match[1], 10),
-    minor: Number.parseInt(match[2], 10),
-    patch: match[3] ? Number.parseInt(match[3], 10) : 0,
-    label: match[4]?.replace(/\.$/, '') || 'stable',
-    raw: versionOutput.trim(),
+    major,
+    minor,
+    patch,
+    label: labelRaw || 'stable',
+    raw: trimmed,
   }
 }
 

--- a/src/init-server.ts
+++ b/src/init-server.ts
@@ -15,6 +15,8 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { detectGodot } from './godot/detector.js'
 import type { GodotConfig } from './godot/types.js'
+import { GodotMCPError } from './tools/helpers/errors.js'
+import { pathExists } from './tools/helpers/paths.js'
 import { registerTools } from './tools/registry.js'
 
 const SERVER_NAME = 'better-godot-mcp'
@@ -47,6 +49,18 @@ export async function initServer(): Promise<void> {
 
     // Resolve project path from env var (tools also accept project_path per call)
     const projectPath = process.env.GODOT_PROJECT_PATH ?? null
+
+    // Security: Validate GODOT_PROJECT_PATH if provided
+    if (projectPath) {
+      const isProject = await pathExists(join(projectPath, 'project.godot'))
+      if (!isProject) {
+        throw new GodotMCPError(
+          'Invalid GODOT_PROJECT_PATH',
+          'INVALID_ARGS',
+          `The directory at '${projectPath}' (from GODOT_PROJECT_PATH) does not contain a 'project.godot' file.`,
+        )
+      }
+    }
 
     const config: GodotConfig = {
       godotPath: detection?.path ?? null,

--- a/tests/init-server.test.ts
+++ b/tests/init-server.test.ts
@@ -36,6 +36,11 @@ vi.mock('../src/tools/registry.js', () => ({
   registerTools: vi.fn(),
 }))
 
+vi.mock('../src/tools/helpers/paths.js', () => ({
+  pathExists: vi.fn().mockResolvedValue(true),
+  safeResolve: vi.fn().mockImplementation((_base, target) => target),
+}))
+
 // Mock node:fs to test getVersion catch block
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>()
@@ -54,6 +59,11 @@ describe('initServer', () => {
     // Suppress console.error output during tests
     vi.spyOn(console, 'error').mockImplementation(() => {})
     process.env = { ...originalEnv }
+
+    // Default pathExists to true
+    import('../src/tools/helpers/paths.js').then((m) => {
+      vi.mocked(m.pathExists).mockResolvedValue(true)
+    })
   })
 
   afterEach(() => {
@@ -128,9 +138,11 @@ describe('initServer', () => {
     )
   })
 
-  it('should read GODOT_PROJECT_PATH from environment', async () => {
+  it('should read GODOT_PROJECT_PATH from environment and validate it', async () => {
     const { detectGodot } = await import('../src/godot/detector.js')
+    const { pathExists } = await import('../src/tools/helpers/paths.js')
     vi.mocked(detectGodot).mockReturnValue(null)
+    vi.mocked(pathExists).mockResolvedValue(true)
     process.env.GODOT_PROJECT_PATH = '/path/to/my/project'
 
     const { initServer } = await import('../src/init-server.js')
@@ -143,6 +155,18 @@ describe('initServer', () => {
         projectPath: '/path/to/my/project',
       }),
     )
+    expect(pathExists).toHaveBeenCalled()
+  })
+
+  it('should throw error if GODOT_PROJECT_PATH is invalid', async () => {
+    const { detectGodot } = await import('../src/godot/detector.js')
+    const { pathExists } = await import('../src/tools/helpers/paths.js')
+    vi.mocked(detectGodot).mockReturnValue(null)
+    vi.mocked(pathExists).mockResolvedValue(false)
+    process.env.GODOT_PROJECT_PATH = '/invalid/path'
+
+    const { initServer } = await import('../src/init-server.js')
+    await expect(initServer()).rejects.toThrow('Invalid GODOT_PROJECT_PATH')
   })
 
   it('should pass null projectPath if GODOT_PROJECT_PATH is not set', async () => {

--- a/tests/security/binary_validation.test.ts
+++ b/tests/security/binary_validation.test.ts
@@ -30,7 +30,7 @@ describe('Security: Binary Validation', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     // Default to a regular executable
-    vi.mocked(fs.statSync).mockReturnValue({ isFile: () => true } as unknown as string)
+    vi.mocked(fs.statSync).mockReturnValue({ isFile: () => true } as unknown as fs.Stats)
     vi.mocked(fs.accessSync).mockReturnValue(undefined)
   })
 

--- a/tests/security/binary_validation.test.ts
+++ b/tests/security/binary_validation.test.ts
@@ -1,0 +1,83 @@
+import * as child_process from 'node:child_process'
+import * as fs from 'node:fs'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleConfig } from '../../src/tools/composite/config.js'
+
+// Mock dependencies
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}))
+
+vi.mock('node:fs', () => ({
+  statSync: vi.fn(),
+  accessSync: vi.fn(),
+  constants: { X_OK: 1 },
+}))
+
+vi.mock('../../src/tools/helpers/paths.js', () => ({
+  pathExists: vi.fn(),
+}))
+
+describe('Security: Binary Validation', () => {
+  const config: GodotConfig = {
+    godotPath: null,
+    godotVersion: null,
+    projectPath: null,
+    activePids: [],
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    // Default to a regular executable
+    vi.mocked(fs.statSync).mockReturnValue({ isFile: () => true } as unknown as string)
+    vi.mocked(fs.accessSync).mockReturnValue(undefined)
+  })
+
+  it('should reject non-Godot binaries (like ls)', async () => {
+    // Simulate 'ls --version' output
+    vi.mocked(child_process.execFileSync).mockReturnValue('ls (GNU coreutils) 9.1\n' as unknown as string)
+
+    await expect(handleConfig('set', { key: 'godot_path', value: '/usr/bin/ls' }, config)).rejects.toThrow(
+      'Invalid Godot binary',
+    )
+
+    expect(config.godotPath).toBeNull()
+  })
+
+  it('should reject generic "v1.2.3" version strings from other tools', async () => {
+    // Simulate 'node --version' output
+    vi.mocked(child_process.execFileSync).mockReturnValue('v20.10.0\n' as unknown as string)
+
+    await expect(handleConfig('set', { key: 'godot_path', value: '/usr/bin/node' }, config)).rejects.toThrow(
+      'Invalid Godot binary',
+    )
+  })
+
+  it('should accept valid Godot version strings', async () => {
+    // Simulate 'godot --version' output
+    vi.mocked(child_process.execFileSync).mockReturnValue('Godot Engine v4.3.stable.official\n' as unknown as string)
+
+    const result = await handleConfig('set', { key: 'godot_path', value: '/usr/bin/godot' }, config)
+
+    expect(result.isError).toBeFalsy()
+    expect(config.godotPath).toBe('/usr/bin/godot')
+    expect(config.godotVersion?.major).toBe(4)
+  })
+
+  it('should accept complex Godot build filenames', async () => {
+    vi.mocked(child_process.execFileSync).mockReturnValue('Godot_v4.3-stable_win64_console.exe\n' as unknown as string)
+
+    await handleConfig('set', { key: 'godot_path', value: 'C:\\Godot.exe' }, config)
+    expect(config.godotPath).toBe('C:\\Godot.exe')
+  })
+
+  it('should reject binaries that return version but are not likely Godot', async () => {
+    // A binary that returns a version-like string but doesn't mention Godot and isn't a known Godot version
+    vi.mocked(child_process.execFileSync).mockReturnValue('1.2.3\n' as unknown as string)
+
+    await expect(handleConfig('set', { key: 'godot_path', value: '/usr/bin/fake' }, config)).rejects.toThrow(
+      'Invalid Godot binary',
+    )
+  })
+})


### PR DESCRIPTION
Strengthen Godot binary validation to prevent execution of arbitrary binaries.

- Implement strict regex anchors and Godot-specific heuristics in parseGodotVersion to ensure only valid Godot binaries are accepted.
- Add validation for GODOT_PROJECT_PATH environment variable during server initialization to ensure it points to a valid Godot project.
- Add security regression tests to verify rejection of non-Godot binaries (e.g., ls, node).
- Update init-server.test.ts to cover new validation logic.

---
*PR created automatically by Jules for task [9149370337278956041](https://jules.google.com/task/9149370337278956041) started by @n24q02m*