### PR TITLE
⚡ Bolt: [performance improvement] Optimize string parsing in signals disconnect

### DIFF
--- a/src/tools/composite/signals.ts
+++ b/src/tools/composite/signals.ts
@@ -98,19 +98,34 @@ export async function handleSignals(action: string, args: Record<string, unknown
       }
 
       const content = await readScene()
-      const lines = content.split('\n')
-      const filtered = lines.filter((line) => {
+      const filtered: string[] = []
+      let pos = 0
+      const len = content.length
+      let found = false
+
+      while (pos < len) {
+        let nextNewline = content.indexOf('\n', pos)
+        if (nextNewline === -1) nextNewline = len
+
+        const line = content.substring(pos, nextNewline)
         const trimmed = line.trim()
-        if (!trimmed.startsWith('[connection')) return true
-        return !(
+
+        if (
+          trimmed.startsWith('[connection') &&
           trimmed.includes(`signal="${signal}"`) &&
           trimmed.includes(`from="${from}"`) &&
           trimmed.includes(`to="${to}"`) &&
           trimmed.includes(`method="${method}"`)
-        )
-      })
+        ) {
+          found = true
+        } else {
+          filtered.push(line)
+        }
 
-      if (filtered.length === lines.length) {
+        pos = nextNewline + 1
+      }
+
+      if (!found) {
         throw new GodotMCPError(
           'Connection not found',
           'SIGNAL_ERROR',


### PR DESCRIPTION
Replaced `.split('\n')` and `.filter()` with a single-pass manual loop using `.indexOf('\n')` and `.substring()` in the `disconnect` action of `src/tools/composite/signals.ts`.

Godot `.tscn` files can be quite large. Using `.split('\n')` allocates a large intermediate array of strings, which then gets processed by `.filter()`. A manual loop avoids these allocations, reducing memory overhead and garbage collection pressure, improving performance especially on large scenes.

All unit tests successfully passed, including `bun run test` and `bun run check`. Added corresponding learning to `.jules/bolt.md`.

---
*PR created automatically by Jules for task [15923021463766099376](https://jules.google.com/task/15923021463766099376) started by @n24q02m*