### PR TITLE
⚡ Bolt: [performance improvement] optimize scene node listing allocations

### DIFF
--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -4,7 +4,7 @@
  */
 
 import { readFile, writeFile } from 'node:fs/promises'
-import type { GodotConfig, SceneNode } from '../../godot/types.js'
+import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
 import {
@@ -12,30 +12,8 @@ import {
   parseSceneContent,
   removeNodeFromContent,
   renameNodeInContent,
-  type SceneNodeInfo,
   setNodePropertyInContent,
 } from '../helpers/scene-parser.js'
-
-/**
- * Map scene-parser's SceneNodeInfo to internal SceneNode format
- */
-function mapToSceneNode(node: SceneNodeInfo): SceneNode {
-  const properties = { ...node.properties }
-  let script: string | null = null
-
-  if (properties.script) {
-    script = properties.script
-    delete properties.script
-  }
-
-  return {
-    name: node.name,
-    type: node.type || 'Node',
-    parent: node.parent || null,
-    properties,
-    script,
-  }
-}
 
 function resolveScenePath(projectPath: string, scenePath: string): string {
   return safeResolve(projectPath, scenePath)
@@ -165,17 +143,23 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
 
       const content = await readFile(fullPath, 'utf-8')
       const scene = parseSceneContent(content)
-      const nodes = scene.nodes.map(mapToSceneNode)
+
+      // ⚡ Bolt: Eliminated intermediate array allocation and object cloning (mapToSceneNode).
+      // We now iterate once and directly extract exactly what's needed for the JSON response.
+      const formattedNodes = []
+      for (const n of scene.nodes) {
+        formattedNodes.push({
+          name: n.name,
+          type: n.type || 'Node',
+          parent: n.parent || '(root)',
+          hasScript: n.properties.script !== undefined,
+        })
+      }
 
       return formatJSON({
         scene: scenePath,
-        nodeCount: nodes.length,
-        nodes: nodes.map((n) => ({
-          name: n.name,
-          type: n.type,
-          parent: n.parent || '(root)',
-          hasScript: n.script !== null,
-        })),
+        nodeCount: formattedNodes.length,
+        nodes: formattedNodes,
       })
     }
 


### PR DESCRIPTION
💡 **What:** 
Replaced a double `.map()` iteration with a single 1-pass loop in `src/tools/composite/nodes.ts` under the `list` action. Removed the `mapToSceneNode` function completely, which used an expensive object spread to clone properties just to check if a `script` property existed.

🎯 **Why:** 
The previous implementation performed two sequential iterations: one to map nodes into an intermediate `SceneNode` format (cloning objects along the way) and another to map them into the final JSON output shape. This generated avoidable garbage collection pressure via redundant memory allocations.

📊 **Impact:** 
Reduced memory footprint and slightly improved execution speed for the `nodes:list` action by directly extracting exactly what's needed for the JSON response in a single iteration.

🔬 **Measurement:** 
Run `bun run check`, `bun run format`, and verify existing tests pass `bun x vitest run tests/composite/nodes.test.ts`. This confirms that despite omitting the intermediate type allocations, the output structure matches perfectly.

---
*PR created automatically by Jules for task [15538764090647957083](https://jules.google.com/task/15538764090647957083) started by @n24q02m*