### PR TITLE
⚡ Bolt: [PERF] Regex object instantiation in loop (scripts)

### DIFF
--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -10,6 +10,8 @@ import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '..
 import { pathExists, safeResolve } from '../helpers/paths.js'
 import { escapeRegExp } from '../helpers/scene-parser.js'
 
+const BACKSLASH_RE = /\\/g
+
 const SCRIPT_TEMPLATES: Record<string, string> = {
   Node: `extends Node
 
@@ -210,7 +212,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
 
       let content = await readFile(sceneFullPath, 'utf-8')
-      const resPath = `res://${scriptPath.replace(/\\/g, '/')}`
+      const resPath = `res://${scriptPath.replace(BACKSLASH_RE, '/')}`
 
       if (nodeName) {
         const nodePattern = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
@@ -242,7 +244,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
       const prefixLen = resolvedPath.length + (resolvedPath.endsWith('/') || resolvedPath.endsWith('\\') ? 0 : 1)
       const relativePaths = new Array(scripts.length)
       for (let i = 0; i < scripts.length; i++) {
-        relativePaths[i] = scripts[i].substring(prefixLen).replace(/\\/g, '/')
+        relativePaths[i] = scripts[i].substring(prefixLen).replace(BACKSLASH_RE, '/')
       }
 
       return formatJSON({ project: resolvedPath, count: relativePaths.length, scripts: relativePaths })

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -10,6 +10,7 @@ import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '..
 import { pathExists, safeResolve } from '../helpers/paths.js'
 import { escapeRegExp } from '../helpers/scene-parser.js'
 
+// Pre-compiled regex for replacing backslashes with forward slashes in paths
 const BACKSLASH_RE = /\\/g
 
 const SCRIPT_TEMPLATES: Record<string, string> = {


### PR DESCRIPTION
💡 What: Pre-compiled the backslash replacement regex into a module-level constant `BACKSLASH_RE` and updated `handleScripts`'s 'list' and 'attach' actions to use it.
🎯 Why: Regex object instantiation in a loop (scripts:list) is inefficient and causes unnecessary GC pressure.
📊 Impact: Improved performance of `scripts:list` and `scripts:attach` by avoiding redundant regex compilation.
🔬 Measurement: Verified with existing test suite and confirmed no regressions.

---
*PR created automatically by Jules for task [1770596657320258368](https://jules.google.com/task/1770596657320258368) started by @n24q02m*