### PR TITLE
[FIX] Fix strict type checks for readdirSync mock

### DIFF
--- a/tests/godot/detector.test.ts
+++ b/tests/godot/detector.test.ts
@@ -337,13 +337,16 @@ describe('detector', () => {
               isDirectory: () => true,
               name: 'GodotEngine.GodotEngine_Microsoft.Winget.Source_8wekyb3d8bbwe',
             } as Dirent,
-          ]
+          ] as unknown as ReturnType<typeof readdirSync>
         }
         if (path === pkgDir) {
-          return ['Godot_v4.3-stable_win64.exe', 'Godot_v4.3-stable_win64_console.exe']
+          return ['Godot_v4.3-stable_win64.exe', 'Godot_v4.3-stable_win64_console.exe'] as unknown as ReturnType<
+            typeof readdirSync
+          >
         }
-        return []
-      }) as typeof readdirSync)
+        return [] as unknown as ReturnType<typeof readdirSync>
+        // biome-ignore lint/suspicious/noExplicitAny: mock overload
+      }) as any)
 
       vi.mocked(execFileSync).mockImplementation((cmd) => {
         if (typeof cmd === 'string' && cmd.includes('Godot_v4.3-stable_win64.exe'))
@@ -367,7 +370,10 @@ describe('detector', () => {
       vi.mocked(statSync).mockImplementation(() => {
         throw new Error('ENOENT')
       })
-      vi.mocked(readdirSync).mockImplementation(((_path: PathLike, _options?: unknown) => []) as typeof readdirSync)
+      vi.mocked(readdirSync).mockImplementation(
+        // biome-ignore lint/suspicious/noExplicitAny: mock overload
+        ((_path: PathLike, _options?: unknown) => [] as unknown as ReturnType<typeof readdirSync>) as any,
+      )
 
       expect(detectGodot()).toBeNull()
     })


### PR DESCRIPTION
This PR fixes strict type checks for `readdirSync` mocks in `tests/godot/detector.test.ts`. 

The `fs.readdirSync` function has complex overloads in Node.js, which makes it difficult to mock with exact types in Vitest. By casting internal return values to `as unknown as ReturnType<typeof readdirSync>` and the entire implementation to `as any`, we satisfy the compiler while maintaining test correctness. Biome linting is preserved using `// biome-ignore` comments.

---
*PR created automatically by Jules for task [788871968492534231](https://jules.google.com/task/788871968492534231) started by @n24q02m*