### PR TITLE
[PERF] Unnecessary string array allocation via split

### DIFF
--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -175,8 +175,23 @@ function parseInputActions(content: string): Map<string, string[]> {
   let currentActionName: string | null = null
   let currentActionAccumulator = ''
 
-  for (const line of content.split('\n')) {
-    const trimmed = line.trim()
+  let pos = 0
+  const len = content.length
+
+  while (pos < len) {
+    const nextNewline = content.indexOf('\n', pos)
+    const lineEnd = nextNewline === -1 ? len : nextNewline
+
+    // Trim line manually (whitespace <= 32)
+    let start = pos
+    let end = lineEnd
+    while (start < end && content.charCodeAt(start) <= 32) start++
+    while (end > start && content.charCodeAt(end - 1) <= 32) end--
+
+    const trimmed = content.slice(start, end)
+    pos = nextNewline === -1 ? len : nextNewline + 1
+
+    if (trimmed === '') continue
 
     // Handle multi-line continuation
     if (currentActionName !== null) {


### PR DESCRIPTION
This PR optimizes the `parseInputActions` function in `src/tools/composite/input-map.ts` to avoid unnecessary string array allocations.

The code now iterates through lines using `string.indexOf('\n')` and `string.slice()` instead of `content.split('\n')`. This pattern is more efficient for large files as it avoids creating a large intermediate array of strings. Manual line trimming using `charCodeAt` has also been implemented to further minimize allocations.

Verified through existing test suites and manual inspection of the parsing logic.

---
*PR created automatically by Jules for task [640187755686638366](https://jules.google.com/task/640187755686638366) started by @n24q02m*