### PR TITLE
[SECURITY] Scene File Injection via Unsanitized Node Construction

### DIFF
--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -69,9 +69,25 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
       if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
       const nodeName = args.name as string
       if (!nodeName) throw new GodotMCPError('No node name specified', 'INVALID_ARGS', 'Provide name for the new node.')
+
+      if (nodeName.includes('"') || nodeName.includes('\n') || nodeName.includes('\r')) {
+        throw new GodotMCPError('Invalid node name', 'INVALID_ARGS', 'Node name must not contain quotes or newlines.')
+      }
+
       const nodeType = (args.type as string) || 'Node'
+      if (nodeType.includes('"') || nodeType.includes('\n') || nodeType.includes('\r')) {
+        throw new GodotMCPError('Invalid node type', 'INVALID_ARGS', 'Node type must not contain quotes or newlines.')
+      }
+
       const rawParent = (args.parent as string) || '.'
       const { path: parent } = normalizeNodePath(rawParent)
+      if (parent.includes('"') || parent.includes('\n') || parent.includes('\r')) {
+        throw new GodotMCPError(
+          'Invalid parent path',
+          'INVALID_ARGS',
+          'Parent path must not contain quotes or newlines.',
+        )
+      }
 
       const fullPath = resolveScenePath(projectPath, scenePath)
       if (!(await pathExists(fullPath)))
@@ -106,6 +122,20 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
               'Invalid property value',
               'INVALID_ARGS',
               'Property keys and values must be strings.',
+            )
+          }
+          if (key.includes('=') || key.includes('\n') || key.includes('\r')) {
+            throw new GodotMCPError(
+              'Invalid property key',
+              'INVALID_ARGS',
+              'Property keys must not contain "=", newlines.',
+            )
+          }
+          if (value.includes('\n') || value.includes('\r')) {
+            throw new GodotMCPError(
+              'Invalid property value',
+              'INVALID_ARGS',
+              'Property values must not contain newlines.',
             )
           }
           nodeDecl += `${key} = ${value}\n`
@@ -143,6 +173,14 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
       const newName = args.new_name as string
       if (!nodeName || !newName)
         throw new GodotMCPError('Both name and new_name required', 'INVALID_ARGS', 'Provide name and new_name.')
+
+      if (newName.includes('"') || newName.includes('\n') || newName.includes('\r')) {
+        throw new GodotMCPError(
+          'Invalid node name',
+          'INVALID_ARGS',
+          'New node name must not contain quotes or newlines.',
+        )
+      }
 
       const fullPath = resolveScenePath(projectPath, scenePath)
       if (!(await pathExists(fullPath)))
@@ -191,6 +229,13 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
           'INVALID_ARGS',
           'Provide name, property, and value.',
         )
+      }
+
+      if (property.includes('=') || property.includes('\n') || property.includes('\r')) {
+        throw new GodotMCPError('Invalid property key', 'INVALID_ARGS', 'Property keys must not contain "=", newlines.')
+      }
+      if (value.includes('\n') || value.includes('\r')) {
+        throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property values must not contain newlines.')
       }
 
       const fullPath = resolveScenePath(projectPath, scenePath)

--- a/tests/composite/nodes-security.test.ts
+++ b/tests/composite/nodes-security.test.ts
@@ -1,0 +1,179 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleNodes } from '../../src/tools/composite/nodes.js'
+
+describe('Nodes Tool Security', () => {
+  const projectPath = join(process.cwd(), 'tmp_security_nodes_test')
+  const config: GodotConfig = { projectPath }
+
+  beforeEach(() => {
+    mkdirSync(projectPath, { recursive: true })
+    writeFileSync(join(projectPath, 'project.godot'), '[config]')
+    writeFileSync(join(projectPath, 'scene.tscn'), '[gd_scene format=3]\n\n[node name="Root" type="Node"]\n')
+  })
+
+  afterEach(() => {
+    rmSync(projectPath, { recursive: true, force: true })
+  })
+
+  it('should prevent injection in node name (add)', async () => {
+    const maliciousName = 'Root" type="Injected" parent=".'
+
+    await expect(
+      handleNodes(
+        'add',
+        {
+          scene_path: 'scene.tscn',
+          name: maliciousName,
+          type: 'Node',
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid node name')
+
+    const content = readFileSync(join(projectPath, 'scene.tscn'), 'utf-8')
+    expect(content).not.toContain('type="Injected"')
+  })
+
+  it('should prevent injection in node type (add)', async () => {
+    const maliciousType = 'Node" parent="." injected="true'
+
+    await expect(
+      handleNodes(
+        'add',
+        {
+          scene_path: 'scene.tscn',
+          name: 'NewNode',
+          type: maliciousType,
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid node type')
+
+    const content = readFileSync(join(projectPath, 'scene.tscn'), 'utf-8')
+    expect(content).not.toContain('injected="true"')
+  })
+
+  it('should prevent injection in parent path (add)', async () => {
+    const maliciousParent = 'Root" injected="true'
+
+    await expect(
+      handleNodes(
+        'add',
+        {
+          scene_path: 'scene.tscn',
+          name: 'NewNode',
+          parent: maliciousParent,
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid parent path')
+
+    const content = readFileSync(join(projectPath, 'scene.tscn'), 'utf-8')
+    expect(content).not.toContain('injected="true"')
+  })
+
+  it('should prevent injection in property key (add)', async () => {
+    const maliciousKey = 'some_prop = 1\n[node name="Injected" type="Node"]\nunused'
+
+    await expect(
+      handleNodes(
+        'add',
+        {
+          scene_path: 'scene.tscn',
+          name: 'NewNode',
+          properties: {
+            [maliciousKey]: 'value',
+          },
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid property key')
+
+    const content = readFileSync(join(projectPath, 'scene.tscn'), 'utf-8')
+    expect(content).not.toContain('[node name="Injected"')
+  })
+
+  it('should prevent injection in property value (add) via newline', async () => {
+    const maliciousValue = '123\n[node name="Injected" type="Node"]'
+
+    await expect(
+      handleNodes(
+        'add',
+        {
+          scene_path: 'scene.tscn',
+          name: 'NewNode',
+          type: 'Node',
+          properties: {
+            some_prop: maliciousValue,
+          },
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid property value')
+
+    const content = readFileSync(join(projectPath, 'scene.tscn'), 'utf-8')
+    expect(content).not.toContain('[node name="Injected"')
+  })
+
+  it('should prevent injection in new_name (rename)', async () => {
+    const maliciousName = 'Root" type="Injected" parent=".'
+
+    await expect(
+      handleNodes(
+        'rename',
+        {
+          scene_path: 'scene.tscn',
+          name: 'Root',
+          new_name: maliciousName,
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid node name')
+
+    const content = readFileSync(join(projectPath, 'scene.tscn'), 'utf-8')
+    expect(content).not.toContain('type="Injected"')
+  })
+
+  it('should prevent injection in property key (set_property)', async () => {
+    const maliciousKey = 'some_prop = 1\n[node name="Injected" type="Node"]\nunused'
+
+    await expect(
+      handleNodes(
+        'set_property',
+        {
+          scene_path: 'scene.tscn',
+          name: 'Root',
+          property: maliciousKey,
+          value: '123',
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid property key')
+
+    const content = readFileSync(join(projectPath, 'scene.tscn'), 'utf-8')
+    expect(content).not.toContain('[node name="Injected"')
+  })
+
+  it('should prevent injection in property value (set_property) via newline', async () => {
+    const maliciousValue = '123\n[node name="Injected" type="Node"]'
+
+    await expect(
+      handleNodes(
+        'set_property',
+        {
+          scene_path: 'scene.tscn',
+          name: 'Root',
+          property: 'some_prop',
+          value: maliciousValue,
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid property value')
+
+    const content = readFileSync(join(projectPath, 'scene.tscn'), 'utf-8')
+    expect(content).not.toContain('[node name="Injected"')
+  })
+})


### PR DESCRIPTION
This PR addresses a security vulnerability in the nodes tool where unsanitized input could lead to scene file injection.

### Changes
- Implemented validation for `nodeName`, `nodeType`, and `parent` in the `add` action to reject double quotes (`"`) and newlines (`\n`, `\r`).
- Implemented validation for `newName` in the `rename` action to reject double quotes and newlines.
- Implemented validation for property keys and values in both `add` and `set_property` actions to reject newlines and, for keys, the equals sign (`=`).
- Added a comprehensive security test suite in `tests/composite/nodes-security.test.ts` to verify these fixes and prevent regressions.

### Why
Unsanitized inputs allowed an attacker (or a misbehaving LLM) to inject arbitrary node declarations or properties into `.tscn` files by prematurely closing attributes with quotes or starting new lines. This could lead to file corruption or the introduction of malicious nodes/scripts into the Godot project.

---
*PR created automatically by Jules for task [255639899754793483](https://jules.google.com/task/255639899754793483) started by @n24q02m*