### PR TITLE
[FIX] Long Function: handleScripts

### DIFF
--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -15,31 +15,31 @@ const SCRIPT_TEMPLATES: Record<string, string> = {
 
 
 func _ready() -> void:
-\tpass
+	pass
 
 
 func _process(delta: float) -> void:
-\tpass
+	pass
 `,
   Node2D: `extends Node2D
 
 
 func _ready() -> void:
-\tpass
+	pass
 
 
 func _process(delta: float) -> void:
-\tpass
+	pass
 `,
   Node3D: `extends Node3D
 
 
 func _ready() -> void:
-\tpass
+	pass
 
 
 func _process(delta: float) -> void:
-\tpass
+	pass
 `,
   CharacterBody2D: `extends CharacterBody2D
 
@@ -48,19 +48,19 @@ const JUMP_VELOCITY = -400.0
 
 
 func _physics_process(delta: float) -> void:
-\tif not is_on_floor():
-\t\tvelocity += get_gravity() * delta
+	if not is_on_floor():
+		velocity += get_gravity() * delta
 
-\tif Input.is_action_just_pressed("ui_accept") and is_on_floor():
-\t\tvelocity.y = JUMP_VELOCITY
+	if Input.is_action_just_pressed("ui_accept") and is_on_floor():
+		velocity.y = JUMP_VELOCITY
 
-\tvar direction := Input.get_axis("ui_left", "ui_right")
-\tif direction:
-\t\tvelocity.x = direction * SPEED
-\telse:
-\t\tvelocity.x = move_toward(velocity.x, 0, SPEED)
+	var direction := Input.get_axis("ui_left", "ui_right")
+	if direction:
+		velocity.x = direction * SPEED
+	else:
+		velocity.x = move_toward(velocity.x, 0, SPEED)
 
-\tmove_and_slide()
+	move_and_slide()
 `,
   CharacterBody3D: `extends CharacterBody3D
 
@@ -69,28 +69,28 @@ const JUMP_VELOCITY = 4.5
 
 
 func _physics_process(delta: float) -> void:
-\tif not is_on_floor():
-\t\tvelocity += get_gravity() * delta
+	if not is_on_floor():
+		velocity += get_gravity() * delta
 
-\tif Input.is_action_just_pressed("ui_accept") and is_on_floor():
-\t\tvelocity.y = JUMP_VELOCITY
+	if Input.is_action_just_pressed("ui_accept") and is_on_floor():
+		velocity.y = JUMP_VELOCITY
 
-\tvar input_dir := Input.get_vector("ui_left", "ui_right", "ui_up", "ui_down")
-\tvar direction := (transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
-\tif direction:
-\t\tvelocity.x = direction.x * SPEED
-\t\tvelocity.z = direction.z * SPEED
-\telse:
-\t\tvelocity.x = move_toward(velocity.x, 0, SPEED)
-\t\tvelocity.z = move_toward(velocity.z, 0, SPEED)
+	var input_dir := Input.get_vector("ui_left", "ui_right", "ui_up", "ui_down")
+	var direction := (transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
+	if direction:
+		velocity.x = direction.x * SPEED
+		velocity.z = direction.z * SPEED
+	else:
+		velocity.x = move_toward(velocity.x, 0, SPEED)
+		velocity.z = move_toward(velocity.z, 0, SPEED)
 
-\tmove_and_slide()
+	move_and_slide()
 `,
   Control: `extends Control
 
 
 func _ready() -> void:
-\tpass
+	pass
 `,
 }
 
@@ -126,6 +126,119 @@ async function findScriptFiles(dir: string, results: string[] = []): Promise<str
   }
 }
 
+async function createScript(args: Record<string, unknown>, resolvePath: (path: string) => string) {
+  const scriptPath = args.script_path as string
+  if (!scriptPath)
+    throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path (e.g., "player.gd").')
+  const extendsType = (args.extends as string) || 'Node'
+  const content = (args.content as string) || getTemplate(extendsType)
+
+  const fullPath = resolvePath(scriptPath)
+  if (await pathExists(fullPath)) {
+    throw new GodotMCPError(
+      `Script already exists: ${scriptPath}`,
+      'SCRIPT_ERROR',
+      'Use write action to modify existing scripts.',
+    )
+  }
+
+  await mkdir(dirname(fullPath), { recursive: true })
+  await writeFile(fullPath, content, 'utf-8')
+  return formatSuccess(`Created script: ${scriptPath}\nExtends: ${extendsType}`)
+}
+
+async function readScript(args: Record<string, unknown>, resolvePath: (path: string) => string) {
+  const scriptPath = args.script_path as string
+  if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path.')
+
+  const fullPath = resolvePath(scriptPath)
+  if (!(await pathExists(fullPath)))
+    throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
+
+  const content = await readFile(fullPath, 'utf-8')
+  return formatSuccess(`File: ${scriptPath}\n\n${content}`)
+}
+
+async function writeScript(args: Record<string, unknown>, resolvePath: (path: string) => string) {
+  const scriptPath = args.script_path as string
+  if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path.')
+  const content = args.content as string
+  if (content === undefined || content === null)
+    throw new GodotMCPError('No content specified', 'INVALID_ARGS', 'Provide content to write.')
+
+  const fullPath = resolvePath(scriptPath)
+  await mkdir(dirname(fullPath), { recursive: true })
+  await writeFile(fullPath, content, 'utf-8')
+  return formatSuccess(`Written: ${scriptPath} (${content.length} chars)`)
+}
+
+async function attachScript(args: Record<string, unknown>, resolvePath: (path: string) => string) {
+  const scenePath = args.scene_path as string
+  const scriptPath = args.script_path as string
+  const nodeName = args.node_name as string
+  if (!scenePath || !scriptPath) {
+    throw new GodotMCPError(
+      'Both scene_path and script_path required',
+      'INVALID_ARGS',
+      'Provide scene_path and script_path.',
+    )
+  }
+
+  const sceneFullPath = resolvePath(scenePath)
+  if (!(await pathExists(sceneFullPath)))
+    throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
+
+  let content = await readFile(sceneFullPath, 'utf-8')
+  const resPath = `res://${scriptPath.replace(/\\/g, '/')}`
+
+  if (nodeName) {
+    const nodePattern = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
+    const match = content.match(nodePattern)
+    if (!match)
+      throw new GodotMCPError(
+        `Node "${nodeName}" not found in scene`,
+        'NODE_ERROR',
+        'Check node name with nodes.list action.',
+      )
+    content = content.replace(nodePattern, `$1\nscript = ExtResource("${resPath}")`)
+  } else {
+    content = content.replace(/(\[node [^\]]+\])/, `$1\nscript = ExtResource("${resPath}")`)
+  }
+
+  await writeFile(sceneFullPath, content, 'utf-8')
+  return formatSuccess(`Attached script ${scriptPath} to ${nodeName || 'root node'} in ${scenePath}`)
+}
+
+async function listScripts(baseDir: string, projectPath: string | undefined) {
+  if (!projectPath)
+    throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
+
+  const resolvedPath = safeResolve(baseDir, projectPath)
+  const scripts = await findScriptFiles(resolvedPath)
+
+  // OPTIMIZATION: Use substring and a pre-allocated array instead of .map() and node:path.relative
+  // for significantly faster execution on large arrays of prefixed paths.
+  const prefixLen = resolvedPath.length + (resolvedPath.endsWith('/') || resolvedPath.endsWith('\\') ? 0 : 1)
+  const relativePaths = new Array(scripts.length)
+  for (let i = 0; i < scripts.length; i++) {
+    relativePaths[i] = scripts[i].substring(prefixLen).replace(/\\/g, '/')
+  }
+
+  return formatJSON({ project: resolvedPath, count: relativePaths.length, scripts: relativePaths })
+}
+
+async function deleteScript(args: Record<string, unknown>, resolvePath: (path: string) => string) {
+  const scriptPath = args.script_path as string
+  if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path to delete.')
+
+  const fullPath = resolvePath(scriptPath)
+  if (!(await pathExists(fullPath)))
+    throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
+
+  await unlink(fullPath)
+  return formatSuccess(`Deleted script: ${scriptPath}`)
+}
+
 export async function handleScripts(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const baseDir = config.projectPath || process.cwd()
   // Validate args.project_path against the trusted baseDir to prevent path traversal vulnerabilities
@@ -147,120 +260,18 @@ export async function handleScripts(action: string, args: Record<string, unknown
   }
 
   switch (action) {
-    case 'create': {
-      const scriptPath = args.script_path as string
-      if (!scriptPath)
-        throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path (e.g., "player.gd").')
-      const extendsType = (args.extends as string) || 'Node'
-      const content = (args.content as string) || getTemplate(extendsType)
-
-      const fullPath = resolvePath(scriptPath)
-      if (await pathExists(fullPath)) {
-        throw new GodotMCPError(
-          `Script already exists: ${scriptPath}`,
-          'SCRIPT_ERROR',
-          'Use write action to modify existing scripts.',
-        )
-      }
-
-      await mkdir(dirname(fullPath), { recursive: true })
-      await writeFile(fullPath, content, 'utf-8')
-      return formatSuccess(`Created script: ${scriptPath}\nExtends: ${extendsType}`)
-    }
-
-    case 'read': {
-      const scriptPath = args.script_path as string
-      if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path.')
-
-      const fullPath = resolvePath(scriptPath)
-      if (!(await pathExists(fullPath)))
-        throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
-
-      const content = await readFile(fullPath, 'utf-8')
-      return formatSuccess(`File: ${scriptPath}\n\n${content}`)
-    }
-
-    case 'write': {
-      const scriptPath = args.script_path as string
-      if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path.')
-      const content = args.content as string
-      if (content === undefined || content === null)
-        throw new GodotMCPError('No content specified', 'INVALID_ARGS', 'Provide content to write.')
-
-      const fullPath = resolvePath(scriptPath)
-      await mkdir(dirname(fullPath), { recursive: true })
-      await writeFile(fullPath, content, 'utf-8')
-      return formatSuccess(`Written: ${scriptPath} (${content.length} chars)`)
-    }
-
-    case 'attach': {
-      const scenePath = args.scene_path as string
-      const scriptPath = args.script_path as string
-      const nodeName = args.node_name as string
-      if (!scenePath || !scriptPath) {
-        throw new GodotMCPError(
-          'Both scene_path and script_path required',
-          'INVALID_ARGS',
-          'Provide scene_path and script_path.',
-        )
-      }
-
-      const sceneFullPath = resolvePath(scenePath)
-      if (!(await pathExists(sceneFullPath)))
-        throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
-
-      let content = await readFile(sceneFullPath, 'utf-8')
-      const resPath = `res://${scriptPath.replace(/\\/g, '/')}`
-
-      if (nodeName) {
-        const nodePattern = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-        const match = content.match(nodePattern)
-        if (!match)
-          throw new GodotMCPError(
-            `Node "${nodeName}" not found in scene`,
-            'NODE_ERROR',
-            'Check node name with nodes.list action.',
-          )
-        content = content.replace(nodePattern, `$1\nscript = ExtResource("${resPath}")`)
-      } else {
-        content = content.replace(/(\[node [^\]]+\])/, `$1\nscript = ExtResource("${resPath}")`)
-      }
-
-      await writeFile(sceneFullPath, content, 'utf-8')
-      return formatSuccess(`Attached script ${scriptPath} to ${nodeName || 'root node'} in ${scenePath}`)
-    }
-
-    case 'list': {
-      if (!projectPath)
-        throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
-
-      const resolvedPath = safeResolve(baseDir, projectPath)
-      const scripts = await findScriptFiles(resolvedPath)
-
-      // OPTIMIZATION: Use substring and a pre-allocated array instead of .map() and node:path.relative
-      // for significantly faster execution on large arrays of prefixed paths.
-      const prefixLen = resolvedPath.length + (resolvedPath.endsWith('/') || resolvedPath.endsWith('\\') ? 0 : 1)
-      const relativePaths = new Array(scripts.length)
-      for (let i = 0; i < scripts.length; i++) {
-        relativePaths[i] = scripts[i].substring(prefixLen).replace(/\\/g, '/')
-      }
-
-      return formatJSON({ project: resolvedPath, count: relativePaths.length, scripts: relativePaths })
-    }
-
-    case 'delete': {
-      const scriptPath = args.script_path as string
-      if (!scriptPath)
-        throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path to delete.')
-
-      const fullPath = resolvePath(scriptPath)
-      if (!(await pathExists(fullPath)))
-        throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
-
-      await unlink(fullPath)
-      return formatSuccess(`Deleted script: ${scriptPath}`)
-    }
-
+    case 'create':
+      return createScript(args, resolvePath)
+    case 'read':
+      return readScript(args, resolvePath)
+    case 'write':
+      return writeScript(args, resolvePath)
+    case 'attach':
+      return attachScript(args, resolvePath)
+    case 'list':
+      return listScripts(baseDir, projectPath ?? undefined)
+    case 'delete':
+      return deleteScript(args, resolvePath)
     default:
       throwUnknownAction(action, ['create', 'read', 'write', 'attach', 'list', 'delete'])
   }


### PR DESCRIPTION
This PR refactors the `handleScripts` function in `src/tools/composite/scripts.ts` to address a 'Long Function' code smell.

Each action's logic (`create`, `read`, `write`, `attach`, `list`, `delete`) has been moved into its own dedicated async helper function. This cleanup reduces the complexity of `handleScripts` and makes the code easier to maintain and test in isolation.

Key changes:
- Created `createScript`, `readScript`, `writeScript`, `attachScript`, `listScripts`, and `deleteScript` helpers.
- Refactored `handleScripts` to delegate to these helpers using a clean switch statement.
- Added necessary type handling (e.g., `projectPath ?? undefined`) to satisfy TypeScript requirements.
- Verified that all integration tests pass and Biome linting is satisfied.

---
*PR created automatically by Jules for task [7325339597330128146](https://jules.google.com/task/7325339597330128146) started by @n24q02m*