### PR TITLE
[SECURITY] Argument Injection in Godot Export CLI Execution

### DIFF
--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -184,6 +184,22 @@ export async function handleProject(action: string, args: Record<string, unknown
         )
       }
 
+      if (preset.startsWith('-')) {
+        throw new GodotMCPError(
+          'Invalid preset name',
+          'INVALID_ARGS',
+          'Preset name cannot start with a hyphen to prevent argument injection.',
+        )
+      }
+
+      if (outputPath.startsWith('-')) {
+        throw new GodotMCPError(
+          'Invalid output path',
+          'INVALID_ARGS',
+          'Output path cannot start with a hyphen to prevent argument injection.',
+        )
+      }
+
       const resolvedProjectPath = safeResolve(config.projectPath || process.cwd(), projectPath)
       const result = await execGodotAsync(config.godotPath, [
         '--headless',

--- a/tests/composite/project-security.test.ts
+++ b/tests/composite/project-security.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { handleProject } from '../../src/tools/composite/project.js'
+import { makeConfig } from '../fixtures.js'
+
+vi.mock('../../src/godot/headless.js', () => ({
+  execGodotAsync: vi.fn().mockResolvedValue({ success: true, stdout: '', stderr: '', exitCode: 0 }),
+  execGodotSync: vi.fn(),
+  runGodotProject: vi.fn(),
+}))
+
+import { execGodotAsync } from '../../src/godot/headless.js'
+
+describe('Project Tool Security', () => {
+  const config = makeConfig({ godotPath: '/path/to/godot', projectPath: '/tmp/project' })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('export action - argument injection', () => {
+    it('should reject preset starting with hyphen', async () => {
+      const promise = handleProject(
+        'export',
+        {
+          project_path: '.',
+          preset: '--script',
+          output_path: 'build/out',
+        },
+        config,
+      )
+
+      await expect(promise).rejects.toThrow('Invalid preset name')
+      expect(execGodotAsync).not.toHaveBeenCalled()
+    })
+
+    it('should reject output_path starting with hyphen', async () => {
+      const promise = handleProject(
+        'export',
+        {
+          project_path: '.',
+          preset: 'Linux',
+          output_path: '--script',
+        },
+        config,
+      )
+
+      await expect(promise).rejects.toThrow('Invalid output path')
+      expect(execGodotAsync).not.toHaveBeenCalled()
+    })
+
+    it('should allow valid preset and output_path', async () => {
+      await handleProject(
+        'export',
+        {
+          project_path: '.',
+          preset: 'Linux',
+          output_path: 'build/out',
+        },
+        config,
+      )
+
+      expect(execGodotAsync).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
Validated 'preset' and 'output_path' in 'export' action to reject values starting with a hyphen. This prevents attackers from passing unintended CLI flags to the Godot binary. Added 'tests/composite/project-security.test.ts' to verify the fix.

---
*PR created automatically by Jules for task [6998086112692269678](https://jules.google.com/task/6998086112692269678) started by @n24q02m*