### PR TITLE
[SECURITY] Arbitrary Binary Execution via Godot Path Configuration

### DIFF
--- a/src/godot/detector.ts
+++ b/src/godot/detector.ts
@@ -9,7 +9,7 @@
  */
 
 import { execFileSync } from 'node:child_process'
-import { accessSync, constants, existsSync, readdirSync, statSync } from 'node:fs'
+import { accessSync, closeSync, constants, existsSync, openSync, readdirSync, readSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import type { DetectionResult, GodotVersion } from './types.js'
 
@@ -46,6 +46,7 @@ export function isVersionSupported(version: GodotVersion): boolean {
  * Try to get Godot version from a binary path
  */
 export function tryGetVersion(binaryPath: string): GodotVersion | null {
+  if (!isLikelyGodotBinary(binaryPath)) return null
   try {
     const output = execFileSync(binaryPath, ['--version'], {
       timeout: 5000,
@@ -55,6 +56,36 @@ export function tryGetVersion(binaryPath: string): GodotVersion | null {
     return parseGodotVersion(output)
   } catch {
     return null
+  }
+}
+
+/**
+ * Check if a file is likely a Godot binary by looking for specific signatures.
+ * This is a security measure to prevent execution of arbitrary binaries via config.
+ */
+export function isLikelyGodotBinary(filePath: string): boolean {
+  let fd: number | null = null
+  try {
+    fd = openSync(filePath, 'r')
+    // Read first 4MB - Godot binaries are typically 40MB-100MB+
+    // Signatures like "Godot Engine" or "GDScript" are usually present early or scattered
+    const buffer = Buffer.alloc(4 * 1024 * 1024)
+    const bytesRead = readSync(fd, buffer, 0, buffer.length, 0)
+
+    const sig1 = Buffer.from('Godot Engine')
+    const sig2 = Buffer.from('GDScript')
+
+    return buffer.subarray(0, bytesRead).includes(sig1) || buffer.subarray(0, bytesRead).includes(sig2)
+  } catch {
+    return false
+  } finally {
+    if (fd !== null) {
+      try {
+        closeSync(fd)
+      } catch {
+        /* ignore */
+      }
+    }
   }
 }
 

--- a/tests/godot/detector.test.ts
+++ b/tests/godot/detector.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process'
 import type { Dirent, PathLike } from 'node:fs'
-import { accessSync, existsSync, readdirSync, statSync } from 'node:fs'
+import { accessSync, existsSync, openSync, readdirSync, readSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 /**
  * Tests for Godot binary detector
@@ -169,6 +169,12 @@ describe('detector', () => {
     it('should return true for a regular executable file', () => {
       vi.mocked(statSync).mockReturnValue({ isFile: () => true } as unknown as import('node:fs').Stats)
       vi.mocked(accessSync).mockReturnValue(undefined)
+      vi.mocked(openSync).mockReturnValue(999)
+      vi.mocked(readSync).mockImplementation((_fd, buffer) => {
+        const b = buffer as Buffer
+        b.write('Godot Engine')
+        return 'Godot Engine'.length
+      })
       expect(isExecutable('/usr/bin/godot')).toBe(true)
     })
 
@@ -206,6 +212,12 @@ describe('detector', () => {
       // Default: statSync returns a file, accessSync succeeds (isExecutable passes)
       vi.mocked(statSync).mockReturnValue({ isFile: () => true } as unknown as import('node:fs').Stats)
       vi.mocked(accessSync).mockReturnValue(undefined)
+      vi.mocked(openSync).mockReturnValue(999)
+      vi.mocked(readSync).mockImplementation((_fd, buffer) => {
+        const b = buffer as Buffer
+        b.write('Godot Engine')
+        return 'Godot Engine'.length
+      })
     })
 
     afterEach(() => {

--- a/tests/security/binary_validation.test.ts
+++ b/tests/security/binary_validation.test.ts
@@ -1,0 +1,92 @@
+import { execFileSync } from 'node:child_process'
+import { openSync, readSync, statSync } from 'node:fs'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { tryGetVersion } from '../../src/godot/detector.js'
+import { handleConfig } from '../../src/tools/composite/config.js'
+
+vi.mock('node:child_process')
+vi.mock('node:fs')
+
+describe('Binary Validation Security', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Default mock for statSync to pass isExecutable
+    vi.mocked(statSync).mockReturnValue({ isFile: () => true } as unknown as import('node:fs').Stats)
+  })
+
+  it('should REJECT non-Godot binaries (like ls)', () => {
+    const maliciousPath = '/usr/bin/ls'
+    // Mock readSync to return something that doesn't contain Godot signatures
+    vi.mocked(openSync).mockReturnValue(123)
+    vi.mocked(readSync).mockImplementation((_fd, buffer: Buffer) => {
+      buffer.write('standard linux binary content')
+      return 'standard linux binary content'.length
+    })
+
+    const result = tryGetVersion(maliciousPath)
+
+    // Should NOT execute it
+    expect(execFileSync).not.toHaveBeenCalled()
+    expect(result).toBeNull()
+  })
+
+  it('should ACCEPT valid Godot binaries', () => {
+    const godotPath = '/usr/bin/godot'
+    vi.mocked(openSync).mockReturnValue(124)
+    vi.mocked(readSync).mockImplementation((_fd, buffer: Buffer) => {
+      buffer.write('some data... Godot Engine ... more data')
+      return buffer.length
+    })
+    vi.mocked(execFileSync).mockReturnValue('Godot Engine v4.1.stable')
+
+    const result = tryGetVersion(godotPath)
+
+    // Should execute it to get version
+    expect(execFileSync).toHaveBeenCalledWith(godotPath, ['--version'], expect.any(Object))
+    expect(result).not.toBeNull()
+    expect(result?.major).toBe(4)
+  })
+
+  it('should handle file read errors gracefully', () => {
+    const errorPath = '/tmp/error_file'
+    vi.mocked(openSync).mockImplementation(() => {
+      throw new Error('Read error')
+    })
+
+    const result = tryGetVersion(errorPath)
+    expect(result).toBeNull()
+    expect(execFileSync).not.toHaveBeenCalled()
+  })
+})
+
+describe('handleConfig Security', () => {
+  it('should reject non-Godot binary when setting godot_path', async () => {
+    const config = { godotPath: null, godotVersion: null, projectPath: null, activePids: [] }
+    vi.mocked(openSync).mockReturnValue(125)
+    vi.mocked(readSync).mockImplementation((_fd, buffer: Buffer) => {
+      buffer.write('not a godot binary')
+      return 'not a godot binary'.length
+    })
+
+    await expect(handleConfig('set', { key: 'godot_path', value: '/usr/bin/ls' }, config)).rejects.toThrow(
+      'Invalid Godot binary',
+    )
+
+    expect(config.godotPath).toBeNull()
+  })
+
+  it('should accept valid Godot binary when setting godot_path', async () => {
+    const config = { godotPath: null, godotVersion: null, projectPath: null, activePids: [] }
+    vi.mocked(openSync).mockReturnValue(126)
+    vi.mocked(readSync).mockImplementation((_fd, buffer: Buffer) => {
+      buffer.write('Godot Engine v4.1')
+      return buffer.length
+    })
+    vi.mocked(execFileSync).mockReturnValue('Godot Engine v4.1.stable')
+
+    await handleConfig('set', { key: 'godot_path', value: '/usr/bin/godot' }, config)
+
+    expect(config.godotPath).toBe('/usr/bin/godot')
+    expect(config.godotVersion?.major).toBe(4)
+  })
+})


### PR DESCRIPTION
This PR fixes a security vulnerability where arbitrary binaries could be executed by reconfiguring the 'godot_path' setting. We've introduced a signature-based validation check (\`isLikelyGodotBinary\`) that ensures a file contains Godot-specific markers ('Godot Engine' or 'GDScript') before it is ever executed by the server.

### Changes:
- Added \`isLikelyGodotBinary(filePath: string): boolean\` to \`src/godot/detector.ts\`.
- Updated \`tryGetVersion\` to perform this check before calling \`execFileSync\`.
- Verified that \`handleConfig\` is protected as it relies on \`tryGetVersion\` for path validation.
- Added a new test suite \`tests/security/binary_validation.test.ts\` reproducing the vulnerability and verifying the fix.
- Updated existing detector tests to mock the new filesystem calls.

---
*PR created automatically by Jules for task [2589487313311565065](https://jules.google.com/task/2589487313311565065) started by @n24q02m*