### PR TITLE
[FIX] Overly long line / Hardcoded Object Strings

### DIFF
--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -7,6 +7,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
+import { toGodotObject } from '../helpers/godot-types.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
 import { escapeRegExp } from '../helpers/scene-parser.js'
 
@@ -331,16 +332,59 @@ export async function handleInputMap(action: string, args: Record<string, unknow
       switch (eventType) {
         case 'key': {
           const keyCode = resolveKeyCode(eventValue)
-          eventObj = `Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":${keyCode},"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)`
+          eventObj = toGodotObject('InputEventKey', {
+            resource_local_to_scene: false,
+            resource_name: '',
+            device: -1,
+            window_id: 0,
+            alt_pressed: false,
+            shift_pressed: false,
+            ctrl_pressed: false,
+            meta_pressed: false,
+            pressed: false,
+            keycode: 0,
+            physical_keycode: keyCode,
+            key_label: 0,
+            unicode: 0,
+            location: 0,
+            echo: false,
+            script: null,
+          })
           break
         }
         case 'mouse': {
           const mouseCode = resolveMouseCode(eventValue)
-          eventObj = `Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0,0),"global_position":Vector2(0,0),"factor":1.0,"button_index":${mouseCode},"canceled":false,"pressed":true,"double_click":false,"script":null)`
+          eventObj = toGodotObject('InputEventMouseButton', {
+            resource_local_to_scene: false,
+            resource_name: '',
+            device: -1,
+            window_id: 0,
+            alt_pressed: false,
+            shift_pressed: false,
+            ctrl_pressed: false,
+            meta_pressed: false,
+            button_mask: 0,
+            position: { x: 0, y: 0 },
+            global_position: { x: 0, y: 0 },
+            factor: 1.0,
+            button_index: mouseCode,
+            canceled: false,
+            pressed: true,
+            double_click: false,
+            script: null,
+          })
           break
         }
         case 'joypad':
-          eventObj = `Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":${eventValue},"pressure":0.0,"pressed":true,"script":null)`
+          eventObj = toGodotObject('InputEventJoypadButton', {
+            resource_local_to_scene: false,
+            resource_name: '',
+            device: -1,
+            button_index: Number.parseInt(eventValue, 10),
+            pressure: 0.0,
+            pressed: true,
+            script: null,
+          })
           break
         default:
           throw new GodotMCPError(

--- a/src/tools/helpers/godot-types.ts
+++ b/src/tools/helpers/godot-types.ts
@@ -215,3 +215,13 @@ export function toGodotValue(value: unknown): string {
 
   return String(value)
 }
+
+/**
+ * Serialize a Godot Object to an expression string
+ */
+export function toGodotObject(className: string, properties: Record<string, unknown>): string {
+  const props = Object.entries(properties)
+    .map(([key, value]) => `"${key}":${toGodotValue(value)}`)
+    .join(',')
+  return `Object(${className},${props})`
+}

--- a/tests/helpers/godot-types.test.ts
+++ b/tests/helpers/godot-types.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest'
 import type { GodotColor, Rect2, Vector2, Vector3 } from '../../src/tools/helpers/godot-types.js'
-import { parseGodotValue, toGodotValue } from '../../src/tools/helpers/godot-types.js'
+import { parseGodotValue, toGodotObject, toGodotValue } from '../../src/tools/helpers/godot-types.js'
 
 describe('godot-types', () => {
   // ==========================================
@@ -275,5 +275,24 @@ describe('godot-types', () => {
     it('should roundtrip number', () => {
       expect(toGodotValue(parseGodotValue('42'))).toBe('42')
     })
+  })
+})
+
+// ==========================================
+// toGodotObject
+// ==========================================
+describe('toGodotObject', () => {
+  it('should serialize simple object', () => {
+    const result = toGodotObject('MyClass', { a: 1, b: 'test' })
+    expect(result).toBe('Object(MyClass,"a":1,"b":"test")')
+  })
+
+  it('should serialize object with nested Godot types', () => {
+    const result = toGodotObject('InputEventKey', {
+      device: -1,
+      pressed: false,
+      position: { x: 10, y: 20 },
+    })
+    expect(result).toBe('Object(InputEventKey,"device":-1,"pressed":false,"position":Vector2(10, 20))')
   })
 })


### PR DESCRIPTION
This PR addresses the issue of overly long lines and hardcoded Godot object strings in \`src/tools/composite/input-map.ts\`. 

I introduced a new utility function \`toGodotObject\` in \`src/tools/helpers/godot-types.ts\` which handles the serialization of Godot \`Object\` types by taking a class name and a map of properties. This ensures consistency by reusing the existing \`toGodotValue\` serializer for property values and makes the code in \`input-map.ts\` much cleaner and more maintainable.

Key changes:
1.  **New Helper**: \`toGodotObject(className, properties)\` added to \`src/tools/helpers/godot-types.ts\`.
2.  **Refactoring**: Replaced multi-line template strings in \`src/tools/composite/input-map.ts\` with structured calls to the new helper.
3.  **Testing**: Added new unit tests in \`tests/helpers/godot-types.test.ts\` to verify the serialization of Godot objects, including nested types like \`Vector2\`.
4.  **Verification**: Ran \`bun run check\` and \`bun run test\` to ensure all linting rules are followed and no regressions were introduced.

---
*PR created automatically by Jules for task [5806439592886376245](https://jules.google.com/task/5806439592886376245) started by @n24q02m*