### PR TITLE
[FIX] Duplicate boilerplate in registry.ts

### DIFF
--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -30,6 +30,26 @@ import { handleUI } from './composite/ui.js'
 import { findClosestMatch, formatError, GodotMCPError } from './helpers/errors.js'
 import { wrapToolResult } from './helpers/security.js'
 
+/**
+ * Helper to create standard MCP tool annotations
+ */
+function createAnnotations(
+  title: string,
+  options: {
+    readOnly?: boolean
+    destructive?: boolean
+    idempotent?: boolean
+  } = {},
+) {
+  return {
+    title,
+    readOnlyHint: options.readOnly ?? false,
+    destructiveHint: options.destructive ?? false,
+    idempotentHint: options.idempotent ?? false,
+    openWorldHint: false,
+  }
+}
+
 // =============================================
 // P0 - Core Tools (7)
 // =============================================
@@ -39,13 +59,7 @@ const P0_TOOLS = [
     name: 'project',
     description:
       'Godot project operations.\n\nActions (required params -> optional):\n- info (-> project_path): project metadata\n- version: Godot engine version\n- run (-> project_path): launch game\n- stop: stop running game\n- settings_get (key -> project_path): read project setting\n- settings_set (key, value -> project_path): write project setting\n- export (preset, output_path -> project_path): export game build',
-    annotations: {
-      title: 'Project',
-      readOnlyHint: false,
-      destructiveHint: false,
-      idempotentHint: false,
-      openWorldHint: false,
-    },
+    annotations: createAnnotations('Project'),
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -67,13 +81,7 @@ const P0_TOOLS = [
     name: 'scenes',
     description:
       'Scene file (.tscn) CRUD.\n\nActions (required params -> optional):\n- create (scene_path -> root_type="Node2D", root_name, project_path)\n- list (-> project_path)\n- info (scene_path -> project_path)\n- delete (scene_path -> project_path)\n- duplicate (scene_path, new_path -> project_path)\n- set_main (scene_path -> project_path)\n\nscene_path: relative to project root (e.g., "scenes/main.tscn"), NOT res:// prefix. Use nodes tool to edit nodes within a scene.',
-    annotations: {
-      title: 'Scenes',
-      readOnlyHint: false,
-      destructiveHint: true,
-      idempotentHint: false,
-      openWorldHint: false,
-    },
+    annotations: createAnnotations('Scenes', { destructive: true }),
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -98,13 +106,7 @@ const P0_TOOLS = [
     name: 'nodes',
     description:
       'Scene node operations.\n\nActions (required params -> optional):\n- add (scene_path, name -> type="Node", parent=".", project_path)\n- remove (scene_path, name -> project_path)\n- rename (scene_path, name, new_name -> project_path)\n- list (scene_path -> project_path)\n- set_property (scene_path, name, property, value -> project_path)\n- get_property (scene_path, name, property -> project_path)\n\nNode paths: relative to scene root using "/" (e.g., "Player/Sprite2D"). Use "." for root.',
-    annotations: {
-      title: 'Nodes',
-      readOnlyHint: false,
-      destructiveHint: true,
-      idempotentHint: false,
-      openWorldHint: false,
-    },
+    annotations: createAnnotations('Nodes', { destructive: true }),
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -133,13 +135,7 @@ const P0_TOOLS = [
     name: 'scripts',
     description:
       'GDScript file CRUD.\n\nActions (required params -> optional):\n- create (script_path -> extends="Node", content, project_path): generate template\n- read (script_path -> project_path)\n- write (script_path, content -> project_path): replace entire file\n- attach (script_path, scene_path, node_name -> project_path): link to scene node\n- list (-> project_path)\n- delete (script_path -> project_path)\n\nscript_path: relative to project root (e.g., "scripts/player.gd").',
-    annotations: {
-      title: 'Scripts',
-      readOnlyHint: false,
-      destructiveHint: true,
-      idempotentHint: false,
-      openWorldHint: false,
-    },
+    annotations: createAnnotations('Scripts', { destructive: true }),
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -162,13 +158,7 @@ const P0_TOOLS = [
     name: 'editor',
     description:
       'Godot editor control.\n\nActions (required params -> optional):\n- launch (-> project_path): open editor\n- status (-> project_path): check if editor is running\n\nFor running the game, use project(action="run") instead.',
-    annotations: {
-      title: 'Editor',
-      readOnlyHint: false,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: false,
-    },
+    annotations: createAnnotations('Editor', { idempotent: true }),
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -182,13 +172,7 @@ const P0_TOOLS = [
     name: 'config',
     description:
       'Server configuration and environment.\n\nActions (required params -> optional):\n- status: current config\n- set (key, value): update setting\n- detect_godot: find Godot binary path\n- check: verify project and Godot availability',
-    annotations: {
-      title: 'Config',
-      readOnlyHint: false,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: false,
-    },
+    annotations: createAnnotations('Config', { idempotent: true }),
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -206,13 +190,7 @@ const P0_TOOLS = [
   {
     name: 'help',
     description: 'Full documentation for a tool. Use when compressed descriptions are insufficient.',
-    annotations: {
-      title: 'Help',
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: false,
-    },
+    annotations: createAnnotations('Help', { readOnly: true, idempotent: true }),
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -254,13 +232,7 @@ const P1_TOOLS = [
     name: 'resources',
     description:
       'Resource file management.\n\nActions (required params -> optional):\n- list (-> type, project_path): browse resources (type: image|audio|font|shader|scene|resource)\n- info (resource_path -> project_path): resource metadata\n- delete (resource_path -> project_path)\n- import_config (resource_path -> project_path): view import settings',
-    annotations: {
-      title: 'Resources',
-      readOnlyHint: false,
-      destructiveHint: true,
-      idempotentHint: false,
-      openWorldHint: false,
-    },
+    annotations: createAnnotations('Resources', { destructive: true }),
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -276,13 +248,7 @@ const P1_TOOLS = [
     name: 'input_map',
     description:
       'Input action management.\n\nActions (required params -> optional):\n- list (-> project_path): all input actions\n- add_action (action_name -> deadzone=0.5, project_path)\n- remove_action (action_name -> project_path)\n- add_event (action_name, event_type, event_value -> project_path)\n\nevent_type: key | mouse | joypad. event_value: e.g., KEY_SPACE.',
-    annotations: {
-      title: 'Input Map',
-      readOnlyHint: false,
-      destructiveHint: true,
-      idempotentHint: false,
-      openWorldHint: false,
-    },
+    annotations: createAnnotations('Input Map', { destructive: true }),
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -304,13 +270,7 @@ const P1_TOOLS = [
     name: 'signals',
     description:
       'Signal connection management.\n\nActions (required params -> optional):\n- list (scene_path -> project_path): all signal connections\n- connect (scene_path, signal, from, to, method -> flags, project_path)\n- disconnect (scene_path, signal, from, to, method -> project_path)',
-    annotations: {
-      title: 'Signals',
-      readOnlyHint: false,
-      destructiveHint: true,
-      idempotentHint: false,
-      openWorldHint: false,
-    },
+    annotations: createAnnotations('Signals', { destructive: true }),
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -337,13 +297,7 @@ const P2_TOOLS = [
     name: 'animation',
     description:
       'Animation management. Actions: create_player|add_animation|add_track|add_keyframe|list. Use help tool for full docs.',
-    annotations: {
-      title: 'Animation',
-      readOnlyHint: false,
-      destructiveHint: false,
-      idempotentHint: false,
-      openWorldHint: false,
-    },
+    annotations: createAnnotations('Animation'),
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -370,13 +324,7 @@ const P2_TOOLS = [
     name: 'tilemap',
     description:
       'TileSet and TileMap management. Actions: create_tileset|add_source|set_tile|paint|list. Use help tool for full docs.',
-    annotations: {
-      title: 'TileMap',
-      readOnlyHint: false,
-      destructiveHint: false,
-      idempotentHint: false,
-      openWorldHint: false,
-    },
+    annotations: createAnnotations('TileMap'),
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -397,13 +345,7 @@ const P2_TOOLS = [
   {
     name: 'shader',
     description: 'Godot shader management. Actions: create|read|write|get_params|list. Use help tool for full docs.',
-    annotations: {
-      title: 'Shader',
-      readOnlyHint: false,
-      destructiveHint: false,
-      idempotentHint: false,
-      openWorldHint: false,
-    },
+    annotations: createAnnotations('Shader'),
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -427,13 +369,7 @@ const P2_TOOLS = [
     name: 'physics',
     description:
       'Physics config. Actions: layers|collision_setup|body_config|set_layer_name. Use help tool for full docs.',
-    annotations: {
-      title: 'Physics',
-      readOnlyHint: false,
-      destructiveHint: false,
-      idempotentHint: false,
-      openWorldHint: false,
-    },
+    annotations: createAnnotations('Physics'),
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -466,13 +402,7 @@ const P3_TOOLS = [
     name: 'audio',
     description:
       'Audio bus and stream management. Actions: list_buses|add_bus|add_effect|create_stream. Use help tool for full docs.',
-    annotations: {
-      title: 'Audio',
-      readOnlyHint: false,
-      destructiveHint: false,
-      idempotentHint: false,
-      openWorldHint: false,
-    },
+    annotations: createAnnotations('Audio'),
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -498,13 +428,7 @@ const P3_TOOLS = [
     name: 'navigation',
     description:
       'Navigation regions, agents, obstacles. Actions: create_region|add_agent|add_obstacle. Use help tool for full docs.',
-    annotations: {
-      title: 'Navigation',
-      readOnlyHint: false,
-      destructiveHint: false,
-      idempotentHint: false,
-      openWorldHint: false,
-    },
+    annotations: createAnnotations('Navigation'),
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -528,13 +452,7 @@ const P3_TOOLS = [
     name: 'ui',
     description:
       'UI Control nodes and themes. Actions: create_control|set_theme|layout|list_controls. Use help tool for full docs.',
-    annotations: {
-      title: 'UI',
-      readOnlyHint: false,
-      destructiveHint: false,
-      idempotentHint: false,
-      openWorldHint: false,
-    },
+    annotations: createAnnotations('UI'),
     inputSchema: {
       type: 'object' as const,
       properties: {

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -62,7 +62,7 @@ describe('registry', () => {
       registrySource = readFileSync(resolve(import.meta.dirname, '../src/tools/registry.ts'), 'utf-8')
 
       // Count annotations blocks (each tool should have one)
-      const annotationsMatches = registrySource.match(/annotations:\s*\{/g)
+      const annotationsMatches = registrySource.match(/annotations:\s*createAnnotations/g)
       expect(annotationsMatches?.length).toBe(17)
     })
 
@@ -71,18 +71,14 @@ describe('registry', () => {
       const { resolve } = await import('node:path')
       registrySource = readFileSync(resolve(import.meta.dirname, '../src/tools/registry.ts'), 'utf-8')
 
-      // Each annotation block should have all 5 fields
-      const titleCount = (registrySource.match(/title:/g) || []).length
-      const readOnlyCount = (registrySource.match(/readOnlyHint:/g) || []).length
-      const destructiveCount = (registrySource.match(/destructiveHint:/g) || []).length
-      const idempotentCount = (registrySource.match(/idempotentHint:/g) || []).length
-      const openWorldCount = (registrySource.match(/openWorldHint:/g) || []).length
+      const annotationCalls = (registrySource.match(/annotations: createAnnotations/g) || []).length
+      expect(annotationCalls).toBe(17)
 
-      expect(titleCount).toBe(17)
-      expect(readOnlyCount).toBe(17)
-      expect(destructiveCount).toBe(17)
-      expect(idempotentCount).toBe(17)
-      expect(openWorldCount).toBe(17)
+      // The individual hint fields now appear exactly once in the helper function
+      expect(registrySource).toContain('readOnlyHint: options.readOnly ?? false')
+      expect(registrySource).toContain('destructiveHint: options.destructive ?? false')
+      expect(registrySource).toContain('idempotentHint: options.idempotent ?? false')
+      expect(registrySource).toContain('openWorldHint: false')
     })
 
     it('all tools should have inputSchema with required action', async () => {
@@ -243,7 +239,7 @@ describe('registry', () => {
 
       // help should be read-only
       const helpSection = source.slice(source.indexOf("name: 'help'"), source.indexOf('const P1_TOOLS'))
-      expect(helpSection).toContain('readOnlyHint: true')
+      expect(helpSection).toContain('readOnly: true')
     })
 
     it('destructive tools should have destructiveHint=true', async () => {
@@ -256,7 +252,7 @@ describe('registry', () => {
         const start = source.indexOf(`name: '${toolName}'`)
         const end = source.indexOf('},\n', start + 1)
         const section = source.slice(start, end)
-        expect(section, `${toolName} should be destructive`).toContain('destructiveHint: true')
+        expect(section, `${toolName} should be destructive`).toContain('destructive: true')
       }
     })
   })


### PR DESCRIPTION
The annotations block in `src/tools/registry.ts` was duplicated over 20 times, leading to unnecessary boilerplate. This PR introduces a `createAnnotations` factory function to standardize tool metadata and reduces the file size by approximately 100 lines. 

Key changes:
- Introduced `createAnnotations(title, options)` helper in `src/tools/registry.ts`.
- Refactored P0 through P3 tool definitions to use the new helper.
- Updated `tests/registry.test.ts` to use regex patterns compatible with the new function-call based structure for annotations.
- Verified that all tool hints (read-only, destructive, idempotent) are preserved.
- All tests pass, and Biome linting/TypeScript checks are green.

---
*PR created automatically by Jules for task [4372814668810923403](https://jules.google.com/task/4372814668810923403) started by @n24q02m*