### PR TITLE
🛡️ Sentinel: [HIGH] Fix argument injection in Godot project export

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,11 @@
 **Vulnerability:** The `editor status` action used raw shell commands (`pgrep` and `tasklist`) through `execFile` to find Godot processes. It parsed the untrusted string output using regular expressions to extract PIDs.
 **Learning:** Using system tools to globally query processes and manually parsing string output is brittle and exposes the system to potential injection or parsing bugs, especially if malicious process names are introduced or if regexes are loosely bounded.
 **Prevention:** Instead of querying global system state via shell commands, track process lifecycles internally (e.g., `config.activePids`) when launched by the tool. To verify their existence, use safe OS-level APIs like `process.kill(pid, 0)`, which tests process existence synchronously without relying on parsing string output or shelling out to external commands.
+
+## 2025-04-10 - Command Injection / Parameter Injection in Godot Export
+
+**Vulnerability:** The `export` action in `src/tools/composite/project.ts` accepts `preset` and `output_path` parameters that are directly passed as arguments to the `execGodotAsync` function which ultimately invokes the Godot executable. Although `execFile` does not execute through a shell, passing parameters starting with `-` or `--` to a CLI binary can be interpreted as flags rather than positional arguments. This could lead to parameter injection where an attacker could pass an arbitrary flag to the Godot binary, e.g. `--script` followed by a path.
+
+**Learning:** When executing a binary via `child_process.spawn` or `execFile`, arguments derived from user input must be sanitized to prevent parameter injection. Even if shell injection is avoided, the binary itself might misinterpret an argument starting with `-` as a flag rather than data.
+
+**Prevention:** Ensure that string parameters that are intended to be values (such as `preset` or `output_path`) do not begin with `-`. If they do, reject the input or sanitize it.

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -184,6 +184,15 @@ export async function handleProject(action: string, args: Record<string, unknown
         )
       }
 
+      // Security: Prevent argument injection via preset or output path
+      if (preset.startsWith('-') || outputPath.startsWith('-')) {
+        throw new GodotMCPError(
+          'Invalid arguments',
+          'INVALID_ARGS',
+          'Preset and output path must not start with a hyphen (-).',
+        )
+      }
+
       const resolvedProjectPath = safeResolve(config.projectPath || process.cwd(), projectPath)
       const result = await execGodotAsync(config.godotPath, [
         '--headless',

--- a/tests/composite/project-security.test.ts
+++ b/tests/composite/project-security.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Security tests for Project tool
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleProject } from '../../src/tools/composite/project.js'
+import { createTmpProject, makeConfig } from '../fixtures.js'
+
+vi.mock('../../src/godot/headless.js', () => ({
+  execGodotAsync: vi.fn().mockResolvedValue({ success: true, stdout: '', stderr: '', exitCode: 0 }),
+  execGodotSync: vi.fn(),
+  runGodotProject: vi.fn(),
+}))
+
+describe('project security', () => {
+  let projectPath: string
+  let cleanup: () => void
+  let config: GodotConfig
+
+  beforeEach(() => {
+    const tmp = createTmpProject()
+    projectPath = tmp.projectPath
+    cleanup = tmp.cleanup
+    config = makeConfig({ projectPath, godotPath: '/path/to/godot' })
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  describe('export argument injection', () => {
+    it('should reject preset starting with a hyphen', async () => {
+      await expect(
+        handleProject(
+          'export',
+          {
+            project_path: projectPath,
+            preset: '--script',
+            output_path: 'build/game.x86_64',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid arguments')
+    })
+
+    it('should reject output_path starting with a hyphen', async () => {
+      await expect(
+        handleProject(
+          'export',
+          {
+            project_path: projectPath,
+            preset: 'Linux/X11',
+            output_path: '-something',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid arguments')
+    })
+
+    it('should allow valid preset and output_path', async () => {
+      await expect(
+        handleProject(
+          'export',
+          {
+            project_path: projectPath,
+            preset: 'Linux/X11',
+            output_path: 'build/game.x86_64',
+          },
+          config,
+        ),
+      ).resolves.not.toThrow()
+    })
+  })
+})


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix argument injection in Godot project export

🚨 Severity: HIGH
💡 Vulnerability: Parameter Injection in `export` action for Godot. The parameters `preset` and `output_path` are passed directly to `execGodotAsync` which invokes the Godot executable. A malicious user could use hyphen-prefixed strings to pass flags rather than literal argument paths/values (e.g., `--script`), bypassing shell injection constraints.
🎯 Impact: Attacker could force the Godot engine to run unintended internal features, execute side-channel scripts, or crash via malformed flag injection.
🔧 Fix: Add strict checking to block any `preset` or `output_path` that begins with a `-`. Added `tests/composite/project-security.test.ts` to assert this defense.
✅ Verification: Ran `vitest`, `bun run check`, `bun run format`, all tests pass including the new security suite `tests/composite/project-security.test.ts`. Recorded learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [2438743882060355842](https://jules.google.com/task/2438743882060355842) started by @n24q02m*