### PR TITLE
🛡️ Sentinel: [HIGH] Fix argument injection in project export

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The `editor status` action used raw shell commands (`pgrep` and `tasklist`) through `execFile` to find Godot processes. It parsed the untrusted string output using regular expressions to extract PIDs.
 **Learning:** Using system tools to globally query processes and manually parsing string output is brittle and exposes the system to potential injection or parsing bugs, especially if malicious process names are introduced or if regexes are loosely bounded.
 **Prevention:** Instead of querying global system state via shell commands, track process lifecycles internally (e.g., `config.activePids`) when launched by the tool. To verify their existence, use safe OS-level APIs like `process.kill(pid, 0)`, which tests process existence synchronously without relying on parsing string output or shelling out to external commands.
+
+## 2026-04-12 - Godot CLI Argument Injection via Export Parameters
+**Vulnerability:** The `export` action in `src/tools/composite/project.ts` passed the user-provided `preset` and `output_path` parameters directly to `execGodotAsync` without checking for leading hyphens. This allowed argument injection, where an attacker could provide a value like `--script=malicious.gd` to execute arbitrary code within the Godot project context.
+**Learning:** Even when using a safe array-based execution function like `execFile`, arguments passed to command-line utilities can still be parsed as arbitrary operational flags if they start with hyphens.
+**Prevention:** Validate user inputs passed to CLI utilities to ensure they do not start with a hyphen if they are intended to be positional arguments. Explicitly reject payloads starting with `-` or `--`.

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -184,6 +184,14 @@ export async function handleProject(action: string, args: Record<string, unknown
         )
       }
 
+      if (preset.startsWith('-') || outputPath.startsWith('-')) {
+        throw new GodotMCPError(
+          'Invalid arguments',
+          'INVALID_ARGS',
+          'Preset and output path must not start with a hyphen.',
+        )
+      }
+
       const resolvedProjectPath = safeResolve(config.projectPath || process.cwd(), projectPath)
       const result = await execGodotAsync(config.godotPath, [
         '--headless',

--- a/tests/composite/project-security.test.ts
+++ b/tests/composite/project-security.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Security tests for Project tool
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleProject } from '../../src/tools/composite/project.js'
+import { createTmpProject, makeConfig } from '../fixtures.js'
+
+// Mock headless execution
+vi.mock('../../src/godot/headless.js', () => ({
+  execGodotAsync: vi.fn().mockResolvedValue({ success: true, stdout: '', stderr: '', exitCode: 0 }),
+  execGodotSync: vi.fn(),
+  runGodotProject: vi.fn(),
+}))
+
+// Mock child_process for stop command
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}))
+
+import { execGodotAsync } from '../../src/godot/headless.js'
+
+describe('project security', () => {
+  let projectPath: string
+  let cleanup: () => void
+  let config: GodotConfig
+
+  beforeEach(() => {
+    const tmp = createTmpProject()
+    projectPath = tmp.projectPath
+    cleanup = tmp.cleanup
+    config = makeConfig({ projectPath, godotPath: '/path/to/godot' })
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  describe('export argument injection prevention', () => {
+    it('should reject preset starting with a hyphen', async () => {
+      await expect(
+        handleProject(
+          'export',
+          {
+            project_path: projectPath,
+            preset: '--script=malicious.gd',
+            output_path: 'build/game.exe',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid arguments')
+
+      expect(execGodotAsync).not.toHaveBeenCalled()
+    })
+
+    it('should reject output_path starting with a hyphen', async () => {
+      await expect(
+        handleProject(
+          'export',
+          {
+            project_path: projectPath,
+            preset: 'Windows Desktop',
+            output_path: '--script=malicious.gd',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid arguments')
+
+      expect(execGodotAsync).not.toHaveBeenCalled()
+    })
+
+    it('should allow valid preset and output_path', async () => {
+      const result = await handleProject(
+        'export',
+        {
+          project_path: projectPath,
+          preset: 'Windows Desktop',
+          output_path: 'build/game.exe',
+        },
+        config,
+      )
+
+      expect(result.content[0].text).toContain('Export complete: build/game.exe')
+      expect(execGodotAsync).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
🚨 **Severity**: HIGH

💡 **Vulnerability**: The `export` action in `src/tools/composite/project.ts` passed user-provided `preset` and `output_path` parameters to the Godot CLI execution (`execGodotAsync`) without validating whether they start with a hyphen. This allowed for argument injection if an attacker passed something like `--script=malicious.gd` as a preset, allowing arbitrary execution within the Godot project context.

🎯 **Impact**: Argument injection could allow an attacker to bypass intended headless execution flows and execute arbitrary gdscripts or otherwise manipulate the Godot execution flow, potentially leading to unauthorized system access or file tampering.

🔧 **Fix**: Added validation in `handleProject` within `src/tools/composite/project.ts` to ensure that neither `preset` nor `outputPath` start with a hyphen. If they do, the action securely fails and throws an `INVALID_ARGS` error. Added explicit unit tests in a new `tests/composite/project-security.test.ts` file.

✅ **Verification**: Run `bun run test` to verify the security tests (`tests/composite/project-security.test.ts`) properly reject hyphens and ensure 100% test suite passage. Checked formatting and linting via `bun run check`.

---
*PR created automatically by Jules for task [1226908776313114518](https://jules.google.com/task/1226908776313114518) started by @n24q02m*