### PR TITLE
⚡ Bolt: Optimize node renaming overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-14 - String Replacement Optimization
+**Learning:** For replacing exact sub-strings, native `String.prototype.replaceAll` is significantly faster than using dynamically created `RegExp` expressions with the `g` flag since it bypasses expression compilation and memory allocation overhead.
+**Action:** Always prefer `replaceAll` or `replace` with a string argument for exact match substitution, especially in potentially hot functions like scene parsing/manipulation.

--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -323,18 +323,20 @@ export function renameNodeInContent(content: string, oldName: string, newName: s
     return content
   }
 
+  // Replace in node declarations, parent references, and connections
+  // OPTIMIZATION: Use string.replaceAll for exact string replacement instead of dynamic RegExp to avoid compilation overhead
+  let result = content
+    .replaceAll(`name="${oldName}"`, `name="${newName}"`)
+    .replaceAll(`parent="${oldName}"`, `parent="${newName}"`)
+    .replaceAll(`from="${oldName}"`, `from="${newName}"`)
+    .replaceAll(`to="${oldName}"`, `to="${newName}"`)
+
   const escapedOldName = escapeRegExp(oldName)
 
-  // Replace in node declarations
-  let result = content.replace(new RegExp(`name="${escapedOldName}"`, 'g'), `name="${newName}"`)
-  // Replace in parent references
-  result = result.replace(new RegExp(`parent="${escapedOldName}"`, 'g'), `parent="${newName}"`)
-  // Replace in parent paths containing the old name
+  // Replace in parent paths containing the old name (requires regex for complex hierarchical patterns)
   result = result.replace(new RegExp(`parent="([^"]*/)${escapedOldName}(/[^"]*)"`, 'g'), `parent="$1${newName}$2"`)
   result = result.replace(new RegExp(`parent="([^"]*/)${escapedOldName}"`, 'g'), `parent="$1${newName}"`)
-  // Replace in connection references
-  result = result.replace(new RegExp(`from="${escapedOldName}"`, 'g'), `from="${newName}"`)
-  result = result.replace(new RegExp(`to="${escapedOldName}"`, 'g'), `to="${newName}"`)
+
   return result
 }
 


### PR DESCRIPTION
💡 **What**: Refactored `renameNodeInContent` inside `src/tools/helpers/scene-parser.ts` to use `String.prototype.replaceAll` for exact substring matching instead of executing dynamically built, global `RegExp` expressions. A critical learning note was also appended to `.jules/bolt.md`.

🎯 **Why**: Using `.replace(new RegExp("...", "g"))` incurs overhead from regular expression compilation, execution, and unnecessary memory allocations when simply exact-matching and replacing a literal string. This function is typically hot in node manipulation scenarios, especially in deep scene files with lots of connections or nodes.

📊 **Impact**: Faster execution of string replacements within node rename operations and less garbage collector pressure overall. Reduced risk of potential bugs stemming from manually escaping RegExp.

🔬 **Measurement**: Verify via `bun run test`. All tests correctly pass, confirming identical functional behavior while ensuring exact substitution takes the faster native exact string matching route. All type-checking and biome checks continue to strictly pass.

---
*PR created automatically by Jules for task [17247535134375787361](https://jules.google.com/task/17247535134375787361) started by @n24q02m*