### PR TITLE
fix(detector): skip signature heuristic for explicit paths, add overlap to chunked scan

### DIFF
--- a/src/godot/detector.ts
+++ b/src/godot/detector.ts
@@ -43,10 +43,12 @@ export function isVersionSupported(version: GodotVersion): boolean {
 }
 
 /**
- * Try to get Godot version from a binary path
+ * Try to get Godot version from a binary path.
+ * When skipSignatureCheck is true (e.g. user explicitly provided the path),
+ * the binary signature heuristic is skipped and only --version validation is used.
  */
-export function tryGetVersion(binaryPath: string): GodotVersion | null {
-  if (!isLikelyGodotBinary(binaryPath)) return null
+export function tryGetVersion(binaryPath: string, skipSignatureCheck = false): GodotVersion | null {
+  if (!skipSignatureCheck && !isLikelyGodotBinary(binaryPath)) return null
   try {
     const output = execFileSync(binaryPath, ['--version'], {
       timeout: 5000,
@@ -67,15 +69,21 @@ export function isLikelyGodotBinary(filePath: string): boolean {
   let fd: number | null = null
   try {
     fd = openSync(filePath, 'r')
-    // Read first 4MB - Godot binaries are typically 40MB-100MB+
-    // Signatures like "Godot Engine" or "GDScript" are usually present early or scattered
-    const buffer = Buffer.alloc(4 * 1024 * 1024)
-    const bytesRead = readSync(fd, buffer, 0, buffer.length, 0)
-
+    const stats = statSync(filePath)
+    const fileSize = stats.size
+    const chunkSize = 4 * 1024 * 1024
     const sig1 = Buffer.from('Godot Engine')
     const sig2 = Buffer.from('GDScript')
-
-    return buffer.subarray(0, bytesRead).includes(sig1) || buffer.subarray(0, bytesRead).includes(sig2)
+    const maxSigLen = Math.max(sig1.length, sig2.length)
+    const overlap = maxSigLen - 1
+    const step = chunkSize - overlap
+    const buffer = Buffer.alloc(chunkSize)
+    for (let offset = 0; offset < fileSize; offset += step) {
+      const readLen = Math.min(chunkSize, fileSize - offset)
+      const bytesRead = readSync(fd, buffer, 0, readLen, offset)
+      if (buffer.subarray(0, bytesRead).includes(sig1) || buffer.subarray(0, bytesRead).includes(sig2)) return true
+    }
+    return false
   } catch {
     return false
   } finally {
@@ -221,10 +229,10 @@ function getSystemPaths(): string[] {
  * @returns Detection result or null if not found
  */
 export function detectGodot(): DetectionResult | null {
-  // 1. Check GODOT_PATH env var
+  // 1. Check GODOT_PATH env var — skip signature heuristic since user explicitly provided the path
   const envPath = process.env.GODOT_PATH
   if (envPath && isExecutable(envPath)) {
-    const version = tryGetVersion(envPath)
+    const version = tryGetVersion(envPath, true)
     if (version && isVersionSupported(version)) {
       return { path: envPath, version, source: 'env' }
     }

--- a/src/godot/detector.ts
+++ b/src/godot/detector.ts
@@ -9,11 +9,11 @@
  */
 
 import { execFileSync } from 'node:child_process'
-import { accessSync, closeSync, constants, existsSync, openSync, readdirSync, readSync, statSync } from 'node:fs'
+import { accessSync, closeSync, constants, existsSync, fstatSync, openSync, readdirSync, readSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import type { DetectionResult, GodotVersion } from './types.js'
 
-const GODOT_BINARY_NAMES = ['godot', 'godot4', 'Godot_v4']
+const GODOT_BINARY_NAMES = ['godot', 'godot4', 'godot-preview', 'Godot_v4']
 const MIN_VERSION = { major: 4, minor: 1 }
 
 /**
@@ -69,7 +69,7 @@ export function isLikelyGodotBinary(filePath: string): boolean {
   let fd: number | null = null
   try {
     fd = openSync(filePath, 'r')
-    const stats = statSync(filePath)
+    const stats = fstatSync(fd)
     const fileSize = stats.size
     const chunkSize = 4 * 1024 * 1024
     const sig1 = Buffer.from('Godot Engine')
@@ -195,6 +195,7 @@ function getSystemPaths(): string[] {
     paths.push(
       '/Applications/Godot.app/Contents/MacOS/Godot',
       '/Applications/Godot_mono.app/Contents/MacOS/Godot',
+      '/Applications/Godot_preview.app/Contents/MacOS/Godot',
       // Homebrew
       '/opt/homebrew/bin/godot',
       '/usr/local/bin/godot',
@@ -205,6 +206,8 @@ function getSystemPaths(): string[] {
       '/usr/bin/godot',
       '/usr/local/bin/godot',
       '/usr/bin/godot4',
+      '/usr/bin/godot-preview',
+      '/opt/godot-preview/godot-preview',
       // Snap
       '/snap/bin/godot',
       '/snap/bin/godot-4',

--- a/src/godot/detector.ts
+++ b/src/godot/detector.ts
@@ -71,9 +71,20 @@ export function isLikelyGodotBinary(filePath: string): boolean {
     fd = openSync(filePath, 'r')
     const stats = fstatSync(fd)
     const fileSize = stats.size
-    const chunkSize = 4 * 1024 * 1024
     const sig1 = Buffer.from('Godot Engine')
     const sig2 = Buffer.from('GDScript')
+
+    const fastSize = 64 * 1024
+    const fastBuf = Buffer.alloc(fastSize)
+    const headRead = readSync(fd, fastBuf, 0, Math.min(fastSize, fileSize), 0)
+    if (headRead > 0 && (fastBuf.subarray(0, headRead).includes(sig1) || fastBuf.subarray(0, headRead).includes(sig2))) return true
+    if (fileSize > fastSize) {
+      const tailOffset = fileSize - fastSize
+      const tailRead = readSync(fd, fastBuf, 0, fastSize, tailOffset)
+      if (tailRead > 0 && (fastBuf.subarray(0, tailRead).includes(sig1) || fastBuf.subarray(0, tailRead).includes(sig2))) return true
+    }
+
+    const chunkSize = 4 * 1024 * 1024
     const maxSigLen = Math.max(sig1.length, sig2.length)
     const overlap = maxSigLen - 1
     const step = chunkSize - overlap

--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -71,7 +71,7 @@ export async function handleConfig(action: string, args: Record<string, unknown>
             `The path '${value}' is not an executable file.`,
           )
         }
-        const version = tryGetVersion(value)
+        const version = tryGetVersion(value, true)
         if (!version) {
           throw new GodotMCPError(
             'Invalid Godot binary',

--- a/tests/godot/detector.test.ts
+++ b/tests/godot/detector.test.ts
@@ -193,10 +193,10 @@ describe('detector', () => {
       let callCount = 0
       vi.mocked(statSync).mockReturnValue({ isFile: () => true, size: largeSize } as unknown as import('node:fs').Stats)
       vi.mocked(openSync).mockReturnValue(999)
-      vi.mocked(readSync).mockImplementation((_fd, buffer, _len, offset) => {
+      vi.mocked(readSync).mockImplementation((_fd, buffer, _bufferOffset, _length, filePosition) => {
         callCount++
         const b = buffer as Buffer
-        if (offset > 70 * 1024 * 1024) {
+        if (typeof filePosition === 'number' && filePosition > 70 * 1024 * 1024) {
           b.write('Godot Engine')
           return 'Godot Engine'.length
         }
@@ -246,15 +246,15 @@ describe('detector', () => {
       let callCount = 0
       vi.mocked(statSync).mockReturnValue({ isFile: () => true, size: fileSize } as unknown as import('node:fs').Stats)
       vi.mocked(openSync).mockReturnValue(999)
-      vi.mocked(readSync).mockImplementation((_fd, buffer, _len, offset) => {
+      vi.mocked(readSync).mockImplementation((_fd, buffer, _bufferOffset, _length, filePosition) => {
         callCount++
         const b = buffer as Buffer
-        if (offset >= step) {
+        if (typeof filePosition === 'number' && filePosition >= step) {
           b.write('Godot Engine')
           return maxSigLen
         }
         b.fill(0)
-        return Math.min(chunkSize, fileSize - offset)
+        return Math.min(chunkSize, fileSize - (filePosition ?? 0))
       })
       expect(isLikelyGodotBinary('/usr/bin/godot-boundary')).toBe(true)
       expect(callCount).toBeGreaterThan(1)

--- a/tests/godot/detector.test.ts
+++ b/tests/godot/detector.test.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path'
  * Tests for Godot binary detector
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { detectGodot, isExecutable, isVersionSupported, parseGodotVersion } from '../../src/godot/detector.js'
+import { detectGodot, isExecutable, isLikelyGodotBinary, isVersionSupported, parseGodotVersion, tryGetVersion } from '../../src/godot/detector.js'
 
 vi.mock('node:child_process')
 vi.mock('node:fs')
@@ -163,6 +163,139 @@ describe('detector', () => {
   })
 
   // ==========================================
+  // isLikelyGodotBinary
+  // ==========================================
+  describe('isLikelyGodotBinary', () => {
+    it('should return true when signature is in first chunk', () => {
+      vi.mocked(statSync).mockReturnValue({ isFile: () => true, size: 50 * 1024 * 1024 } as unknown as import('node:fs').Stats)
+      vi.mocked(openSync).mockReturnValue(999)
+      vi.mocked(readSync).mockImplementation((_fd, buffer) => {
+        const b = buffer as Buffer
+        b.write('Godot Engine')
+        return 'Godot Engine'.length
+      })
+      expect(isLikelyGodotBinary('/usr/bin/godot')).toBe(true)
+    })
+
+    it('should return true when GDScript signature is found', () => {
+      vi.mocked(statSync).mockReturnValue({ isFile: () => true, size: 50 * 1024 * 1024 } as unknown as import('node:fs').Stats)
+      vi.mocked(openSync).mockReturnValue(999)
+      vi.mocked(readSync).mockImplementation((_fd, buffer) => {
+        const b = buffer as Buffer
+        b.write('GDScript')
+        return 'GDScript'.length
+      })
+      expect(isLikelyGodotBinary('/usr/bin/godot')).toBe(true)
+    })
+
+    it('should scan multiple chunks for large binaries where signature is not in first chunk', () => {
+      const largeSize = 139 * 1024 * 1024
+      let callCount = 0
+      vi.mocked(statSync).mockReturnValue({ isFile: () => true, size: largeSize } as unknown as import('node:fs').Stats)
+      vi.mocked(openSync).mockReturnValue(999)
+      vi.mocked(readSync).mockImplementation((_fd, buffer, _len, offset) => {
+        callCount++
+        const b = buffer as Buffer
+        if (offset > 70 * 1024 * 1024) {
+          b.write('Godot Engine')
+          return 'Godot Engine'.length
+        }
+        b.write('ELF\x00'.repeat(100))
+        return 400
+      })
+      expect(isLikelyGodotBinary('/usr/bin/godot-preview')).toBe(true)
+      expect(callCount).toBeGreaterThan(1)
+    })
+
+    it('should return false when no signature is found', () => {
+      vi.mocked(statSync).mockReturnValue({ isFile: () => true, size: 50 * 1024 * 1024 } as unknown as import('node:fs').Stats)
+      vi.mocked(openSync).mockReturnValue(999)
+      vi.mocked(readSync).mockImplementation((_fd, buffer) => {
+        const b = buffer as Buffer
+        b.write('some random binary')
+        return 18
+      })
+      expect(isLikelyGodotBinary('/usr/bin/not-godot')).toBe(false)
+    })
+
+    it('should handle small files under 4MB', () => {
+      vi.mocked(statSync).mockReturnValue({ isFile: () => true, size: 1024 * 1024 } as unknown as import('node:fs').Stats)
+      vi.mocked(openSync).mockReturnValue(999)
+      vi.mocked(readSync).mockImplementation((_fd, buffer) => {
+        const b = buffer as Buffer
+        b.write('Godot Engine')
+        return 'Godot Engine'.length
+      })
+      expect(isLikelyGodotBinary('/usr/bin/godot-small')).toBe(true)
+    })
+
+    it('should return false on read error', () => {
+      vi.mocked(statSync).mockReturnValue({ isFile: () => true, size: 50 * 1024 * 1024 } as unknown as import('node:fs').Stats)
+      vi.mocked(openSync).mockImplementation(() => {
+        throw new Error('ENOENT')
+      })
+      expect(isLikelyGodotBinary('/nonexistent')).toBe(false)
+    })
+
+    it('should detect signature that straddles a chunk boundary', () => {
+      const chunkSize = 4 * 1024 * 1024
+      const maxSigLen = 12
+      const overlap = maxSigLen - 1
+      const step = chunkSize - overlap
+      const fileSize = step * 2 + 100
+      let callCount = 0
+      vi.mocked(statSync).mockReturnValue({ isFile: () => true, size: fileSize } as unknown as import('node:fs').Stats)
+      vi.mocked(openSync).mockReturnValue(999)
+      vi.mocked(readSync).mockImplementation((_fd, buffer, _len, offset) => {
+        callCount++
+        const b = buffer as Buffer
+        if (offset >= step) {
+          b.write('Godot Engine')
+          return maxSigLen
+        }
+        b.fill(0)
+        return Math.min(chunkSize, fileSize - offset)
+      })
+      expect(isLikelyGodotBinary('/usr/bin/godot-boundary')).toBe(true)
+      expect(callCount).toBeGreaterThan(1)
+    })
+  })
+
+  // ==========================================
+  // tryGetVersion
+  // ==========================================
+  describe('tryGetVersion', () => {
+    it('should skip signature check when skipSignatureCheck is true', () => {
+      vi.mocked(statSync).mockReturnValue({ isFile: () => true } as unknown as import('node:fs').Stats)
+      vi.mocked(openSync).mockReturnValue(999)
+      vi.mocked(readSync).mockImplementation((_fd, buffer) => {
+        const b = buffer as Buffer
+        b.write('not a godot binary')
+        return 18
+      })
+      vi.mocked(execFileSync).mockReturnValue('4.7.dev4.official.abcdef')
+
+      const result = tryGetVersion('/custom/godot', true)
+      expect(result).not.toBeNull()
+      expect(result?.major).toBe(4)
+      expect(result?.minor).toBe(7)
+    })
+
+    it('should require signature check when skipSignatureCheck is false', () => {
+      vi.mocked(statSync).mockReturnValue({ isFile: () => true, size: 50 * 1024 * 1024 } as unknown as import('node:fs').Stats)
+      vi.mocked(openSync).mockReturnValue(999)
+      vi.mocked(readSync).mockImplementation((_fd, buffer) => {
+        const b = buffer as Buffer
+        b.write('not a godot binary')
+        return 18
+      })
+
+      const result = tryGetVersion('/custom/godot', false)
+      expect(result).toBeNull()
+    })
+  })
+
+  // ==========================================
   // isExecutable
   // ==========================================
   describe('isExecutable', () => {
@@ -210,7 +343,7 @@ describe('detector', () => {
       vi.clearAllMocks()
       process.env = { ...originalEnv }
       // Default: statSync returns a file, accessSync succeeds (isExecutable passes)
-      vi.mocked(statSync).mockReturnValue({ isFile: () => true } as unknown as import('node:fs').Stats)
+      vi.mocked(statSync).mockReturnValue({ isFile: () => true, size: 50 * 1024 * 1024 } as unknown as import('node:fs').Stats)
       vi.mocked(accessSync).mockReturnValue(undefined)
       vi.mocked(openSync).mockReturnValue(999)
       vi.mocked(readSync).mockImplementation((_fd, buffer) => {
@@ -236,6 +369,25 @@ describe('detector', () => {
       expect(result?.path).toBe('/custom/path/godot')
       expect(result?.version.major).toBe(4)
       expect(result?.version.minor).toBe(2)
+      expect(result?.source).toBe('env')
+    })
+
+    it('should detect from GODOT_PATH even when binary signature is not in first 4MB', () => {
+      process.env.GODOT_PATH = '/custom/path/godot-preview'
+      vi.mocked(existsSync).mockReturnValue(true)
+      vi.mocked(execFileSync).mockReturnValue('4.7.dev4.official.755fa449c')
+      vi.mocked(readSync).mockImplementation((_fd, buffer) => {
+        const b = buffer as Buffer
+        b.write('ELF no signature here')
+        return 22
+      })
+
+      const result = detectGodot()
+
+      expect(result).not.toBeNull()
+      expect(result?.path).toBe('/custom/path/godot-preview')
+      expect(result?.version.major).toBe(4)
+      expect(result?.version.minor).toBe(7)
       expect(result?.source).toBe('env')
     })
 

--- a/tests/godot/detector.test.ts
+++ b/tests/godot/detector.test.ts
@@ -237,6 +237,42 @@ describe('detector', () => {
       expect(isLikelyGodotBinary('/nonexistent')).toBe(false)
     })
 
+    it('should find signature via head fast path', () => {
+      vi.mocked(statSync).mockReturnValue({ isFile: () => true, size: 50 * 1024 * 1024 } as unknown as import('node:fs').Stats)
+      vi.mocked(openSync).mockReturnValue(999)
+      let readCalls = 0
+      vi.mocked(readSync).mockImplementation((_fd, buffer, _bufOff, _len, pos) => {
+        readCalls++
+        const b = buffer as Buffer
+        if (typeof pos === 'number' && pos === 0) {
+          b.write('Godot Engine')
+          return 'Godot Engine'.length
+        }
+        b.fill(0)
+        return 64 * 1024
+      })
+      expect(isLikelyGodotBinary('/usr/bin/godot-fast-head')).toBe(true)
+      expect(readCalls).toBe(1)
+    })
+
+    it('should find signature via tail fast path', () => {
+      vi.mocked(statSync).mockReturnValue({ isFile: () => true, size: 100 * 1024 * 1024 } as unknown as import('node:fs').Stats)
+      vi.mocked(openSync).mockReturnValue(999)
+      let readCalls = 0
+      vi.mocked(readSync).mockImplementation((_fd, buffer, _bufOff, _len, pos) => {
+        readCalls++
+        const b = buffer as Buffer
+        const p = typeof pos === 'number' ? pos : 0
+        if (p > 90 * 1024 * 1024) {
+          b.write('Godot Engine')
+          return 'Godot Engine'.length
+        }
+        b.fill(0)
+        return _len as number
+      })
+      expect(isLikelyGodotBinary('/usr/bin/godot-fast-tail')).toBe(true)
+    })
+
     it('should detect signature that straddles a chunk boundary', () => {
       const chunkSize = 4 * 1024 * 1024
       const maxSigLen = 12


### PR DESCRIPTION
## Summary

Fixes Godot binary detection failing silently on many Godot builds where the `"Godot Engine"` / `"GDScript"` signature strings are located beyond the first 4MB of the binary.

### Problem

`isLikelyGodotBinary()` only scans the first 4MB of a binary file for signature strings. Godot binaries are typically 40-140MB+, and the signature can appear deep in the file — observed at offset 78MB+ in a 139MB `godot-preview` binary installed via AUR. This causes `detectGodot()` to always return `null`, making all headless CLI tools unavailable.

### Changes

**1. Skip signature heuristic for explicit user paths**

When the binary path comes from `GODOT_PATH` env var or `config set godot_path`, skip the heuristic and validate via `godot --version`. Deterministic, zero I/O overhead. If the user explicitly provides the path, trust it and verify by execution.

- `tryGetVersion(binaryPath, skipSignatureCheck = false)` — new optional param
- `detectGodot()` passes `true` for the `GODOT_PATH` case
- `config set godot_path` passes `true` for user-provided paths
- PATH and system detection still use the heuristic (defense in depth)

**2. Head/tail fast path**

Before the full chunked scan, read the first and last 64KB. Most Godot builds have signatures near the header or string table at the end. This catches typical binaries with only 128KB I/O, falling back to the full scan only when both miss.

**3. Overlapped chunked scanning**

Replaces the single 4MB head scan with an overlapped scan across the entire file:
- `step = chunkSize - (maxSignatureLength - 1)` — guarantees no signature straddles a chunk boundary
- 4MB chunks with 11-byte overlap (max sig "Godot Engine" = 12 bytes)
- Early exit on first match
- Uses `fstatSync(fd)` instead of `statSync(filePath)` since fd is already open (avoids TOCTOU)

**4. Broader binary names and system paths**

- Added `godot-preview` to `GODOT_BINARY_NAMES` for PATH detection
- Added `/usr/bin/godot-preview`, `/opt/godot-preview/godot-preview` to Linux paths
- Added `Godot_preview.app` to macOS paths

### Testing

Added test coverage for:
- `isLikelyGodotBinary`: first chunk match, GDScript signature, multi-chunk scan for large binaries, no signature, small files, read error, boundary-straddling signature, head fast path, tail fast path
- `tryGetVersion`: `skipSignatureCheck` flag behavior
- `detectGodot`: GODOT_PATH detection succeeds even when binary signature is not in first 4MB

### Security

The signature heuristic is a defense-in-depth measure. Skipping it for explicit user paths is safe because:
1. `isExecutable()` still validates the path exists, is a regular file, and is executable
2. `godot --version` must return a parseable version ≥ 4.1
3. The heuristic protects against *inadvertent* execution from PATH/system scans, not *deliberate* misconfiguration by the user