### PR TITLE
[FIX] Overly long line / Hardcoded Object Strings

### DIFF
--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -7,6 +7,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
+import { serializeGodotObject } from '../helpers/godot-types.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
 import { escapeRegExp } from '../helpers/scene-parser.js'
 
@@ -341,16 +342,59 @@ export async function handleInputMap(action: string, args: Record<string, unknow
       switch (eventType) {
         case 'key': {
           const keyCode = resolveKeyCode(eventValue)
-          eventObj = `Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":${keyCode},"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)`
+          eventObj = serializeGodotObject('InputEventKey', {
+            resource_local_to_scene: false,
+            resource_name: '',
+            device: -1,
+            window_id: 0,
+            alt_pressed: false,
+            shift_pressed: false,
+            ctrl_pressed: false,
+            meta_pressed: false,
+            pressed: false,
+            keycode: 0,
+            physical_keycode: keyCode,
+            key_label: 0,
+            unicode: 0,
+            location: 0,
+            echo: false,
+            script: null,
+          })
           break
         }
         case 'mouse': {
           const mouseCode = resolveMouseCode(eventValue)
-          eventObj = `Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0,0),"global_position":Vector2(0,0),"factor":1.0,"button_index":${mouseCode},"canceled":false,"pressed":true,"double_click":false,"script":null)`
+          eventObj = serializeGodotObject('InputEventMouseButton', {
+            resource_local_to_scene: false,
+            resource_name: '',
+            device: -1,
+            window_id: 0,
+            alt_pressed: false,
+            shift_pressed: false,
+            ctrl_pressed: false,
+            meta_pressed: false,
+            button_mask: 0,
+            position: { x: 0, y: 0 },
+            global_position: { x: 0, y: 0 },
+            factor: 1.0,
+            button_index: mouseCode,
+            canceled: false,
+            pressed: true,
+            double_click: false,
+            script: null,
+          })
           break
         }
         case 'joypad':
-          eventObj = `Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":${eventValue},"pressure":0.0,"pressed":true,"script":null)`
+          eventObj = serializeGodotObject('InputEventJoypadButton', {
+            resource_local_to_scene: false,
+            resource_name: '',
+            device: -1,
+            button_index: Number.parseInt(eventValue, 10),
+            pressure: 0.0,
+            pressed: true,
+            script: null,
+          })
           break
         default:
           throw new GodotMCPError(

--- a/src/tools/helpers/godot-types.ts
+++ b/src/tools/helpers/godot-types.ts
@@ -218,3 +218,14 @@ export function toGodotValue(value: unknown): string {
 
   return String(value)
 }
+
+/**
+ * Serialize a Godot Object with class name and properties
+ */
+export function serializeGodotObject(className: string, properties: Record<string, unknown>): string {
+  let result = `Object(${className}`
+  for (const [key, value] of Object.entries(properties)) {
+    result += `,"${key}":${toGodotValue(value)}`
+  }
+  return `${result})`
+}

--- a/tests/helpers/serialize-godot-object.test.ts
+++ b/tests/helpers/serialize-godot-object.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { serializeGodotObject } from '../../src/tools/helpers/godot-types.js'
+
+describe('serializeGodotObject', () => {
+  it('should serialize a simple Godot object', () => {
+    const result = serializeGodotObject('MyClass', { prop1: 1, prop2: 'value' })
+    expect(result).toBe('Object(MyClass,"prop1":1,"prop2":"value")')
+  })
+
+  it('should handle nested Godot types via toGodotValue', () => {
+    const result = serializeGodotObject('InputEventMouseButton', {
+      position: { x: 10, y: 20 },
+      pressed: true,
+      factor: 1.0,
+    })
+    expect(result).toBe('Object(InputEventMouseButton,"position":Vector2(10, 20),"pressed":true,"factor":1)')
+  })
+
+  it('should serialize with empty properties', () => {
+    const result = serializeGodotObject('EmptyClass', {})
+    expect(result).toBe('Object(EmptyClass)')
+  })
+})


### PR DESCRIPTION
This PR improves code quality by refactoring hardcoded Godot object strings into a structured serialization helper.

Key changes:
- Added `serializeGodotObject` helper to `src/tools/helpers/godot-types.ts` for consistent and readable Godot object serialization.
- Refactored `add_event` in `src/tools/composite/input-map.ts` to use the new helper, eliminating overly long template strings and improving maintainability.
- Added unit tests for `serializeGodotObject` in `tests/helpers/serialize-godot-object.test.ts`.
- Ensured all tests pass and followed project linting/formatting standards.

---
*PR created automatically by Jules for task [16615188591451347803](https://jules.google.com/task/16615188591451347803) started by @n24q02m*