### PR TITLE
[FIX] Fix strict type checks for readdirSync mock

### DIFF
--- a/tests/godot/detector.test.ts
+++ b/tests/godot/detector.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import type { Dirent, PathLike } from 'node:fs'
+import type { PathLike } from 'node:fs'
 import { accessSync, existsSync, openSync, readdirSync, readSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 /**
@@ -619,13 +619,14 @@ describe('detector', () => {
         return false
       })
 
-      vi.mocked(readdirSync).mockImplementation(((path: PathLike, _options?: unknown) => {
-        if (path === packagesDir) {
+      vi.mocked(readdirSync).mockImplementation(((path: PathLike, ...args: unknown[]) => {
+        const options = args[0] as { withFileTypes?: boolean } | undefined
+        if (path === packagesDir && options?.withFileTypes) {
           return [
             {
               isDirectory: () => true,
               name: 'GodotEngine.GodotEngine_Microsoft.Winget.Source_8wekyb3d8bbwe',
-            } as Dirent,
+            },
           ] as unknown as ReturnType<typeof readdirSync>
         }
         if (path === pkgDir) {


### PR DESCRIPTION
Refactored the `readdirSync` mock in `tests/godot/detector.test.ts` to satisfy strict TypeScript checking. The mock now uses a variadic argument list with `unknown[]` and appropriate type casting to align with Node.js `fs` module overloads. Unused imports were also cleaned up.

---
*PR created automatically by Jules for task [17623210445795453964](https://jules.google.com/task/17623210445795453964) started by @n24q02m*