### PR TITLE
[TEST] Missing edge case test for `setSettingInContent`

### DIFF
--- a/tests/helpers/project-settings.test.ts
+++ b/tests/helpers/project-settings.test.ts
@@ -200,6 +200,12 @@ describe('project-settings', () => {
       expect(result).toBe(original)
     })
 
+    it('should return original content for path with no slash', () => {
+      const content = '[section]\nkey=value'
+      const result = setSettingInContent(content, 'noslash', 'newvalue')
+      expect(result).toBe(content)
+    })
+
     it('should handle single-segment path (section_only)', () => {
       const result = setSettingInContent(SAMPLE_PROJECT_GODOT, 'section_only', 'value')
       expect(result).toBe(SAMPLE_PROJECT_GODOT)


### PR DESCRIPTION
Added a test case in tests/helpers/project-settings.test.ts to verify that setSettingInContent correctly handles paths with no slash (single-segment paths) by returning the original content unchanged. This ensures full branch coverage for the input validation check at the beginning of the function.

---
*PR created automatically by Jules for task [9642559300204671775](https://jules.google.com/task/9642559300204671775) started by @n24q02m*