### PR TITLE
[PERF] Blocking file read during server initialization

### DIFF
--- a/src/init-server.ts
+++ b/src/init-server.ts
@@ -10,10 +10,8 @@
  * Defaults to HTTP mode. Use --stdio flag or MCP_TRANSPORT=stdio for stdio mode.
  */
 
-import { readFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import pkg from '../package.json' with { type: 'json' }
 import { detectGodot } from './godot/detector.js'
 import type { GodotConfig } from './godot/types.js'
 import { registerTools } from './tools/registry.js'
@@ -21,15 +19,7 @@ import { registerTools } from './tools/registry.js'
 const SERVER_NAME = 'better-godot-mcp'
 
 function getVersion(): string {
-  try {
-    const __filename = fileURLToPath(import.meta.url)
-    const __dirname = dirname(__filename)
-    const pkgPath = join(__dirname, '..', 'package.json')
-    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
-    return pkg.version ?? '0.0.0'
-  } catch {
-    return '0.0.0'
-  }
+  return pkg.version ?? '0.0.0'
 }
 
 export function createGodotServer(): Server {

--- a/tests/init-server.test.ts
+++ b/tests/init-server.test.ts
@@ -38,14 +38,12 @@ vi.mock('../src/tools/registry.js', () => ({
   registerTools: vi.fn(),
 }))
 
-// Mock node:fs to test getVersion catch block
-vi.mock('node:fs', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs')>()
-  return {
-    ...actual,
-    readFileSync: vi.fn(actual.readFileSync),
-  }
-})
+// Mock package.json
+vi.mock('../package.json', () => ({
+  default: {
+    version: '1.2.3',
+  },
+}))
 
 // Mock mcp-core runLocalServer to avoid starting real server.
 // init-server.ts dynamically imports '@n24q02m/mcp-core' only for HTTP mode.
@@ -350,10 +348,7 @@ describe('initServer', () => {
   })
 
   describe('getVersion', () => {
-    it('should handle missing version in package.json', async () => {
-      const { readFileSync } = await import('node:fs')
-      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({}))
-
+    it('should return version from package.json', async () => {
       const { detectGodot } = await import('../src/godot/detector.js')
       vi.mocked(detectGodot).mockReturnValue(null)
 
@@ -362,27 +357,7 @@ describe('initServer', () => {
 
       expect(mockServerConstructor).toHaveBeenCalledWith(
         expect.objectContaining({
-          version: '0.0.0',
-        }),
-        expect.anything(),
-      )
-    })
-
-    it('should handle errors in getVersion by returning default version', async () => {
-      const { readFileSync } = await import('node:fs')
-      vi.mocked(readFileSync).mockImplementation(() => {
-        throw new Error('File not found')
-      })
-
-      const { detectGodot } = await import('../src/godot/detector.js')
-      vi.mocked(detectGodot).mockReturnValue(null)
-
-      const { createGodotServer } = await import('../src/init-server.js')
-      createGodotServer()
-
-      expect(mockServerConstructor).toHaveBeenCalledWith(
-        expect.objectContaining({
-          version: '0.0.0',
+          version: '1.2.3',
         }),
         expect.anything(),
       )


### PR DESCRIPTION
Replaced synchronous \`readFileSync\` of \`package.json\` with a top-level JSON import in \`src/init-server.ts\`.

💡 What:
Replaced synchronous \`readFileSync\` of \`package.json\` with a top-level JSON import in \`src/init-server.ts\`.

🎯 Why:
The synchronous file read was blocking the main thread during server initialization, which is inefficient. Using JSON imports with import attributes is the modern and performant way to handle this in ESM.

📊 Impact:
Removes a blocking I/O operation from the critical path of server startup, improving initialization performance.

🔬 Measurement:
- Verified that \`node build/scripts/start-server.js --stdio\` correctly reports the package version (v1.12.0).
- All unit tests in \`tests/init-server.test.ts\` pass with the updated mocking strategy.
- Full test suite passes.

---
*PR created automatically by Jules for task [5368275818918805400](https://jules.google.com/task/5368275818918805400) started by @n24q02m*