### PR TITLE
[SECURITY] Scene File Injection via Unsanitized Signal Connection Parameters

### DIFF
--- a/src/tools/composite/signals.ts
+++ b/src/tools/composite/signals.ts
@@ -9,13 +9,17 @@ import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '..
 import { safeResolve } from '../helpers/paths.js'
 import { parseSceneContent } from '../helpers/scene-parser.js'
 
-function validateParameters(...params: string[]) {
+function validateParameters(...params: unknown[]) {
   for (const param of params) {
-    if (param.includes('\n') || param.includes('\r') || param.includes('"')) {
+    if (typeof param !== 'string' && typeof param !== 'number' && param !== undefined) {
+      throw new GodotMCPError('Invalid parameter type', 'INVALID_ARGS', 'Signal parameters must be strings or numbers.')
+    }
+    const s = String(param)
+    if (s.includes('\n') || s.includes('\r') || s.includes('"') || s.includes(']')) {
       throw new GodotMCPError(
         'Invalid characters in parameters',
         'INVALID_ARGS',
-        'Signal parameters (signal, from, to, method) must not contain newlines or double quotes.',
+        'Signal parameters must not contain newlines, double quotes, or closing brackets (]).',
       )
     }
   }
@@ -70,9 +74,12 @@ export async function handleSignals(action: string, args: Record<string, unknown
         )
       }
 
-      validateParameters(signal, from, to, method)
-
       const flags = args.flags as number | undefined
+      if (flags !== undefined && typeof flags !== 'number') {
+        throw new GodotMCPError('flags must be a number', 'INVALID_ARGS')
+      }
+
+      validateParameters(signal, from, to, method, flags)
 
       let content = await readScene()
 

--- a/test-project-flags/test.tscn
+++ b/test-project-flags/test.tscn
@@ -1,0 +1,3 @@
+[gd_scene format=3]
+
+[node name="Node" type="Node"]

--- a/tests/security/signals-injection.test.ts
+++ b/tests/security/signals-injection.test.ts
@@ -1,0 +1,86 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleSignals } from '../../src/tools/composite/signals.js'
+
+describe('signals security', () => {
+  const projectPath = './test-project-security'
+  const scenePath = 'test.tscn'
+  const fullPath = join(projectPath, scenePath)
+  const config: GodotConfig = { projectPath, godotPath: 'godot' }
+
+  beforeEach(async () => {
+    await mkdir(projectPath, { recursive: true })
+    await writeFile(fullPath, '[gd_scene format=3]\n\n[node name="Node" type="Node"]\n', 'utf-8')
+  })
+
+  afterEach(async () => {
+    await rm(projectPath, { recursive: true, force: true })
+  })
+
+  it('should block newline injection in signal name', async () => {
+    await expect(
+      handleSignals(
+        'connect',
+        {
+          scene_path: scenePath,
+          signal: 'my_signal\n[evil]',
+          from: 'Node',
+          to: 'Node',
+          method: 'target',
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid characters in parameters')
+  })
+
+  it('should block quote injection in signal name', async () => {
+    await expect(
+      handleSignals(
+        'connect',
+        {
+          scene_path: scenePath,
+          signal: 'my_signal" from="Other"',
+          from: 'Node',
+          to: 'Node',
+          method: 'target',
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid characters in parameters')
+  })
+
+  it('should block bracket injection in signal name', async () => {
+    await expect(
+      handleSignals(
+        'connect',
+        {
+          scene_path: scenePath,
+          signal: 'my_signal] [evil]',
+          from: 'Node',
+          to: 'Node',
+          method: 'target',
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid characters in parameters')
+  })
+
+  it('should block non-number flags', async () => {
+    await expect(
+      handleSignals(
+        'connect',
+        {
+          scene_path: scenePath,
+          signal: 'my_signal',
+          from: 'Node',
+          to: 'Node',
+          method: 'target',
+          flags: '0] [evil]',
+        },
+        config,
+      ),
+    ).rejects.toThrow('flags must be a number')
+  })
+})


### PR DESCRIPTION
This PR fixes a security vulnerability where unsanitized signal connection parameters could be used to inject arbitrary content into Godot scene files (.tscn).

The fix includes:
- Improving 'validateParameters' in 'src/tools/composite/signals.ts' to reject newlines, carriage returns, double quotes, and closing brackets (']').
- Ensuring 'flags' are strictly validated as numbers.
- Applying validation to all parameters used in connection line construction.
- Adding a new test suite 'tests/security/signals-injection.test.ts' to verify the protection.

---
*PR created automatically by Jules for task [1093704905002746410](https://jules.google.com/task/1093704905002746410) started by @n24q02m*