### PR TITLE
[FIX] Long Function: handleNodes

### DIFF
--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -37,221 +37,209 @@ function normalizeNodePath(path: string): { path: string; corrected: boolean } {
   return { path, corrected: false }
 }
 
-export async function handleNodes(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const baseProjectPath = config.projectPath || process.cwd()
-  const projectPath = args.project_path ? safeResolve(baseProjectPath, args.project_path as string) : baseProjectPath
+async function handleAddNode(projectPath: string, args: Record<string, unknown>) {
+  const scenePath = args.scene_path as string
+  if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+  const nodeName = args.name as string
+  if (!nodeName) throw new GodotMCPError('No node name specified', 'INVALID_ARGS', 'Provide name for the new node.')
 
-  switch (action) {
-    case 'add': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
-      const nodeName = args.name as string
-      if (!nodeName) throw new GodotMCPError('No node name specified', 'INVALID_ARGS', 'Provide name for the new node.')
+  if (nodeName.includes('"') || nodeName.includes('\n') || nodeName.includes('\r')) {
+    throw new GodotMCPError('Invalid node name', 'INVALID_ARGS', 'Node name must not contain quotes or newlines.')
+  }
 
-      if (nodeName.includes('"') || nodeName.includes('\n') || nodeName.includes('\r')) {
-        throw new GodotMCPError('Invalid node name', 'INVALID_ARGS', 'Node name must not contain quotes or newlines.')
-      }
+  const nodeType = (args.type as string) || 'Node'
+  if (nodeType.includes('"') || nodeType.includes('\n') || nodeType.includes('\r')) {
+    throw new GodotMCPError('Invalid node type', 'INVALID_ARGS', 'Node type must not contain quotes or newlines.')
+  }
 
-      const nodeType = (args.type as string) || 'Node'
-      if (nodeType.includes('"') || nodeType.includes('\n') || nodeType.includes('\r')) {
-        throw new GodotMCPError('Invalid node type', 'INVALID_ARGS', 'Node type must not contain quotes or newlines.')
-      }
+  const rawParent = (args.parent as string) || '.'
+  const { path: parent } = normalizeNodePath(rawParent)
+  if (parent.includes('"') || parent.includes('\n') || parent.includes('\r')) {
+    throw new GodotMCPError('Invalid parent path', 'INVALID_ARGS', 'Parent path must not contain quotes or newlines.')
+  }
 
-      const rawParent = (args.parent as string) || '.'
-      const { path: parent } = normalizeNodePath(rawParent)
-      if (parent.includes('"') || parent.includes('\n') || parent.includes('\r')) {
-        throw new GodotMCPError(
-          'Invalid parent path',
-          'INVALID_ARGS',
-          'Parent path must not contain quotes or newlines.',
-        )
-      }
+  const fullPath = resolveScenePath(projectPath, scenePath)
+  if (!(await pathExists(fullPath)))
+    throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
 
-      const fullPath = resolveScenePath(projectPath, scenePath)
-      if (!(await pathExists(fullPath)))
-        throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
+  const content = await readFile(fullPath, 'utf-8')
+  const scene = parseSceneContent(content)
+  const duplicate = scene.nodes.find((n) => n.name === nodeName && (n.parent || '.') === parent)
+  if (duplicate) {
+    throw new GodotMCPError(
+      `Node "${nodeName}" already exists under parent "${parent}"`,
+      'NODE_ERROR',
+      'Use a different name.',
+    )
+  }
 
-      const content = await readFile(fullPath, 'utf-8')
-      const scene = parseSceneContent(content)
-      const duplicate = scene.nodes.find((n) => n.name === nodeName && (n.parent || '.') === parent)
-      if (duplicate) {
-        throw new GodotMCPError(
-          `Node "${nodeName}" already exists under parent "${parent}"`,
-          'NODE_ERROR',
-          'Use a different name.',
-        )
-      }
+  const parentAttr = parent === '.' ? '' : ` parent="${parent}"`
+  let nodeDecl = `\n[node name="${nodeName}" type="${nodeType}"${parentAttr}]\n`
 
-      const parentAttr = parent === '.' ? '' : ` parent="${parent}"`
-      let nodeDecl = `\n[node name="${nodeName}" type="${nodeType}"${parentAttr}]\n`
-
-      // Handle properties parsing
-      if (args.properties !== undefined) {
-        if (typeof args.properties !== 'object' || args.properties === null || Array.isArray(args.properties)) {
-          throw new GodotMCPError(
-            'Invalid properties format',
-            'INVALID_ARGS',
-            'properties must be an object with string keys and values.',
-          )
-        }
-        for (const [key, value] of Object.entries(args.properties)) {
-          if (typeof key !== 'string' || typeof value !== 'string') {
-            throw new GodotMCPError(
-              'Invalid property value',
-              'INVALID_ARGS',
-              'Property keys and values must be strings.',
-            )
-          }
-          if (key.includes('=') || key.includes('\n') || key.includes('\r')) {
-            throw new GodotMCPError(
-              'Invalid property key',
-              'INVALID_ARGS',
-              'Property keys must not contain "=", newlines.',
-            )
-          }
-          if (value.includes('\n') || value.includes('\r')) {
-            throw new GodotMCPError(
-              'Invalid property value',
-              'INVALID_ARGS',
-              'Property values must not contain newlines.',
-            )
-          }
-          nodeDecl += `${key} = ${value}\n`
-        }
-      }
-
-      const updated = `${content.trimEnd()}\n${nodeDecl}`
-      await writeFile(fullPath, updated, 'utf-8')
-
-      return formatSuccess(`Added node: ${nodeName} (${nodeType}) under ${parent}`)
+  // Handle properties parsing
+  if (args.properties !== undefined) {
+    if (typeof args.properties !== 'object' || args.properties === null || Array.isArray(args.properties)) {
+      throw new GodotMCPError(
+        'Invalid properties format',
+        'INVALID_ARGS',
+        'properties must be an object with string keys and values.',
+      )
     }
-
-    case 'remove': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
-      const rawName = args.name as string
-      if (!rawName) throw new GodotMCPError('No node name specified', 'INVALID_ARGS', 'Provide name of node to remove.')
-      const { path: nodeName } = normalizeNodePath(rawName)
-
-      const fullPath = resolveScenePath(projectPath, scenePath)
-      if (!(await pathExists(fullPath)))
-        throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
-
-      const content = await readFile(fullPath, 'utf-8')
-      const updated = removeNodeFromContent(content, nodeName)
-      await writeFile(fullPath, updated, 'utf-8')
-
-      return formatSuccess(`Removed node: ${nodeName} from ${scenePath}`)
-    }
-
-    case 'rename': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
-      const { path: nodeName } = normalizeNodePath((args.name as string) || '')
-      const newName = args.new_name as string
-      if (!nodeName || !newName)
-        throw new GodotMCPError('Both name and new_name required', 'INVALID_ARGS', 'Provide name and new_name.')
-
-      if (newName.includes('"') || newName.includes('\n') || newName.includes('\r')) {
-        throw new GodotMCPError(
-          'Invalid node name',
-          'INVALID_ARGS',
-          'New node name must not contain quotes or newlines.',
-        )
+    for (const [key, value] of Object.entries(args.properties)) {
+      if (typeof key !== 'string' || typeof value !== 'string') {
+        throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property keys and values must be strings.')
       }
-
-      const fullPath = resolveScenePath(projectPath, scenePath)
-      if (!(await pathExists(fullPath)))
-        throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
-
-      const content = await readFile(fullPath, 'utf-8')
-      const updated = renameNodeInContent(content, nodeName, newName)
-      await writeFile(fullPath, updated, 'utf-8')
-
-      return formatSuccess(`Renamed node: ${nodeName} -> ${newName} in ${scenePath}`)
-    }
-
-    case 'list': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
-
-      const fullPath = resolveScenePath(projectPath, scenePath)
-      if (!(await pathExists(fullPath)))
-        throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
-
-      const content = await readFile(fullPath, 'utf-8')
-      const scene = parseSceneContent(content)
-      // ⚡ Bolt: Removed double .map() passes and expensive object spread (...node.properties) in mapToSceneNode.
-      // Iterating scene.nodes directly in a single pass reduces O(N) allocation overhead for scenes with many nodes.
-      const nodes = []
-      for (const n of scene.nodes) {
-        nodes.push({
-          name: n.name,
-          type: n.type || 'Node',
-          parent: n.parent || '(root)',
-          hasScript: !!n.properties.script,
-        })
-      }
-
-      return formatJSON({
-        scene: scenePath,
-        nodeCount: scene.nodes.length,
-        nodes,
-      })
-    }
-
-    case 'set_property': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
-      const { path: nodeName } = normalizeNodePath((args.name as string) || '')
-      const property = args.property as string
-      const value = args.value as string
-      if (!nodeName || !property || value === undefined) {
-        throw new GodotMCPError(
-          'name, property, and value required',
-          'INVALID_ARGS',
-          'Provide name, property, and value.',
-        )
-      }
-
-      if (property.includes('=') || property.includes('\n') || property.includes('\r')) {
+      if (key.includes('=') || key.includes('\n') || key.includes('\r')) {
         throw new GodotMCPError('Invalid property key', 'INVALID_ARGS', 'Property keys must not contain "=", newlines.')
       }
       if (value.includes('\n') || value.includes('\r')) {
         throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property values must not contain newlines.')
       }
-
-      const fullPath = resolveScenePath(projectPath, scenePath)
-      if (!(await pathExists(fullPath)))
-        throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
-
-      const content = await readFile(fullPath, 'utf-8')
-      const updated = setNodePropertyInContent(content, nodeName, property, value)
-      await writeFile(fullPath, updated, 'utf-8')
-
-      return formatSuccess(`Set ${property} = ${value} on node ${nodeName}`)
+      nodeDecl += `${key} = ${value}\n`
     }
+  }
 
-    case 'get_property': {
-      const scenePath = args.scene_path as string
-      if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
-      const { path: nodeName } = normalizeNodePath((args.name as string) || '')
-      const property = args.property as string
-      if (!nodeName || !property) {
-        throw new GodotMCPError('name and property required', 'INVALID_ARGS', 'Provide name and property.')
-      }
+  const updated = `${content.trimEnd()}\n${nodeDecl}`
+  await writeFile(fullPath, updated, 'utf-8')
 
-      const fullPath = resolveScenePath(projectPath, scenePath)
-      if (!(await pathExists(fullPath)))
-        throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
+  return formatSuccess(`Added node: ${nodeName} (${nodeType}) under ${parent}`)
+}
 
-      const content = await readFile(fullPath, 'utf-8')
-      const scene = parseSceneContent(content)
-      const val = getNodeProperty(scene, nodeName, property)
+async function handleRemoveNode(projectPath: string, args: Record<string, unknown>) {
+  const scenePath = args.scene_path as string
+  if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+  const rawName = args.name as string
+  if (!rawName) throw new GodotMCPError('No node name specified', 'INVALID_ARGS', 'Provide name of node to remove.')
+  const { path: nodeName } = normalizeNodePath(rawName)
 
-      return formatJSON({ node: nodeName, property, value: val ?? null })
-    }
+  const fullPath = resolveScenePath(projectPath, scenePath)
+  if (!(await pathExists(fullPath)))
+    throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
 
+  const content = await readFile(fullPath, 'utf-8')
+  const updated = removeNodeFromContent(content, nodeName)
+  await writeFile(fullPath, updated, 'utf-8')
+
+  return formatSuccess(`Removed node: ${nodeName} from ${scenePath}`)
+}
+
+async function handleRenameNode(projectPath: string, args: Record<string, unknown>) {
+  const scenePath = args.scene_path as string
+  if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+  const { path: nodeName } = normalizeNodePath((args.name as string) || '')
+  const newName = args.new_name as string
+  if (!nodeName || !newName)
+    throw new GodotMCPError('Both name and new_name required', 'INVALID_ARGS', 'Provide name and new_name.')
+
+  if (newName.includes('"') || newName.includes('\n') || newName.includes('\r')) {
+    throw new GodotMCPError('Invalid node name', 'INVALID_ARGS', 'New node name must not contain quotes or newlines.')
+  }
+
+  const fullPath = resolveScenePath(projectPath, scenePath)
+  if (!(await pathExists(fullPath)))
+    throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
+
+  const content = await readFile(fullPath, 'utf-8')
+  const updated = renameNodeInContent(content, nodeName, newName)
+  await writeFile(fullPath, updated, 'utf-8')
+
+  return formatSuccess(`Renamed node: ${nodeName} -> ${newName} in ${scenePath}`)
+}
+
+async function handleListNodes(projectPath: string, args: Record<string, unknown>) {
+  const scenePath = args.scene_path as string
+  if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+
+  const fullPath = resolveScenePath(projectPath, scenePath)
+  if (!(await pathExists(fullPath)))
+    throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
+
+  const content = await readFile(fullPath, 'utf-8')
+  const scene = parseSceneContent(content)
+  // ⚡ Bolt: Removed double .map() passes and expensive object spread (...node.properties) in mapToSceneNode.
+  // Iterating scene.nodes directly in a single pass reduces O(N) allocation overhead for scenes with many nodes.
+  const nodes = []
+  for (const n of scene.nodes) {
+    nodes.push({
+      name: n.name,
+      type: n.type || 'Node',
+      parent: n.parent || '(root)',
+      hasScript: !!n.properties.script,
+    })
+  }
+
+  return formatJSON({
+    scene: scenePath,
+    nodeCount: scene.nodes.length,
+    nodes,
+  })
+}
+
+async function handleSetNodeProperty(projectPath: string, args: Record<string, unknown>) {
+  const scenePath = args.scene_path as string
+  if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+  const { path: nodeName } = normalizeNodePath((args.name as string) || '')
+  const property = args.property as string
+  const value = args.value as string
+  if (!nodeName || !property || value === undefined) {
+    throw new GodotMCPError('name, property, and value required', 'INVALID_ARGS', 'Provide name, property, and value.')
+  }
+
+  if (property.includes('=') || property.includes('\n') || property.includes('\r')) {
+    throw new GodotMCPError('Invalid property key', 'INVALID_ARGS', 'Property keys must not contain "=", newlines.')
+  }
+  if (value.includes('\n') || value.includes('\r')) {
+    throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property values must not contain newlines.')
+  }
+
+  const fullPath = resolveScenePath(projectPath, scenePath)
+  if (!(await pathExists(fullPath)))
+    throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
+
+  const content = await readFile(fullPath, 'utf-8')
+  const updated = setNodePropertyInContent(content, nodeName, property, value)
+  await writeFile(fullPath, updated, 'utf-8')
+
+  return formatSuccess(`Set ${property} = ${value} on node ${nodeName}`)
+}
+
+async function handleGetNodeProperty(projectPath: string, args: Record<string, unknown>) {
+  const scenePath = args.scene_path as string
+  if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+  const { path: nodeName } = normalizeNodePath((args.name as string) || '')
+  const property = args.property as string
+  if (!nodeName || !property) {
+    throw new GodotMCPError('name and property required', 'INVALID_ARGS', 'Provide name and property.')
+  }
+
+  const fullPath = resolveScenePath(projectPath, scenePath)
+  if (!(await pathExists(fullPath)))
+    throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
+
+  const content = await readFile(fullPath, 'utf-8')
+  const scene = parseSceneContent(content)
+  const val = getNodeProperty(scene, nodeName, property)
+
+  return formatJSON({ node: nodeName, property, value: val ?? null })
+}
+
+export async function handleNodes(action: string, args: Record<string, unknown>, config: GodotConfig) {
+  const baseProjectPath = config.projectPath || process.cwd()
+  const projectPath = args.project_path ? safeResolve(baseProjectPath, args.project_path as string) : baseProjectPath
+
+  switch (action) {
+    case 'add':
+      return handleAddNode(projectPath, args)
+    case 'remove':
+      return handleRemoveNode(projectPath, args)
+    case 'rename':
+      return handleRenameNode(projectPath, args)
+    case 'list':
+      return handleListNodes(projectPath, args)
+    case 'set_property':
+      return handleSetNodeProperty(projectPath, args)
+    case 'get_property':
+      return handleGetNodeProperty(projectPath, args)
     default:
       throwUnknownAction(action, ['add', 'remove', 'rename', 'list', 'set_property', 'get_property'])
   }


### PR DESCRIPTION
The `handleNodes` function in `src/tools/composite/nodes.ts` was over 200 lines long, making it difficult to maintain and test. This PR refactors it by extracting the logic for each action into separate, specialized handler functions:

- `handleAddNode`: Handles node addition and property initialization.
- `handleRemoveNode`: Handles node removal.
- `handleRenameNode`: Handles node renaming.
- `handleListNodes`: Lists nodes in a scene (optimized single-pass iteration).
- `handleSetNodeProperty`: Sets a property on a node.
- `handleGetNodeProperty`: Retrieves a property value from a node.

The `handleNodes` function now acts as a clean dispatcher. All existing security validations (preventing injection in names/types/properties) and performance optimizations (Bolt optimization in `list`) have been preserved.

Verified with the following test suites:
- `tests/composite/nodes.test.ts`
- `tests/composite/nodes-security.test.ts`
- `tests/composite/cov-shader-nodes-physics.test.ts`

---
*PR created automatically by Jules for task [17420992300604116948](https://jules.google.com/task/17420992300604116948) started by @n24q02m*