### PR TITLE
[SECURITY] Argument Injection in Godot Export CLI Execution

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -39,17 +39,17 @@ export async function handleConfig(action: string, args: Record<string, unknown>
         throw new GodotMCPError(`Invalid config key: ${key}`, 'INVALID_ARGS', `Valid keys: ${validKeys.join(', ')}`)
       }
 
-      // Validate paths don't contain shell metacharacters
+      // Validate paths don't contain shell metacharacters and don't start with hyphen
       // Note: backslash (\) is allowed since it's the Windows path separator
       // and we use spawnSync/spawn (not shell exec), so it's not a security risk
       if (
         (key === 'project_path' || key === 'godot_path') &&
-        (typeof value !== 'string' || /[;&|`$(){}<>'"\0\n\r]/.test(value))
+        (typeof value !== 'string' || /[;&|`$(){}<>'"\0\n\r]/.test(value) || value.startsWith('-'))
       ) {
         throw new GodotMCPError(
-          `Invalid characters in ${key}`,
+          `Invalid characters or format in ${key}`,
           'INVALID_ARGS',
-          'Path must not contain shell metacharacters: ; & | ` $ ( ) { } < > \' " \\0 \\n \\r',
+          'Path must not contain shell metacharacters and must not start with a hyphen.',
         )
       }
 

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -75,6 +75,9 @@ export async function handleProject(action: string, args: Record<string, unknown
           'Provide project_path argument or set it via config.set action.',
         )
       }
+      if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
+        throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
+      }
       const info = await parseProjectGodot(safeResolve(config.projectPath || process.cwd(), projectPath))
       return formatJSON(info)
     }
@@ -93,6 +96,9 @@ export async function handleProject(action: string, args: Record<string, unknown
       const projectPath = (args.project_path as string) || config.projectPath
       if (!projectPath)
         throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
+      if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
+        throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
+      }
       const { pid } = runGodotProject(config.godotPath, safeResolve(config.projectPath || process.cwd(), projectPath))
       if (pid) {
         config.activePids.push(pid)
@@ -133,6 +139,9 @@ export async function handleProject(action: string, args: Record<string, unknown
     case 'settings_get': {
       const projectPath = (args.project_path as string) || config.projectPath
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
+      if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
+        throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
+      }
       const key = args.key as string
       if (!key)
         throw new GodotMCPError('No key specified', 'INVALID_ARGS', 'Provide key (e.g., "application/config/name").')
@@ -152,6 +161,9 @@ export async function handleProject(action: string, args: Record<string, unknown
     case 'settings_set': {
       const projectPath = (args.project_path as string) || config.projectPath
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
+      if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
+        throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
+      }
       const key = args.key as string
       const value = args.value as string
       if (!key || value === undefined)
@@ -181,6 +193,9 @@ export async function handleProject(action: string, args: Record<string, unknown
         throw new GodotMCPError('Godot not found', 'GODOT_NOT_FOUND', 'Set GODOT_PATH env var or install Godot.')
       const projectPath = (args.project_path as string) || config.projectPath
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
+      if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
+        throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
+      }
       const preset = args.preset as string
       const outputPath = args.output_path as string
       if (!preset || !outputPath) {
@@ -189,6 +204,10 @@ export async function handleProject(action: string, args: Record<string, unknown
           'INVALID_ARGS',
           'Provide preset name and output path.',
         )
+      }
+
+      if (typeof preset !== 'string' || typeof outputPath !== 'string') {
+        throw new GodotMCPError('Invalid arguments', 'INVALID_ARGS', 'Preset and output path must be strings.')
       }
 
       if (preset.startsWith('-') || outputPath.startsWith('-')) {

--- a/tests/composite/config.test.ts
+++ b/tests/composite/config.test.ts
@@ -209,6 +209,15 @@ describe('config', () => {
       ).rejects.toThrow('Invalid characters')
     })
 
+    it('should reject paths starting with a hyphen', async () => {
+      await expect(handleConfig('set', { key: 'godot_path', value: '--some-flag' }, config)).rejects.toThrow(
+        'Invalid characters or format',
+      )
+      await expect(handleConfig('set', { key: 'project_path', value: '-evil' }, config)).rejects.toThrow(
+        'Invalid characters or format',
+      )
+    })
+
     it('should reject paths that are not strings', async () => {
       await expect(
         handleConfig('set', { key: 'godot_path', value: ['node', '-e', 'pwned'] as unknown as string }, config),

--- a/tests/composite/project-security.test.ts
+++ b/tests/composite/project-security.test.ts
@@ -39,7 +39,7 @@ describe('project security', () => {
     vi.restoreAllMocks()
   })
 
-  describe('export argument injection prevention', () => {
+  describe('argument injection prevention', () => {
     it('should reject preset starting with a hyphen', async () => {
       await expect(
         handleProject(
@@ -72,6 +72,22 @@ describe('project security', () => {
       expect(execGodotAsync).not.toHaveBeenCalled()
     })
 
+    it('should reject project_path starting with a hyphen', async () => {
+      await expect(
+        handleProject(
+          'export',
+          {
+            project_path: '--some-arg',
+            preset: 'Windows Desktop',
+            output_path: 'build/game.exe',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid project path')
+
+      expect(execGodotAsync).not.toHaveBeenCalled()
+    })
+
     it('should allow valid preset and output_path', async () => {
       const result = await handleProject(
         'export',
@@ -85,6 +101,32 @@ describe('project security', () => {
 
       expect(result.content[0].text).toContain('Export complete: build/game.exe')
       expect(execGodotAsync).toHaveBeenCalled()
+    })
+
+    it('should reject preset or output_path that are not strings', async () => {
+      await expect(
+        handleProject(
+          'export',
+          {
+            project_path: projectPath,
+            preset: 123,
+            output_path: 'build/game.exe',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid arguments')
+
+      await expect(
+        handleProject(
+          'export',
+          {
+            project_path: projectPath,
+            preset: 'Windows Desktop',
+            output_path: true,
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid arguments')
     })
   })
 })


### PR DESCRIPTION
This PR fixes a potential argument injection vulnerability in the Godot export CLI execution. Although the arguments were passed in an array, unvalidated strings starting with '--' could allow unintended flags to be passed to Godot. 

The fix introduces strict validation to reject any user-provided path or preset starting with a hyphen ('-') across the project and config tools. It also adds robust type validation for these parameters. 

New security tests have been added to verify the fix and prevent regressions in `tests/composite/project-security.test.ts` and `tests/composite/config.test.ts`.

---
*PR created automatically by Jules for task [13883913561598034919](https://jules.google.com/task/13883913561598034919) started by @n24q02m*