### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Scene Injection in UI and Audio tools

### DIFF
--- a/src/tools/composite/audio.ts
+++ b/src/tools/composite/audio.ts
@@ -41,6 +41,17 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       if (!busName) throw new GodotMCPError('No bus_name specified', 'INVALID_ARGS', 'Provide bus name.')
       const sendTo = (args.send_to as string) || 'Master'
 
+      if (
+        busName.includes('"') || busName.includes('\n') || busName.includes('\r') ||
+        sendTo.includes('"') || sendTo.includes('\n') || sendTo.includes('\r')
+      ) {
+        throw new GodotMCPError(
+          'Invalid characters in parameters',
+          'INVALID_ARGS',
+          'Parameters must not contain quotes or newlines.',
+        )
+      }
+
       const busLayoutPath = join(safeResolve(baseDir, projectPath), 'default_bus_layout.tres')
       let content: string
 
@@ -87,6 +98,17 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
           'bus_name and effect_type required',
           'INVALID_ARGS',
           'Provide bus name and effect type (e.g., "Reverb", "Compressor", "Limiter", "EQ").',
+        )
+      }
+
+      if (
+        busName.includes('"') || busName.includes('\n') || busName.includes('\r') ||
+        effectType.includes('"') || effectType.includes('\n') || effectType.includes('\r')
+      ) {
+        throw new GodotMCPError(
+          'Invalid characters in parameters',
+          'INVALID_ARGS',
+          'Parameters must not contain quotes or newlines.',
         )
       }
 
@@ -157,6 +179,19 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       const streamType = (args.stream_type as string) || '2D'
       const parent = (args.parent as string) || '.'
       const bus = (args.bus as string) || 'Master'
+
+      if (
+        nodeName.includes('"') || nodeName.includes('\n') || nodeName.includes('\r') ||
+        streamType.includes('"') || streamType.includes('\n') || streamType.includes('\r') ||
+        parent.includes('"') || parent.includes('\n') || parent.includes('\r') ||
+        bus.includes('"') || bus.includes('\n') || bus.includes('\r')
+      ) {
+        throw new GodotMCPError(
+          'Invalid characters in parameters',
+          'INVALID_ARGS',
+          'Parameters must not contain quotes or newlines.',
+        )
+      }
 
       const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
       if (!(await pathExists(fullPath)))

--- a/src/tools/composite/audio.ts
+++ b/src/tools/composite/audio.ts
@@ -42,8 +42,12 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       const sendTo = (args.send_to as string) || 'Master'
 
       if (
-        busName.includes('"') || busName.includes('\n') || busName.includes('\r') ||
-        sendTo.includes('"') || sendTo.includes('\n') || sendTo.includes('\r')
+        busName.includes('"') ||
+        busName.includes('\n') ||
+        busName.includes('\r') ||
+        sendTo.includes('"') ||
+        sendTo.includes('\n') ||
+        sendTo.includes('\r')
       ) {
         throw new GodotMCPError(
           'Invalid characters in parameters',
@@ -102,8 +106,12 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       }
 
       if (
-        busName.includes('"') || busName.includes('\n') || busName.includes('\r') ||
-        effectType.includes('"') || effectType.includes('\n') || effectType.includes('\r')
+        busName.includes('"') ||
+        busName.includes('\n') ||
+        busName.includes('\r') ||
+        effectType.includes('"') ||
+        effectType.includes('\n') ||
+        effectType.includes('\r')
       ) {
         throw new GodotMCPError(
           'Invalid characters in parameters',
@@ -181,10 +189,18 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       const bus = (args.bus as string) || 'Master'
 
       if (
-        nodeName.includes('"') || nodeName.includes('\n') || nodeName.includes('\r') ||
-        streamType.includes('"') || streamType.includes('\n') || streamType.includes('\r') ||
-        parent.includes('"') || parent.includes('\n') || parent.includes('\r') ||
-        bus.includes('"') || bus.includes('\n') || bus.includes('\r')
+        nodeName.includes('"') ||
+        nodeName.includes('\n') ||
+        nodeName.includes('\r') ||
+        streamType.includes('"') ||
+        streamType.includes('\n') ||
+        streamType.includes('\r') ||
+        parent.includes('"') ||
+        parent.includes('\n') ||
+        parent.includes('\r') ||
+        bus.includes('"') ||
+        bus.includes('\n') ||
+        bus.includes('\r')
       ) {
         throw new GodotMCPError(
           'Invalid characters in parameters',

--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -83,9 +83,15 @@ async function handleCreateControl(projectPath: string | null | undefined, args:
   if (!controlName) throw new GodotMCPError('No name specified', 'INVALID_ARGS', 'Provide control node name.')
 
   if (
-    controlName.includes('"') || controlName.includes('\n') || controlName.includes('\r') ||
-    controlType.includes('"') || controlType.includes('\n') || controlType.includes('\r') ||
-    parent.includes('"') || parent.includes('\n') || parent.includes('\r')
+    controlName.includes('"') ||
+    controlName.includes('\n') ||
+    controlName.includes('\r') ||
+    controlType.includes('"') ||
+    controlType.includes('\n') ||
+    controlType.includes('\r') ||
+    parent.includes('"') ||
+    parent.includes('\n') ||
+    parent.includes('\r')
   ) {
     throw new GodotMCPError(
       'Invalid characters in parameters',
@@ -149,8 +155,12 @@ async function handleLayout(projectPath: string | null | undefined, args: Record
   const preset = (args.preset as string) || 'full_rect'
 
   if (
-    nodeName.includes('"') || nodeName.includes('\n') || nodeName.includes('\r') ||
-    preset.includes('"') || preset.includes('\n') || preset.includes('\r')
+    nodeName.includes('"') ||
+    nodeName.includes('\n') ||
+    nodeName.includes('\r') ||
+    preset.includes('"') ||
+    preset.includes('\n') ||
+    preset.includes('\r')
   ) {
     throw new GodotMCPError(
       'Invalid characters in parameters',

--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -82,6 +82,18 @@ async function handleCreateControl(projectPath: string | null | undefined, args:
 
   if (!controlName) throw new GodotMCPError('No name specified', 'INVALID_ARGS', 'Provide control node name.')
 
+  if (
+    controlName.includes('"') || controlName.includes('\n') || controlName.includes('\r') ||
+    controlType.includes('"') || controlType.includes('\n') || controlType.includes('\r') ||
+    parent.includes('"') || parent.includes('\n') || parent.includes('\r')
+  ) {
+    throw new GodotMCPError(
+      'Invalid characters in parameters',
+      'INVALID_ARGS',
+      'Parameters must not contain quotes or newlines.',
+    )
+  }
+
   const fullPath = await resolveScene(projectPath, scenePath)
   let content = await readFile(fullPath, 'utf-8')
 
@@ -135,6 +147,17 @@ async function handleLayout(projectPath: string | null | undefined, args: Record
   const nodeName = args.name as string
   if (!nodeName) throw new GodotMCPError('No name specified', 'INVALID_ARGS', 'Provide node name.')
   const preset = (args.preset as string) || 'full_rect'
+
+  if (
+    nodeName.includes('"') || nodeName.includes('\n') || nodeName.includes('\r') ||
+    preset.includes('"') || preset.includes('\n') || preset.includes('\r')
+  ) {
+    throw new GodotMCPError(
+      'Invalid characters in parameters',
+      'INVALID_ARGS',
+      'Parameters must not contain quotes or newlines.',
+    )
+  }
 
   const fullPath = await resolveScene(projectPath, scenePath)
   let content = await readFile(fullPath, 'utf-8')

--- a/tests/composite/ui-security.test.ts
+++ b/tests/composite/ui-security.test.ts
@@ -1,0 +1,138 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleUI } from '../../src/tools/composite/ui.js'
+import { handleAudio } from '../../src/tools/composite/audio.js'
+import { createTmpProject, createTmpScene, makeConfig } from '../fixtures.js'
+
+describe('Security: Scene Injection Prevention in UI and Audio tools', () => {
+  let projectPath: string
+  let cleanup: () => void
+  let config: GodotConfig
+
+  beforeEach(() => {
+    const tmp = createTmpProject()
+    projectPath = tmp.projectPath
+    cleanup = tmp.cleanup
+    config = makeConfig({ projectPath })
+  })
+
+  afterEach(() => cleanup())
+
+  describe('UI tool', () => {
+    it('should prevent injection via node name in create_control', async () => {
+      createTmpScene(projectPath, 'main.tscn')
+
+      await expect(
+        handleUI(
+          'create_control',
+          {
+            project_path: projectPath,
+            scene_path: 'main.tscn',
+            name: 'Button"\n[node name="Malicious" type="Node"]\n"',
+            type: 'Button',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid characters in parameters')
+    })
+
+    it('should prevent injection via type in create_control', async () => {
+      createTmpScene(projectPath, 'main.tscn')
+
+      await expect(
+        handleUI(
+          'create_control',
+          {
+            project_path: projectPath,
+            scene_path: 'main.tscn',
+            name: 'Button',
+            type: 'Button"\n[node name="Malicious" type="Node"]\n"',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid characters in parameters')
+    })
+
+    it('should prevent injection via parent in create_control', async () => {
+      createTmpScene(projectPath, 'main.tscn')
+
+      await expect(
+        handleUI(
+          'create_control',
+          {
+            project_path: projectPath,
+            scene_path: 'main.tscn',
+            name: 'Button',
+            type: 'Button',
+            parent: '."\n[node name="Malicious" type="Node"]\n"',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid characters in parameters')
+    })
+
+    it('should prevent injection via node name in layout', async () => {
+      createTmpScene(projectPath, 'main.tscn', '[node name="Button" type="Button"]')
+
+      await expect(
+        handleUI(
+          'layout',
+          {
+            project_path: projectPath,
+            scene_path: 'main.tscn',
+            name: 'Button"\n[node name="Malicious" type="Node"]\n"',
+            preset: 'full_rect',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid characters in parameters')
+    })
+  })
+
+  describe('Audio tool', () => {
+    it('should prevent injection via node name in create_stream', async () => {
+      createTmpScene(projectPath, 'main.tscn')
+
+      await expect(
+        handleAudio(
+          'create_stream',
+          {
+            project_path: projectPath,
+            scene_path: 'main.tscn',
+            name: 'AudioStreamPlayer"\n[node name="Malicious" type="Node"]\n"',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid characters in parameters')
+    })
+
+    it('should prevent injection via bus name in add_bus', async () => {
+      await expect(
+        handleAudio(
+          'add_bus',
+          {
+            project_path: projectPath,
+            bus_name: 'Master"\n[node name="Malicious" type="Node"]\n"',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid characters in parameters')
+    })
+
+    it('should prevent injection via effect type in add_effect', async () => {
+      await expect(
+        handleAudio(
+          'add_effect',
+          {
+            project_path: projectPath,
+            bus_name: 'Master',
+            effect_type: 'Reverb"\n[node name="Malicious" type="Node"]\n"',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid characters in parameters')
+    })
+  })
+})

--- a/tests/composite/ui-security.test.ts
+++ b/tests/composite/ui-security.test.ts
@@ -1,9 +1,7 @@
-import { existsSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { GodotConfig } from '../../src/godot/types.js'
-import { handleUI } from '../../src/tools/composite/ui.js'
 import { handleAudio } from '../../src/tools/composite/audio.js'
+import { handleUI } from '../../src/tools/composite/ui.js'
 import { createTmpProject, createTmpScene, makeConfig } from '../fixtures.js'
 
 describe('Security: Scene Injection Prevention in UI and Audio tools', () => {


### PR DESCRIPTION
* 🚨 Severity: CRITICAL
* 💡 Vulnerability: The `ui` and `audio` tools accepted unvalidated string parameters (`name`, `type`, `parent`, `bus_name`, `effect_type`, `stream_type`) and injected them directly into `.tscn` and `.tres` file templates. Because Godot scene files are text-based, an attacker could supply strings containing newlines and double quotes to break out of the node declaration and inject arbitrary nodes, properties, or scripts.
* 🎯 Impact: Arbitrary code execution or project corruption by allowing malicious entities to inject arbitrary nodes or scripts into the project.
* 🔧 Fix: Added strict validation checks in `handleCreateControl`, `handleLayout`, `handleAudio(add_bus)`, `handleAudio(add_effect)`, and `handleAudio(create_stream)` to reject any parameters containing newlines, carriage returns, or double quotes.
* ✅ Verification: Ran vitest suite including new specific security tests in `tests/composite/ui-security.test.ts`. All tests passed.

---
*PR created automatically by Jules for task [17663392527766650734](https://jules.google.com/task/17663392527766650734) started by @n24q02m*