### PR TITLE
🛡️ Sentinel: [High] Fix Scene Injection in scene creation

### DIFF
--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -174,6 +174,14 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       const rootType = (args.root_type as string) || 'Node2D'
       const rootName = (args.root_name as string) || basename(scenePath, '.tscn')
 
+      if (rootName.includes('"') || rootName.includes('\n') || rootName.includes('\r')) {
+        throw new GodotMCPError('Invalid root name', 'INVALID_ARGS', 'Root name must not contain quotes or newlines.')
+      }
+
+      if (rootType.includes('"') || rootType.includes('\n') || rootType.includes('\r')) {
+        throw new GodotMCPError('Invalid root type', 'INVALID_ARGS', 'Root type must not contain quotes or newlines.')
+      }
+
       const fullPath = safeResolve(projectPath as string, scenePath)
       if (await pathExists(fullPath)) {
         throw new GodotMCPError(

--- a/tests/composite/scenes-security.test.ts
+++ b/tests/composite/scenes-security.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { GodotConfig } from '../../src/godot/types.js'

--- a/tests/composite/scenes-security.test.ts
+++ b/tests/composite/scenes-security.test.ts
@@ -1,0 +1,83 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleScenes } from '../../src/tools/composite/scenes.js'
+
+describe('Scenes Tool Security', () => {
+  const projectPath = join(process.cwd(), 'tmp_security_scenes_test')
+  const config: GodotConfig = { projectPath }
+
+  beforeEach(() => {
+    mkdirSync(projectPath, { recursive: true })
+    writeFileSync(join(projectPath, 'project.godot'), '[config]')
+  })
+
+  afterEach(() => {
+    rmSync(projectPath, { recursive: true, force: true })
+  })
+
+  it('should prevent injection in root_name (create)', async () => {
+    const maliciousName = 'Root" type="Injected" parent=".'
+
+    await expect(
+      handleScenes(
+        'create',
+        {
+          scene_path: 'new_scene.tscn',
+          root_name: maliciousName,
+          root_type: 'Node',
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid root name')
+  })
+
+  it('should prevent injection in root_type (create)', async () => {
+    const maliciousType = 'Node" parent="." injected="true'
+
+    await expect(
+      handleScenes(
+        'create',
+        {
+          scene_path: 'new_scene.tscn',
+          root_name: 'NewNode',
+          root_type: maliciousType,
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid root type')
+  })
+
+  it('should prevent newline injection in root_name (create)', async () => {
+    const maliciousName = 'Root\n[node name="Injected" type="Node"]'
+
+    await expect(
+      handleScenes(
+        'create',
+        {
+          scene_path: 'new_scene.tscn',
+          root_name: maliciousName,
+          root_type: 'Node',
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid root name')
+  })
+
+  it('should prevent newline injection in root_type (create)', async () => {
+    const maliciousType = 'Node\n[node name="Injected" type="Node"]'
+
+    await expect(
+      handleScenes(
+        'create',
+        {
+          scene_path: 'new_scene.tscn',
+          root_name: 'NewNode',
+          root_type: maliciousType,
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid root type')
+  })
+})


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Scene File Injection in `src/tools/composite/scenes.ts`. The `create` action allowed user inputs (`root_name` and `root_type`) containing quotes (`"`) or newlines (`\n`, `\r`) to be directly interpolated into generated Godot `.tscn` files. 
🎯 Impact: Attackers could break out of standard string properties and inject arbitrary nodes, properties, or scripts into the scene file, potentially leading to arbitrary code execution within the Godot Engine context.
🔧 Fix: Implemented validation in `handleScenes` to actively reject inputs containing quotes or newlines.
✅ Verification: Added comprehensive security test suite in `tests/composite/scenes-security.test.ts` to ensure rejection of malformed inputs. Tests pass successfully.

---
*PR created automatically by Jules for task [911491597437026024](https://jules.google.com/task/911491597437026024) started by @n24q02m*