### PR TITLE
fix: pass MCP_TRANSPORT=stdio in plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,7 +10,8 @@
   "mcpServers": {
     "better-godot-mcp": {
       "command": "npx",
-      "args": ["-y", "@n24q02m/better-godot-mcp"]
+      "args": ["-y", "@n24q02m/better-godot-mcp"],
+      "env": {"MCP_TRANSPORT": "stdio"}
     }
   }
 }


### PR DESCRIPTION
## Summary

- Plugin manifest now passes `MCP_TRANSPORT=stdio` env var so Claude Code spawns the MCP in stdio mode (default is HTTP).
- Without this flag, the server runs HTTP-only and never speaks JSON-RPC stdio to Claude Code -> "Failed to connect" + orphan HTTP daemons -> OOM.

## Test plan

- [ ] CI green
- [ ] After release: Claude Code `/mcp` shows server connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)