### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Scene Injection in Animation and Navigation tools

### DIFF
--- a/src/tools/composite/animation.ts
+++ b/src/tools/composite/animation.ts
@@ -25,6 +25,17 @@ export async function handleAnimation(action: string, args: Record<string, unkno
       const playerName = (args.name as string) || 'AnimationPlayer'
       const parent = (args.parent as string) || '.'
 
+      if (
+        playerName.includes('\n') ||
+        playerName.includes('\r') ||
+        playerName.includes('"') ||
+        parent.includes('\n') ||
+        parent.includes('\r') ||
+        parent.includes('"')
+      ) {
+        throw new GodotMCPError('Invalid arguments: newlines and quotes not allowed', 'INVALID_ARGS')
+      }
+
       const fullPath = await resolveScene(projectPath, scenePath)
       let content = await readFile(fullPath, 'utf-8')
 
@@ -43,6 +54,10 @@ export async function handleAnimation(action: string, args: Record<string, unkno
       if (!animName) throw new GodotMCPError('No anim_name specified', 'INVALID_ARGS', 'Provide animation name.')
       const duration = (args.duration as number) || 1.0
       const loop = args.loop !== false
+
+      if (animName.includes('\n') || animName.includes('\r') || animName.includes('"')) {
+        throw new GodotMCPError('Invalid anim_name: newlines and quotes not allowed', 'INVALID_ARGS')
+      }
 
       const fullPath = await resolveScene(projectPath, scenePath)
       let content = await readFile(fullPath, 'utf-8')
@@ -77,6 +92,23 @@ export async function handleAnimation(action: string, args: Record<string, unkno
           'INVALID_ARGS',
           'All three are required.',
         )
+      }
+
+      if (
+        animName.includes('\n') ||
+        animName.includes('\r') ||
+        animName.includes('"') ||
+        trackType.includes('\n') ||
+        trackType.includes('\r') ||
+        trackType.includes('"') ||
+        nodePath.includes('\n') ||
+        nodePath.includes('\r') ||
+        nodePath.includes('"') ||
+        property.includes('\n') ||
+        property.includes('\r') ||
+        property.includes('"')
+      ) {
+        throw new GodotMCPError('Invalid arguments: newlines and quotes not allowed', 'INVALID_ARGS')
       }
 
       const fullPath = await resolveScene(projectPath, scenePath)

--- a/src/tools/composite/navigation.ts
+++ b/src/tools/composite/navigation.ts
@@ -16,6 +16,20 @@ async function resolveScene(projectPath: string | null | undefined, scenePath: s
 }
 
 function appendNode(content: string, name: string, type: string, parent: string, extraProps?: string): string {
+  if (
+    name.includes('\n') ||
+    name.includes('\r') ||
+    name.includes('"') ||
+    type.includes('\n') ||
+    type.includes('\r') ||
+    type.includes('"') ||
+    parent.includes('\n') ||
+    parent.includes('\r') ||
+    parent.includes('"')
+  ) {
+    throw new GodotMCPError('Invalid arguments: newlines and quotes not allowed', 'INVALID_ARGS')
+  }
+
   const parentAttr = parent === '.' ? '' : ` parent="${parent}"`
   let nodeDecl = `\n[node name="${name}" type="${type}"${parentAttr}]\n`
   if (extraProps) nodeDecl += `${extraProps}\n`

--- a/tests/security/scene-injection.test.ts
+++ b/tests/security/scene-injection.test.ts
@@ -1,0 +1,106 @@
+import * as fs from 'node:fs/promises'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { handleAnimation } from '../../src/tools/composite/animation.js'
+import { handleNavigation } from '../../src/tools/composite/navigation.js'
+import { GodotMCPError } from '../../src/tools/helpers/errors.js'
+import * as paths from '../../src/tools/helpers/paths.js'
+
+// Mock dependencies
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}))
+
+vi.mock('../../src/tools/helpers/paths.js', () => ({
+  pathExists: vi.fn(),
+  safeResolve: vi.fn((_base, target) => `/mock/path/${target}`),
+}))
+
+describe('Scene Injection Prevention', () => {
+  const mockConfig = { projectPath: '/mock/project' }
+  const mockScenePath = 'test.tscn'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(paths.pathExists).mockResolvedValue(true)
+    vi.mocked(fs.readFile).mockResolvedValue('[node name="Root" type="Node"]\n')
+  })
+
+  describe('animation.ts', () => {
+    it('should reject newlines and quotes in create_player parameters', async () => {
+      const maliciousName = 'Anim"\n[node name="Injected" type="Node"]'
+      const maliciousParent = 'Parent"\n[node name="Injected2" type="Node"]'
+
+      // Test name
+      await expect(
+        handleAnimation('create_player', { scene_path: mockScenePath, name: maliciousName }, mockConfig),
+      ).rejects.toThrow(GodotMCPError)
+
+      // Test parent
+      await expect(
+        handleAnimation('create_player', { scene_path: mockScenePath, parent: maliciousParent }, mockConfig),
+      ).rejects.toThrow(GodotMCPError)
+    })
+
+    it('should reject newlines and quotes in add_animation parameters', async () => {
+      const maliciousAnimName = 'Walk"\n[sub_resource type="Script"]'
+
+      await expect(
+        handleAnimation('add_animation', { scene_path: mockScenePath, anim_name: maliciousAnimName }, mockConfig),
+      ).rejects.toThrow(GodotMCPError)
+    })
+
+    it('should reject newlines and quotes in add_track parameters', async () => {
+      const maliciousTrackType = 'value"\n[node name="Injected"]'
+
+      // Need a valid anim_name that exists to get past initial checks,
+      // but the validation happens first so we just pass all malicious args
+      await expect(
+        handleAnimation(
+          'add_track',
+          {
+            scene_path: mockScenePath,
+            anim_name: 'ValidAnim',
+            track_type: maliciousTrackType,
+            node_path: 'Sprite2D',
+            property: 'position',
+          },
+          mockConfig,
+        ),
+      ).rejects.toThrow(GodotMCPError)
+    })
+  })
+
+  describe('navigation.ts', () => {
+    it('should reject newlines and quotes in create_region parameters', async () => {
+      const maliciousName = 'Region"\n[node name="Injected" type="Node"]'
+      const maliciousParent = 'Parent"\n[node name="Injected2" type="Node"]'
+
+      // Test name
+      await expect(
+        handleNavigation('create_region', { scene_path: mockScenePath, name: maliciousName }, mockConfig),
+      ).rejects.toThrow(GodotMCPError)
+
+      // Test parent
+      await expect(
+        handleNavigation('create_region', { scene_path: mockScenePath, parent: maliciousParent }, mockConfig),
+      ).rejects.toThrow(GodotMCPError)
+    })
+
+    it('should reject newlines and quotes in add_agent parameters', async () => {
+      const maliciousName = 'Agent"\n[node name="Injected" type="Node"]'
+
+      await expect(
+        handleNavigation('add_agent', { scene_path: mockScenePath, name: maliciousName }, mockConfig),
+      ).rejects.toThrow(GodotMCPError)
+    })
+
+    it('should reject newlines and quotes in add_obstacle parameters', async () => {
+      const maliciousName = 'Obstacle"\n[node name="Injected" type="Node"]'
+
+      await expect(
+        handleNavigation('add_obstacle', { scene_path: mockScenePath, name: maliciousName }, mockConfig),
+      ).rejects.toThrow(GodotMCPError)
+    })
+  })
+})


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The `animation` and `navigation` composite tools accepted user-supplied strings and interpolated them directly into `.tscn` templates without sanitization. This allowed attackers to break out of structural node/resource declarations using newline and quote characters, achieving arbitrary Scene File Injection.
🎯 **Impact**: Malicious payloads could theoretically inject arbitrary nodes, add external scripts, modify physics shapes, or completely corrupt the Godot scene files.
🔧 **Fix**: Added defensive input validation across critical string parameters (`playerName`, `animName`, `nodePath`, etc.) in `src/tools/composite/animation.ts` and the `appendNode` helper in `src/tools/composite/navigation.ts`. Any string containing `\n`, `\r`, or `"` is now actively rejected with an explicit `INVALID_ARGS` MCP error.
✅ **Verification**: Created `tests/security/scene-injection.test.ts` to strictly verify these injection payloads are successfully blocked. Ran full suite via `bun run test` and `bun run check`. All 772 tests pass.

---
*PR created automatically by Jules for task [9104267107773510010](https://jules.google.com/task/9104267107773510010) started by @n24q02m*