### PR TITLE
⚡ Bolt: Optimize input-map array mapping

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -249,10 +249,16 @@ export async function handleInputMap(action: string, args: Record<string, unknow
       const content = await readFile(configPath, 'utf-8')
       const actions = parseInputActions(content)
 
-      const actionList = Array.from(actions.entries()).map(([name, events]) => ({
-        name,
-        eventCount: events.length,
-      }))
+      // ⚡ Bolt: Use a pre-allocated array and for...of loop instead of Array.from().map()
+      // to avoid intermediate array allocation and reduce garbage collection overhead.
+      const actionList = new Array(actions.size)
+      let idx = 0
+      for (const [name, events] of actions) {
+        actionList[idx++] = {
+          name,
+          eventCount: events.length,
+        }
+      }
 
       return formatJSON({ count: actionList.length, actions: actionList })
     }


### PR DESCRIPTION
💡 What: Replaced the `Array.from(actions.entries()).map(...)` pattern in `handleInputMap` (action: 'list') with a pre-allocated array (`new Array(actions.size)`) and a `for...of` loop.
🎯 Why: In performance-critical paths (or to avoid garbage collection overhead in standard operations), creating an intermediate array from an iterable just to map over it causes unnecessary memory allocations.
📊 Impact: Reduces array allocations and completely avoids the intermediate array creation, thereby marginally reducing garbage collection pressure.
🔬 Measurement: Verify by running `bun run test tests/composite/input-map.test.ts`. All behavior should be identical while avoiding `Array.from`.

---
*PR created automatically by Jules for task [15396542819578746622](https://jules.google.com/task/15396542819578746622) started by @n24q02m*