### PR TITLE
[TEST] Missing Error Path Test for stop process

### DIFF
--- a/tests/composite/project.test.ts
+++ b/tests/composite/project.test.ts
@@ -139,6 +139,32 @@ describe('project', () => {
       const result = await handleProject('stop', {}, config)
       expect(result.content[0].text).toContain('No running Godot processes found (tracked by this server)')
     })
+
+    it('should continue if process is already dead on win32', async () => {
+      const originalPlatform = process.platform
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+
+      config.activePids = [1234, 5678]
+
+      const processKillSpy = vi.spyOn(process, 'kill').mockImplementation((pid, signal) => {
+        if (pid === 1234 && (signal === 0 || signal === '0')) {
+          throw new Error('Process already dead')
+        }
+        return true
+      })
+
+      const result = await handleProject('stop', {}, config)
+      expect(result.content[0].text).toContain('Stopped 1 tracked processes')
+
+      // Should NOT call taskkill for 1234, but SHOULD for 5678
+      expect(execFileSync).not.toHaveBeenCalledWith('taskkill', expect.arrayContaining(['1234']), expect.anything())
+      expect(execFileSync).toHaveBeenCalledWith('taskkill', expect.arrayContaining(['5678']), expect.anything())
+
+      expect(config.activePids).toHaveLength(0)
+
+      processKillSpy.mockRestore()
+      Object.defineProperty(process, 'platform', { value: originalPlatform })
+    })
   })
 
   // ==========================================


### PR DESCRIPTION
This PR adds a missing test case for the error path in `src/tools/composite/project.ts`'s `stop` action. Specifically, it tests the scenario on Windows where `process.kill(pid, 0)` throws an error because the process is already dead. The test ensures that the server correctly catches this error and continues to stop other tracked processes.

Key changes:
- Added `should continue if process is already dead on win32` test case to `tests/composite/project.test.ts`.
- Mocked `process.platform` and `process.kill` to simulate the dead process scenario.
- Verified that `taskkill` is not called for the dead PID but is called for subsequent active PIDs.

---
*PR created automatically by Jules for task [6411525132639994470](https://jules.google.com/task/6411525132639994470) started by @n24q02m*