### PR TITLE
[FIX] Remove XXX Marker in scene-parser.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -3,8 +3,8 @@
  *
  * .tscn format structure:
  * [gd_scene load_steps=N format=3 uid="uid://..."]
- * [ext_resource type="..." uid="uid://..." path="res://..." id="N_xxxxx"]
- * [sub_resource type="..." id="N_xxxxx"]
+ * [ext_resource type="..." uid="uid://..." path="res://..." id="1_abc"]
+ * [sub_resource type="..." id="1_abc"]
  * key = value
  * [node name="..." type="..." parent="."]
  * key = value


### PR DESCRIPTION
Replaced the placeholder N_xxxxx in the documentation comments of src/tools/helpers/scene-parser.ts with a more representative Godot identifier 1_abc. Also updated biome.json to match the CLI version for linting consistency.

---
*PR created automatically by Jules for task [9824490358954826354](https://jules.google.com/task/9824490358954826354) started by @n24q02m*