### PR TITLE
[FIX] Remove XXX Marker from input-map.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -13,7 +13,7 @@ import { escapeRegExp } from '../helpers/scene-parser.js'
 
 /**
  * Godot 4.x Key enum numeric values (@GlobalScope.Key)
- * Letters are ASCII codes, special keys use 4194xxx range
+ * Letters are ASCII codes, special keys use the 4194304+ range (2^22 bit set)
  */
 const GODOT_KEY_CODES: Record<string, number> = {
   // Letters (ASCII)


### PR DESCRIPTION
This PR removes an "XXX" marker from a comment in `src/tools/composite/input-map.ts`. This marker was being flagged by static analysis tools. The comment has been updated to be more descriptive about the Godot special key range (4194304+, which corresponds to the 2^22 bit).

Additionally, `biome.json` was migrated to version 2.4.14 to match the environment.

---
*PR created automatically by Jules for task [3014539156134814758](https://jules.google.com/task/3014539156134814758) started by @n24q02m*