### PR TITLE
[FIX] Known Bug

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/scripts/enforce-commit.sh
+++ b/scripts/enforce-commit.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 MSG=$(head -1 "$1")
-if [[ "$MSG" =~ ^(feat|fix)(\(.+\))?:.+ ]] || [[ "$MSG" =~ ^chore\(release\):.+ ]]; then
+if [[ "$MSG" =~ ^(feat|fix|docs|style|refactor|perf|test|chore|ci|build)(\(.+\))?:.+ ]]; then
   exit 0
 fi
-echo "ERROR: Commit blocked. Only 'feat:' and 'fix:' prefixes allowed."
+echo "ERROR: Commit blocked. Only Conventional Commit prefixes (feat, fix, docs, etc.) are allowed."
 echo "Got: $MSG"
 exit 1


### PR DESCRIPTION
The commit enforcement script `scripts/enforce-commit.sh` was overly restrictive, only allowing `feat` and `fix` types despite `CONTRIBUTING.md` listing ten valid types. This PR updates the script's regex to allow all documented types (`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`) and updates the error message for better clarity.

Verified by running the script against valid and invalid test cases. All project tests passed.

---
*PR created automatically by Jules for task [1834882693870511213](https://jules.google.com/task/1834882693870511213) started by @n24q02m*