### PR TITLE
⚡ Bolt: parallelize documentation directory candidates check

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/composite/help.ts
+++ b/src/tools/composite/help.ts
@@ -43,11 +43,17 @@ async function getDocsDir(): Promise<string> {
     join(process.cwd(), 'build', 'src', 'docs'),
   ]
 
-  for (const candidate of candidates) {
-    // Validate candidate contains actual tool docs (not a random 'docs' directory)
-    const markerFile = join(candidate, 'help.md')
-    if (await pathExists(markerFile)) return candidate
-  }
+  const results = await Promise.all(
+    candidates.map(async (candidate) => {
+      // Validate candidate contains actual tool docs (not a random 'docs' directory)
+      const markerFile = join(candidate, 'help.md')
+      const exists = await pathExists(markerFile)
+      return exists ? candidate : null
+    }),
+  )
+
+  const found = results.find((res) => res !== null)
+  if (found) return found
 
   return join(process.cwd(), 'src', 'docs')
 }


### PR DESCRIPTION
💡 What: Parallelized documentation directory checks in the help tool using \`Promise.all\` and \`Array.prototype.find\`.
🎯 Why: Simple sequential async file checks in a loop can be parallelized to avoid blocking on each candidate dir sequentially, reducing latency.
📊 Impact: Faster discovery of the documentation directory, especially when the valid directory is later in the candidates list.
🔬 Measurement: Verified with existing unit tests in \`tests/composite/help.test.ts\` and full system check with \`bun run test\`.

---
*PR created automatically by Jules for task [17485574126803764737](https://jules.google.com/task/17485574126803764737) started by @n24q02m*