### PR TITLE
[TEST] Missing MAX_PARSE_DEPTH Edge Case Test

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/tests/helpers/godot-types.test.ts
+++ b/tests/helpers/godot-types.test.ts
@@ -180,6 +180,36 @@ describe('godot-types', () => {
     it('should return unrecognized values as-is', () => {
       expect(parseGodotValue('SomeUnknownType()')).toBe('SomeUnknownType()')
     })
+    it('should return expression when manual depth exceeds MAX_PARSE_DEPTH', () => {
+      // @ts-expect-error - accessing internal _depth for testing
+      expect(parseGodotValue('true', 33)).toBe('true')
+    })
+
+    it('should stop parsing and return string when nesting exceeds MAX_PARSE_DEPTH', () => {
+      // To get the limit:
+      let nested = '1'
+      for (let i = 0; i < 33; i++) {
+        nested = `[${nested}]`
+      }
+      // nested is now 33 levels deep: [[...[1]...]]
+      // Depth 0 calls parse(..., 0)
+      // ...
+      // Depth 31 calls parse("[[1]]", 31)
+      // Depth 32 calls parse("[1]", 32)
+      // Inside parse("[1]", 32): calls parse("1", 33) -> returns "1" (string)
+      // So parse("[1]", 32) returns ["1"]
+
+      const result = parseGodotValue(nested) as unknown[]
+
+      let current: unknown = result
+      for (let i = 0; i < 32; i++) {
+        expect(Array.isArray(current)).toBe(true)
+        current = (current as unknown[])[0]
+      }
+
+      // At depth 32, we have the result of parse("[1]", 32), which is ["1"]
+      expect(current).toEqual(['1'])
+    })
   })
 
   // ==========================================


### PR DESCRIPTION
Added unit tests to tests/helpers/godot-types.test.ts to cover the MAX_PARSE_DEPTH edge case in parseGodotValue. This includes:
- A test case manually passing a depth greater than the limit.
- A test case with 33 levels of nested arrays to verify the function stops parsing and returns the string at the limit.
- Updated biome.json to match the installed version (2.4.14).
- Fixed linting warnings in the new test code.

---
*PR created automatically by Jules for task [11878355251028483370](https://jules.google.com/task/11878355251028483370) started by @n24q02m*