### PR TITLE
[FIX] Duplicate Project Path Check

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/composite/audio.ts
+++ b/src/tools/composite/audio.ts
@@ -9,14 +9,24 @@ import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
 
+/**
+ * Helper to resolve the default bus layout path.
+ * Throws GodotMCPError if project path is missing.
+ */
+function resolveBusLayoutPath(projectPath: string | null | undefined, baseDir: string): string {
+  if (!projectPath) {
+    throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
+  }
+  return join(safeResolve(baseDir, projectPath), 'default_bus_layout.tres')
+}
+
 export async function handleAudio(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const projectPath = (args.project_path as string) || config.projectPath
   const baseDir = config.projectPath || process.cwd()
 
   switch (action) {
     case 'list_buses': {
-      if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
-      const busLayoutPath = join(safeResolve(baseDir, projectPath), 'default_bus_layout.tres')
+      const busLayoutPath = resolveBusLayoutPath(projectPath, baseDir)
 
       if (!(await pathExists(busLayoutPath))) {
         return formatJSON({ buses: [{ name: 'Master', volume: 0, effects: [] }], note: 'Using default bus layout.' })
@@ -36,7 +46,7 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
     }
 
     case 'add_bus': {
-      if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
+      const busLayoutPath = resolveBusLayoutPath(projectPath, baseDir)
       const busName = args.bus_name as string
       if (!busName) throw new GodotMCPError('No bus_name specified', 'INVALID_ARGS', 'Provide bus name.')
       const sendTo = (args.send_to as string) || 'Master'
@@ -56,7 +66,6 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
         )
       }
 
-      const busLayoutPath = join(safeResolve(baseDir, projectPath), 'default_bus_layout.tres')
       let content: string
 
       if (await pathExists(busLayoutPath)) {
@@ -94,7 +103,7 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
     }
 
     case 'add_effect': {
-      if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
+      const busLayoutPath = resolveBusLayoutPath(projectPath, baseDir)
       const busName = args.bus_name as string
       const effectType = args.effect_type as string
       if (!busName || !effectType) {
@@ -123,7 +132,6 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       // Normalize effect type name (allow shorthand like "Reverb" -> "AudioEffectReverb")
       const fullEffectType = effectType.startsWith('AudioEffect') ? effectType : `AudioEffect${effectType}`
 
-      const busLayoutPath = join(safeResolve(baseDir, projectPath), 'default_bus_layout.tres')
       let content: string
 
       if (await pathExists(busLayoutPath)) {


### PR DESCRIPTION
Refactored src/tools/composite/audio.ts to centralize project path validation and bus layout path resolution into a helper function `resolveBusLayoutPath`. This reduces boilerplate code and improves maintainability for `list_buses`, `add_bus`, and `add_effect` actions. Verified with existing tests and quality checks.

---
*PR created automatically by Jules for task [14442748247493579421](https://jules.google.com/task/14442748247493579421) started by @n24q02m*