### PR TITLE
[FIX] Repetitive Deep Nesting Error Checks

### DIFF
--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -11,6 +11,7 @@ import { toGodotValue } from '../helpers/godot-types.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
 import { parseProjectSettingsAsync, setSettingInContent } from '../helpers/project-settings.js'
 import { escapeRegExp } from '../helpers/scene-parser.js'
+import { validateNoNewlines } from '../helpers/security.js'
 
 export async function handlePhysics(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const projectPath = (args.project_path as string) || config.projectPath || ''
@@ -43,9 +44,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       const nodeName = args.name as string
       if (!nodeName) throw new GodotMCPError('No node name specified', 'INVALID_ARGS', 'Provide node name.')
 
-      if (scenePath.includes('\n') || scenePath.includes('\r') || nodeName.includes('\n') || nodeName.includes('\r')) {
-        throw new GodotMCPError('Invalid arguments: newlines not allowed', 'INVALID_ARGS')
-      }
+      validateNoNewlines(undefined, scenePath, nodeName)
 
       const collisionLayer = args.collision_layer
       const collisionMask = args.collision_mask
@@ -65,16 +64,12 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       let props = ''
       if (collisionLayer !== undefined) {
         const val = toGodotValue(collisionLayer)
-        if (val.includes('\n') || val.includes('\r')) {
-          throw new GodotMCPError('Invalid collision_layer: newlines not allowed', 'INVALID_ARGS')
-        }
+        validateNoNewlines('Invalid collision_layer: newlines not allowed', val)
         props += `\ncollision_layer = ${val}`
       }
       if (collisionMask !== undefined) {
         const val = toGodotValue(collisionMask)
-        if (val.includes('\n') || val.includes('\r')) {
-          throw new GodotMCPError('Invalid collision_mask: newlines not allowed', 'INVALID_ARGS')
-        }
+        validateNoNewlines('Invalid collision_mask: newlines not allowed', val)
         props += `\ncollision_mask = ${val}`
       }
 
@@ -92,9 +87,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       const nodeName = args.name as string
       if (!nodeName) throw new GodotMCPError('No node name specified', 'INVALID_ARGS', 'Provide node name.')
 
-      if (scenePath.includes('\n') || scenePath.includes('\r') || nodeName.includes('\n') || nodeName.includes('\r')) {
-        throw new GodotMCPError('Invalid arguments: newlines not allowed', 'INVALID_ARGS')
-      }
+      validateNoNewlines(undefined, scenePath, nodeName)
 
       const fullPath = safeResolve(safeResolve(config.projectPath || process.cwd(), projectPath), scenePath)
       if (!(await pathExists(fullPath)))
@@ -110,9 +103,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       for (const prop of physicsProps) {
         if (args[prop] !== undefined) {
           const val = toGodotValue(args[prop])
-          if (val.includes('\n') || val.includes('\r')) {
-            throw new GodotMCPError(`Invalid ${prop}: newlines not allowed`, 'INVALID_ARGS')
-          }
+          validateNoNewlines(`Invalid ${prop}: newlines not allowed`, val)
           props += `\n${prop} = ${val}`
         }
       }
@@ -133,16 +124,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       const name = args.name as string
       if (!name) throw new GodotMCPError('No name specified', 'INVALID_ARGS', 'Provide layer name.')
 
-      if (
-        name.includes('\n') ||
-        name.includes('\r') ||
-        dimension.includes('\n') ||
-        dimension.includes('\r') ||
-        layerNumRaw.includes('\n') ||
-        layerNumRaw.includes('\r')
-      ) {
-        throw new GodotMCPError('Invalid arguments: newlines not allowed', 'INVALID_ARGS')
-      }
+      validateNoNewlines(undefined, name, dimension, layerNumRaw)
 
       const layerNum = Number.parseInt(layerNumRaw, 10)
       if (Number.isNaN(layerNum)) {

--- a/src/tools/helpers/security.ts
+++ b/src/tools/helpers/security.ts
@@ -1,3 +1,5 @@
+import { GodotMCPError } from './errors.js'
+
 /**
  * Security utilities for MCP tool responses.
  * Wraps untrusted file content with safety markers to defend against
@@ -47,5 +49,22 @@ export function wrapToolResult<T extends { content: Array<{ type: string; text: 
       ...item,
       text: `<untrusted_godot_content>\n${item.text}\n</untrusted_godot_content>\n\n${SAFETY_WARNING}`,
     })),
+  }
+}
+
+/**
+ * Validates that the provided values do not contain newlines.
+ * Prevents injection attacks into Godot text files (.tscn, .tres, project.godot).
+ * @param customMessage Custom error message if validation fails.
+ * @param values Values to check.
+ */
+export function validateNoNewlines(
+  customMessage: string | undefined,
+  ...values: (string | number | boolean | undefined | null)[]
+): void {
+  for (const val of values) {
+    if (typeof val === 'string' && (val.includes('\n') || val.includes('\r'))) {
+      throw new GodotMCPError(customMessage || 'Invalid arguments: newlines not allowed', 'INVALID_ARGS')
+    }
   }
 }

--- a/tests/helpers/security.test.ts
+++ b/tests/helpers/security.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { wrapToolResult } from '../../src/tools/helpers/security.js'
+import { validateNoNewlines, wrapToolResult } from '../../src/tools/helpers/security.js'
 
 describe('security', () => {
   // ==========================================
@@ -69,6 +69,39 @@ describe('security', () => {
       expect(wrapped.content[0].text).toContain('script1')
       expect(wrapped.content[1].text).toContain('<untrusted_godot_content>')
       expect(wrapped.content[1].text).toContain('script2')
+    })
+  })
+
+  // ==========================================
+  // validateNoNewlines
+  // ==========================================
+  describe('validateNoNewlines', () => {
+    it('should pass for safe strings', () => {
+      expect(() => validateNoNewlines(undefined, 'safe', 'another safe')).not.toThrow()
+    })
+
+    it('should pass for numbers and booleans', () => {
+      expect(() => validateNoNewlines(undefined, 123, true, false)).not.toThrow()
+    })
+
+    it('should pass for undefined and null', () => {
+      expect(() => validateNoNewlines(undefined, undefined, null)).not.toThrow()
+    })
+
+    it('should throw for string with newline', () => {
+      expect(() => validateNoNewlines(undefined, 'safe', 'has\nnewline')).toThrow('Invalid arguments: newlines not allowed')
+    })
+
+    it('should throw for string with carriage return', () => {
+      expect(() => validateNoNewlines(undefined, 'has\rcarriage', 'safe')).toThrow('Invalid arguments: newlines not allowed')
+    })
+
+    it('should throw for mixed inputs with a newline', () => {
+      expect(() => validateNoNewlines(undefined, 123, 'has\nnewline', true)).toThrow('Invalid arguments: newlines not allowed')
+    })
+
+    it('should use custom message when provided', () => {
+      expect(() => validateNoNewlines('Custom error message', 'has\nnewline')).toThrow('Custom error message')
     })
   })
 })


### PR DESCRIPTION
Refactored repetitive newline and carriage return validation logic from src/tools/composite/physics.ts into a new validateNoNewlines helper in src/tools/helpers/security.ts. This reduces code duplication and improves maintainability while preserving security against scene injection attacks. Updated physics.ts to use the new helper and added comprehensive unit tests in tests/helpers/security.test.ts.

---
*PR created automatically by Jules for task [7123272885241489808](https://jules.google.com/task/7123272885241489808) started by @n24q02m*