### PR TITLE
[FIX] TODO Item

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/generate_todos.py
+++ b/generate_todos.py
@@ -1,0 +1,68 @@
+import os
+import re
+import subprocess
+
+def get_commit_hash():
+    try:
+        return subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').strip()
+    except Exception:
+        return "main"
+
+def analyze_todos():
+    repo_url = "https://github.com/n24q02m/better-godot-mcp"
+    commit_hash = get_commit_hash()
+
+    todos = []
+
+    # We split the pattern string to avoid the script finding itself
+    keywords = ['TO' + 'DO', 'FIX' + 'ME', 'BU' + 'G', 'HA' + 'CK', 'X' + 'XX']
+    pattern = re.compile(r'(' + '|'.join(keywords) + r')[:\s]+(.*)', re.IGNORECASE)
+
+    for root, dirs, files in os.walk('.'):
+        # Skip common directories to ignore
+        if any(ex in root for ex in ['node_modules', '.git', 'build', 'dist', 'target', '.venv', 'venv']):
+            continue
+
+        for file in files:
+            # Focus on common source file extensions
+            if not file.endswith(('.ts', '.js', '.py', '.java', '.md', '.gd', '.gdshader')):
+                continue
+
+            filepath = os.path.join(root, file)
+            # Standardize path for URL generation
+            rel_path = os.path.relpath(filepath, '.')
+
+            # Avoid self-reference
+            if rel_path == 'generate_todos.py':
+                continue
+
+            try:
+                with open(filepath, 'r', encoding='utf-8') as f:
+                    for i, line in enumerate(f, 1):
+                        match = pattern.search(line)
+                        if match:
+                            tag = match.group(1).upper()
+                            message = match.group(2).strip()
+                            github_url = f"{repo_url}/blob/{commit_hash}/{rel_path}#L{i}"
+                            todos.append({
+                                'file': rel_path,
+                                'line': i,
+                                'tag': tag,
+                                'message': message,
+                                'url': github_url
+                            })
+            except (UnicodeDecodeError, PermissionError):
+                continue
+
+    return todos
+
+if __name__ == "__main__":
+    found_todos = analyze_todos()
+    if not found_todos:
+        print("No items found.")
+    else:
+        print(f"Found {len(found_todos)} items:\n")
+        for item in found_todos:
+            print(f"[{item['tag']}] {item['file']}:{item['line']}")
+            print(f"  Message: {item['message']}")
+            print(f"  Link: {item['url']}\n")


### PR DESCRIPTION
This PR implements the missing `generate_todos.py` script as requested. 

The script:
- Scans the repository for `TODO`, `FIXME`, `BUG`, `HACK`, and `XXX` markers.
- Automatically skips irrelevant directories such as `node_modules`, `.git`, `build`, `dist`, `target`, and virtual environments.
- Supports multiple file extensions common in this repository (`.ts`, `.js`, `.py`, `.java`, `.md`, `.gd`, `.gdshader`).
- Dynamically retrieves the current Git commit hash to generate accurate line-specific GitHub URLs.
- Is designed to avoid detecting its own keyword definitions.

Additionally, `biome.json` was migrated to version 2.4.14 to resolve a schema mismatch that was preventing the linting process from running correctly. 

Verified the script manually with test items and ran the full project test suite (`bun run test` and `bun run check`) to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [6231570618945041209](https://jules.google.com/task/6231570618945041209) started by @n24q02m*