### PR TITLE
[FIX] Correct skill tool calls and add run scene support

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/skills/add-mechanic/SKILL.md
+++ b/skills/add-mechanic/SKILL.md
@@ -201,15 +201,15 @@ Use `user://` path (NOT `res://`) for save files -- `res://` is read-only in exp
 1. **Identify mechanic** from user description
 2. **Create script** using the appropriate template above:
    ```
-   scripts(action="create", path="res://scripts/<name>.gd", content="...")
+   scripts(action="create", script_path="res://scripts/<name>.gd", content="...")
    ```
 3. **Attach to scene node** if needed:
    ```
-   nodes(action="set_property", scene="<scene>.tscn", node_path="<node>", property="script", value="res://scripts/<name>.gd")
+   nodes(action="set_property", scene_path="<scene>.tscn", name="<node>", property="script", value="res://scripts/<name>.gd")
    ```
 4. **Add companion nodes** (e.g., HealthComponent as child node)
 5. **Connect signals** in the scene or via script
-6. **Test**: `editor(action="run_scene", scene="<scene>.tscn")`
+6. **Test**: `project(action="run", scene_path="<scene>.tscn")`
 
 ## When to Use
 

--- a/skills/build-scene/SKILL.md
+++ b/skills/build-scene/SKILL.md
@@ -77,29 +77,29 @@ Note: `TileMap` node is deprecated in Godot 4.3+. Use `TileMapLayer` instead.
 
 2. **Create scene**:
    ```
-   scenes(action="create", name="<name>", root_type="<RootType>")
+   scenes(action="create", scene_path="scenes/<name>.tscn", root_type="<RootType>")
    ```
 
 3. **Add nodes top-down** (parent before children):
    ```
-   nodes(action="add", scene="<name>.tscn", parent=".", type="CollisionShape2D", name="CollisionShape2D")
-   nodes(action="add", scene="<name>.tscn", parent=".", type="Sprite2D", name="Sprite2D")
+   nodes(action="add", scene_path="scenes/<name>.tscn", parent=".", type="CollisionShape2D", name="CollisionShape2D")
+   nodes(action="add", scene_path="scenes/<name>.tscn", parent=".", type="Sprite2D", name="Sprite2D")
    ```
 
 4. **Configure properties**:
    ```
-   nodes(action="set_property", scene="<name>.tscn", node_path="Camera2D",
+   nodes(action="set_property", scene_path="scenes/<name>.tscn", name="Camera2D",
          property="position_smoothing_enabled", value="true")
    ```
 
 5. **Attach script** (create from template in add-mechanic skill if needed):
    ```
-   scripts(action="create", path="res://scripts/<name>.gd", content="...")
+   scripts(action="create", script_path="res://scripts/<name>.gd", content="...")
    ```
 
 6. **Verify scene tree**:
    ```
-   scenes(action="get", scene="<name>.tscn")
+   scenes(action="info", scene_path="scenes/<name>.tscn")
    ```
 
 ## Common Mistakes to Prevent

--- a/skills/debug-issue/SKILL.md
+++ b/skills/debug-issue/SKILL.md
@@ -25,17 +25,17 @@ Map user's symptom to the right tree:
 Check in this order -- each step is the most common cause at that point:
 
 1. **Collision layer/mask mismatch** (most common):
-   ```
-   nodes(action="get_property", scene="<scene>.tscn", node_path="<body>", property="collision_layer")
-   nodes(action="get_property", scene="<scene>.tscn", node_path="<body>", property="collision_mask")
-   ```
-   Rule: Object A detects Object B only if A's `collision_mask` has a bit that matches B's `collision_layer`. Both must be set correctly.
+   - Check defined layer names: `physics(action="layers")`
+   - Check node properties:
+     ```
+     nodes(action="get_property", scene_path="<scene>.tscn", name="<body>", property="collision_layer")
+     nodes(action="get_property", scene_path="<scene>.tscn", name="<body>", property="collision_mask")
+     ```
+   - Rule: Object A detects Object B only if A's `collision_mask` has a bit that matches B's `collision_layer`. Both must be set correctly.
 
 2. **Missing CollisionShape2D/3D**:
-   ```
-   scenes(action="get", scene="<scene>.tscn")
-   ```
-   Verify every physics body and Area has a CollisionShape child. A body without a shape = invisible to physics.
+   - Inspect the scene tree: `scenes(action="info", scene_path="<scene>.tscn")`
+   - Verify every physics body and Area has a CollisionShape child. A body without a shape = invisible to physics.
 
 3. **Wrong body type**:
    - `StaticBody2D`: immovable (walls, floors)
@@ -44,6 +44,7 @@ Check in this order -- each step is the most common cause at that point:
    - Common mistake: using `RigidBody2D` for a player character, then fighting the physics engine
 
 4. **Script velocity issues**:
+   - Read the script: `scripts(action="read", script_path="res://scripts/<name>.gd")`
    - Check if `velocity` is being set before `move_and_slide()`
    - Check if gravity is applied in `_physics_process` (not `_process`)
    - Check if `delta` is used for frame-independent movement
@@ -51,8 +52,7 @@ Check in this order -- each step is the most common cause at that point:
 ## Signals Decision Tree
 
 1. **Connection exists?**
-   - Check scene file for `[connection]` entries
-   - Or check script for `connect()` calls
+   - List all connections: `signals(action="list", scene_path="<scene>.tscn")`
    - Missing connection = signal silently does nothing
 
 2. **Signature match?**
@@ -109,7 +109,7 @@ Check in this order -- each step is the most common cause at that point:
 ## Input Decision Tree
 
 1. **Input Map**:
-   - Action defined in Project Settings > Input Map?
+   - List actions: `input_map(action="list")`
    - Check `project.godot` for `[input]` section
 
 2. **Action name match**:
@@ -128,10 +128,10 @@ Check in this order -- each step is the most common cause at that point:
 
 For any category:
 
-1. **Inspect the scene tree**: `scenes(action="get", scene="<scene>.tscn")`
-2. **Read relevant scripts**: `scripts(action="get", path="res://scripts/<name>.gd")`
-3. **Check properties**: `nodes(action="get_property", ...)`
-4. **Run the scene**: `editor(action="run_scene", scene="<scene>.tscn")` and check output for errors
+1. **Inspect the scene tree**: `scenes(action="info", scene_path="<scene>.tscn")`
+2. **Read relevant scripts**: `scripts(action="read", script_path="res://scripts/<name>.gd")`
+3. **Check properties**: `nodes(action="get_property", scene_path="<scene>.tscn", name="<node_path>", property="<name>")`
+4. **Run the scene**: `project(action="run", scene_path="<scene>.tscn")` and check output for errors
 5. **Report findings**: present root cause and specific fix (property change, missing node, script edit)
 
 ## When to Use

--- a/src/godot/headless.ts
+++ b/src/godot/headless.ts
@@ -80,8 +80,17 @@ export async function execGodotAsync(
 /**
  * Run Godot project (non-blocking)
  */
-export function runGodotProject(godotPath: string, projectPath: string): { pid: number | undefined } {
-  const child = spawn(godotPath, ['--path', projectPath], {
+export function runGodotProject(
+  godotPath: string,
+  projectPath: string,
+  scenePath?: string,
+): { pid: number | undefined } {
+  const args = ['--path', projectPath]
+  if (scenePath) {
+    args.push(scenePath)
+  }
+
+  const child = spawn(godotPath, args, {
     detached: true,
     stdio: 'ignore',
   })

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -49,7 +49,7 @@ async function parseProjectGodot(projectPath: string): Promise<ProjectInfo> {
       if (sectionMatch) {
         currentSection = sectionMatch[1]
       } else {
-        const kvMatch = trimmed.match(/^(\S+)\s*=\s*(.+)$/)
+        const kvMatch = trimmed.match(/^([^\s=]+)\s*=\s*(.+)$/)
         if (kvMatch) {
           const [, key, rawValue] = kvMatch
           const value = rawValue.replace(/^"(.*)"$/, '$1')
@@ -112,11 +112,21 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
         throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
       }
-      const { pid } = runGodotProject(config.godotPath, safeResolve(config.projectPath || process.cwd(), projectPath))
+
+      const scenePath = args.scene_path as string
+      if (scenePath && (scenePath.includes('\n') || scenePath.includes('\r'))) {
+        throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain newlines.')
+      }
+
+      const { pid } = runGodotProject(
+        config.godotPath,
+        safeResolve(config.projectPath || process.cwd(), projectPath),
+        scenePath,
+      )
       if (pid) {
         config.activePids.push(pid)
       }
-      return formatSuccess(`Godot project started (PID: ${pid})`)
+      return formatSuccess(`Godot project started (PID: ${pid})${scenePath ? ` for scene ${scenePath}` : ''}`)
     }
 
     case 'stop': {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -58,7 +58,7 @@ const P0_TOOLS = [
   {
     name: 'project',
     description:
-      'Godot project operations.\n\nActions (required params -> optional):\n- info (-> project_path): project metadata\n- version: Godot engine version\n- run (-> project_path): launch game\n- stop: stop running game\n- settings_get (key -> project_path): read project setting\n- settings_set (key, value -> project_path): write project setting\n- export (preset, output_path -> project_path): export game build',
+      'Godot project operations.\n\nActions (required params -> optional):\n- info (-> project_path): project metadata\n- version: Godot engine version\n- run (-> scene_path, project_path): launch game\n- stop: stop running game\n- settings_get (key -> project_path): read project setting\n- settings_set (key, value -> project_path): write project setting\n- export (preset, output_path -> project_path): export game build',
     annotations: createAnnotations('Project'),
     inputSchema: {
       type: 'object' as const,
@@ -69,6 +69,7 @@ const P0_TOOLS = [
           description: 'Action to perform',
         },
         project_path: { type: 'string', description: 'Path to Godot project directory' },
+        scene_path: { type: 'string', description: 'Path to a specific scene to run (optional)' },
         key: { type: 'string', description: 'Settings key (for settings_get/set)' },
         value: { type: 'string', description: 'Settings value (for settings_set)' },
         preset: { type: 'string', description: 'Export preset name (for export)' },

--- a/tests/composite/project.test.ts
+++ b/tests/composite/project.test.ts
@@ -79,7 +79,7 @@ describe('project', () => {
   // ==========================================
   describe('version', () => {
     it('should return godot version', async () => {
-      vi.mocked(execGodotAsync).mockResolvedValue({ stdout: '4.4.stable', stderr: '', exitCode: 0 })
+      vi.mocked(execGodotAsync).mockResolvedValue({ stdout: '4.4.stable', stderr: '', exitCode: 0, success: true })
 
       const result = await handleProject('version', {}, config)
       expect(result.content[0].text).toContain('Godot version: 4.4.stable')
@@ -101,7 +101,16 @@ describe('project', () => {
 
       const result = await handleProject('run', { project_path: projectPath }, config)
       expect(result.content[0].text).toContain('PID: 12345')
-      expect(runGodotProject).toHaveBeenCalledWith('/path/to/godot', expect.stringContaining(projectPath))
+      expect(runGodotProject).toHaveBeenCalledWith('/path/to/godot', projectPath, undefined)
+    })
+
+    it('should start godot project with scene', async () => {
+      vi.mocked(runGodotProject).mockReturnValue({ pid: 12345 })
+
+      const result = await handleProject('run', { project_path: projectPath, scene_path: 'scenes/test.tscn' }, config)
+      expect(result.content[0].text).toContain('PID: 12345')
+      expect(result.content[0].text).toContain('for scene scenes/test.tscn')
+      expect(runGodotProject).toHaveBeenCalledWith('/path/to/godot', projectPath, 'scenes/test.tscn')
     })
 
     it('should throw if godot not found', async () => {
@@ -237,7 +246,12 @@ describe('project', () => {
   // ==========================================
   describe('export', () => {
     it('should export project', async () => {
-      vi.mocked(execGodotAsync).mockResolvedValue({ stdout: 'Export successful', stderr: '', exitCode: 0 })
+      vi.mocked(execGodotAsync).mockResolvedValue({
+        stdout: 'Export successful',
+        stderr: '',
+        exitCode: 0,
+        success: true,
+      })
 
       const result = await handleProject(
         'export',


### PR DESCRIPTION
- Enhanced 'project(action="run")' tool with 'scene_path' parameter to support launching specific Godot scenes.
- Fixed outdated/hallucinated tool actions and parameter names in 'debug-issue', 'build-scene', and 'add-mechanic' skill files.
- Improved 'debug-issue' skill with specialized diagnostic tools ('signals', 'input_map', 'physics').
- Fixed project settings parsing regex in `project.ts` to handle complex Godot values (e.g., `PackedStringArray`).
- Updated unit tests in `tests/composite/project.test.ts` and verified with full test suite (773 tests passed).
- Migrated Biome configuration and resolved formatting issues.

---
*PR created automatically by Jules for task [9311670491672523433](https://jules.google.com/task/9311670491672523433) started by @n24q02m*