### PR TITLE
[FIX] Cleanup Outdated Known Bugs Documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,15 +84,6 @@ PSR v10 (workflow_dispatch) -> npm + Docker (amd64+arm64) + GHCR + MCP Registry.
 - Pre-commit: biome check, tsc --noEmit. Pre-push: bun test.
 - Secrets: skret SSM namespace `/better-godot-mcp/prod` (region `ap-southeast-1`)
 
-## Known bugs (potential -- E2E test chua chay den godot 2026-04-18)
-
-Godot MCP dung `@n24q02m/mcp-core` (core-ts) -- co the bi affect boi upstream core-ts bug:
-
-1. **Browser UI stuck "Waiting for server..." sau khi submit credentials** (neu co relay flow). See `C:\Users\n24q02m-wlap\projects\mcp-core\CLAUDE.md` Known bugs #2.
-2. **Config storage path**: `$APPDATA\mcp\Config\config.enc` (khac Python servers `$LOCALAPPDATA\mcp\config.enc`).
-
-Khi E2E test godot, can clean state tai `$APPDATA\mcp\Config\` + check browser behavior.
-
 ## E2E
 
 Driven by `mcp-core/scripts/e2e/` (matrix-locked, 15 configs). Run a single config from this repo via `make e2e` (proxy) or directly:

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/tests/init-server.test.ts
+++ b/tests/init-server.test.ts
@@ -72,7 +72,7 @@ describe('initServer', () => {
       port: 12345,
       close: vi.fn().mockResolvedValue(undefined),
     })
-    vi.spyOn(process, 'exit').mockImplementation((() => {}) as any)
+    vi.spyOn(process, 'exit').mockImplementation((() => {}) as unknown as never)
     // Suppress console.error output during tests
     vi.spyOn(console, 'error').mockImplementation(() => {})
     process.env = { ...originalEnv }


### PR DESCRIPTION
This PR removes the outdated "Known bugs" section from `CLAUDE.md`. These potential bugs (inherited from `@n24q02m/mcp-core`) are either non-applicable to `better-godot-mcp` (which uses no credentials) or have been resolved by the architecture stabilization mentioned in the README (2026-05-02).

Changes:
- Removed the potential bugs section from `CLAUDE.md`.
- Updated `biome.json` to match the current CLI version (2.4.14).
- Refactored a type cast in `tests/init-server.test.ts` to satisfy linting rules.
- Verified system health by running the full test suite (772/773 passing, 1 skipped as expected).

---
*PR created automatically by Jules for task [3036700592017363839](https://jules.google.com/task/3036700592017363839) started by @n24q02m*