### PR TITLE
🛡️ Sentinel: Fix Argument Injection in Godot Run Action

### DIFF
--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -117,6 +117,9 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (scenePath && (scenePath.includes('\n') || scenePath.includes('\r'))) {
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain newlines.')
       }
+      if (scenePath && scenePath.startsWith('-')) {
+        throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not start with a hyphen.')
+      }
 
       const { pid } = runGodotProject(
         config.godotPath,

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -117,7 +117,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (scenePath && (scenePath.includes('\n') || scenePath.includes('\r'))) {
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain newlines.')
       }
-      if (scenePath && scenePath.startsWith('-')) {
+      if (scenePath?.startsWith('-')) {
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not start with a hyphen.')
       }
 

--- a/tests/composite/project-run-security.test.ts
+++ b/tests/composite/project-run-security.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest'
+import { handleProject } from '../../src/tools/composite/project.js'
+import { makeConfig } from '../fixtures.js'
+import { runGodotProject } from '../../src/godot/headless.js'
+
+vi.mock('../../src/godot/headless.js', () => ({
+  execGodotAsync: vi.fn().mockResolvedValue({ success: true, stdout: '', stderr: '', exitCode: 0 }),
+  runGodotProject: vi.fn().mockReturnValue({ pid: 1234 }),
+}))
+
+describe('project run security', () => {
+  it('should reject scene_path starting with a hyphen', async () => {
+    const config = makeConfig({ projectPath: '/tmp/project', godotPath: '/path/to/godot' })
+    await expect(
+      handleProject(
+        'run',
+        {
+          project_path: '/tmp/project',
+          scene_path: '--script=malicious.gd',
+        },
+        config,
+      )
+    ).rejects.toThrow('Invalid scene path')
+    expect(runGodotProject).not.toHaveBeenCalled()
+  })
+})

--- a/tests/composite/project-run-security.test.ts
+++ b/tests/composite/project-run-security.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
+import { runGodotProject } from '../../src/godot/headless.js'
 import { handleProject } from '../../src/tools/composite/project.js'
 import { makeConfig } from '../fixtures.js'
-import { runGodotProject } from '../../src/godot/headless.js'
 
 vi.mock('../../src/godot/headless.js', () => ({
   execGodotAsync: vi.fn().mockResolvedValue({ success: true, stdout: '', stderr: '', exitCode: 0 }),
@@ -19,7 +19,7 @@ describe('project run security', () => {
           scene_path: '--script=malicious.gd',
         },
         config,
-      )
+      ),
     ).rejects.toThrow('Invalid scene path')
     expect(runGodotProject).not.toHaveBeenCalled()
   })

--- a/tests/helpers/security.test.ts
+++ b/tests/helpers/security.test.ts
@@ -89,15 +89,21 @@ describe('security', () => {
     })
 
     it('should throw for string with newline', () => {
-      expect(() => validateNoNewlines(undefined, 'safe', 'has\nnewline')).toThrow('Invalid arguments: newlines not allowed')
+      expect(() => validateNoNewlines(undefined, 'safe', 'has\nnewline')).toThrow(
+        'Invalid arguments: newlines not allowed',
+      )
     })
 
     it('should throw for string with carriage return', () => {
-      expect(() => validateNoNewlines(undefined, 'has\rcarriage', 'safe')).toThrow('Invalid arguments: newlines not allowed')
+      expect(() => validateNoNewlines(undefined, 'has\rcarriage', 'safe')).toThrow(
+        'Invalid arguments: newlines not allowed',
+      )
     })
 
     it('should throw for mixed inputs with a newline', () => {
-      expect(() => validateNoNewlines(undefined, 123, 'has\nnewline', true)).toThrow('Invalid arguments: newlines not allowed')
+      expect(() => validateNoNewlines(undefined, 123, 'has\nnewline', true)).toThrow(
+        'Invalid arguments: newlines not allowed',
+      )
     })
 
     it('should use custom message when provided', () => {


### PR DESCRIPTION
🛡️ **Sentinel: [MEDIUM] Fix argument injection in Godot Run Action**

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `scene_path` parameter in the `project.run` action was not validated against starting with a hyphen. This path is passed directly as a trailing argument when spawning the Godot executable. A malicious user or script could provide a `scene_path` like `--script=malicious.gd` to inject arbitrary CLI flags.
🎯 **Impact:** While `spawn` does not evaluate shell metacharacters, allowing arbitrary CLI flags can still lead to unintended code execution (e.g., via the `--script` flag) or unexpected application behavior depending on the executable's supported flags.
🔧 **Fix:** Added a validation check to throw an `INVALID_ARGS` error if `scenePath` starts with a hyphen, similar to existing validations for `project_path` and `preset`.
✅ **Verification:** Verified by `tests/composite/project-run-security.test.ts`. Run `bun run test` to execute the suite.

---
*PR created automatically by Jules for task [4978088990489854433](https://jules.google.com/task/4978088990489854433) started by @n24q02m*