### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Scene Injection Vulnerability in scripts and tilemap

### DIFF
--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -9,6 +9,7 @@ import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
 import { escapeRegExp } from '../helpers/scene-parser.js'
+import { validateNoNewlines } from '../helpers/security.js'
 
 const NODE_SECTION_RE = /(\[node [^\]]+\])/
 
@@ -185,6 +186,8 @@ async function attachScript(args: Record<string, unknown>, resolvePath: (path: s
       'Provide scene_path and script_path.',
     )
   }
+
+  validateNoNewlines(undefined, scenePath, scriptPath, nodeName)
 
   const sceneFullPath = resolvePath(scenePath)
   if (!(await pathExists(sceneFullPath)))

--- a/src/tools/composite/tilemap.ts
+++ b/src/tools/composite/tilemap.ts
@@ -9,6 +9,7 @@ import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
+import { validateNoNewlines } from '../helpers/security.js'
 
 /**
  * Async helper to check file existence without blocking the event loop
@@ -66,6 +67,8 @@ export async function handleTilemap(action: string, args: Record<string, unknown
       if (!tilesetPath || !texturePath) {
         throw new GodotMCPError('tileset_path and texture_path required', 'INVALID_ARGS', 'Both are required.')
       }
+
+      validateNoNewlines(undefined, tilesetPath, texturePath)
 
       const fullPath = safeResolve(projectPath || process.cwd(), tilesetPath)
 

--- a/tests/security/scripts-injection.test.ts
+++ b/tests/security/scripts-injection.test.ts
@@ -1,0 +1,26 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleScripts } from '../../src/tools/composite/scripts.js'
+
+describe('Scripts Injection Security Tests', () => {
+  const projectPath = join(process.cwd(), 'tmp_security_scripts_injection_test')
+  const config: GodotConfig = { projectPath }
+
+  beforeEach(() => {
+    mkdirSync(projectPath, { recursive: true })
+    writeFileSync(join(projectPath, 'project.godot'), '[config]')
+    writeFileSync(join(projectPath, 'scene.tscn'), '[gd_scene format=3]\n\n[node name="Root" type="Node"]\n')
+  })
+
+  afterEach(() => {
+    rmSync(projectPath, { recursive: true, force: true })
+  })
+
+  it('should reject newlines in attachScript script_path', async () => {
+    await expect(
+      handleScripts('attach', { scene_path: 'scene.tscn', script_path: 'script.gd"\n[sub_resource]' }, config),
+    ).rejects.toThrow('Invalid arguments: newlines not allowed')
+  })
+})

--- a/tests/security/tilemap-injection.test.ts
+++ b/tests/security/tilemap-injection.test.ts
@@ -1,0 +1,29 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleTilemap } from '../../src/tools/composite/tilemap.js'
+
+describe('TileMap Injection Security Tests', () => {
+  const projectPath = join(process.cwd(), 'tmp_security_tilemap_injection_test')
+  const config: GodotConfig = { projectPath }
+
+  beforeEach(() => {
+    mkdirSync(projectPath, { recursive: true })
+    writeFileSync(join(projectPath, 'project.godot'), '[config]')
+  })
+
+  afterEach(() => {
+    rmSync(projectPath, { recursive: true, force: true })
+  })
+
+  it('should reject newlines and quotes in add_source texture_path', async () => {
+    // Setup valid tileset
+    await handleTilemap('create_tileset', { tileset_path: 'tileset.tres' }, config)
+
+    // Attempt injection
+    await expect(
+      handleTilemap('add_source', { tileset_path: 'tileset.tres', texture_path: 'icon.png"\n[sub_resource]' }, config),
+    ).rejects.toThrow('Invalid arguments: newlines not allowed')
+  })
+})


### PR DESCRIPTION
I have fixed a critical security vulnerability ("Scene Injection") that could allow malicious input to inject arbitrary Godot nodes, scripts, or sub-resources via unescaped newlines in file paths.

I addressed this by:
1. Importing the existing `validateNoNewlines` security utility.
2. Applying it to sensitive parameters in the `attachScript` action within `scripts.ts`.
3. Applying it to sensitive parameters in the `add_source` action within `tilemap.ts`.
4. Adding explicit security test suites (`tests/security/scripts-injection.test.ts` and `tests/security/tilemap-injection.test.ts`) that correctly assert the rejection of newline characters.

These fixes prevent malicious prompt injections from modifying the Godot `.tscn` and `.tres` files by breaking out of standard string paths.

---
*PR created automatically by Jules for task [10576714172469521591](https://jules.google.com/task/10576714172469521591) started by @n24q02m*