### PR TITLE
🛡️ Sentinel: [HIGH] Fix CLI Argument Injection in project run action

### DIFF
--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -114,6 +114,9 @@ export async function handleProject(action: string, args: Record<string, unknown
       }
 
       const scenePath = args.scene_path as string
+      if (typeof scenePath === 'string' && scenePath.startsWith('-')) {
+        throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not start with a hyphen.')
+      }
       if (scenePath && (scenePath.includes('\n') || scenePath.includes('\r'))) {
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain newlines.')
       }

--- a/tests/composite/project-run-security.test.ts
+++ b/tests/composite/project-run-security.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleProject } from '../../src/tools/composite/project.js'
+import { createTmpProject, makeConfig } from '../fixtures.js'
+
+// Mock headless execution
+vi.mock('../../src/godot/headless.js', () => ({
+  execGodotAsync: vi.fn().mockResolvedValue({ success: true, stdout: '', stderr: '', exitCode: 0 }),
+  execGodotSync: vi.fn(),
+  runGodotProject: vi.fn().mockReturnValue({ pid: 12345 }),
+}))
+
+// Mock child_process for stop command
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}))
+
+import { runGodotProject } from '../../src/godot/headless.js'
+
+describe('project run security', () => {
+  let projectPath: string
+  let cleanup: () => void
+  let config: GodotConfig
+
+  beforeEach(() => {
+    const tmp = createTmpProject()
+    projectPath = tmp.projectPath
+    cleanup = tmp.cleanup
+    config = makeConfig({ projectPath, godotPath: '/path/to/godot' })
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  describe('scene path argument injection prevention', () => {
+    it('should reject scene_path starting with a hyphen', async () => {
+      await expect(
+        handleProject(
+          'run',
+          {
+            project_path: projectPath,
+            scene_path: '--script=malicious.gd',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid scene path')
+
+      expect(runGodotProject).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix CLI Argument Injection

**🚨 Severity:** HIGH
**💡 Vulnerability:** The `scene_path` argument in the `run` action of the `project` tool was directly passed to the child process that runs Godot. If an attacker supplied a path starting with a hyphen (e.g. `--script=malicious.gd`), it could be parsed as a CLI option, potentially leading to arbitrary code execution or unexpected behavior.
**🎯 Impact:** A malicious user could exploit this to execute arbitrary scripts via the Godot CLI.
**🔧 Fix:** Added a check to reject any `scene_path` that starts with a hyphen before execution, mirroring the protections already in place for `preset` and `output_path`.
**✅ Verification:** Run `bun run test tests/composite/project-run-security.test.ts` or the full test suite.

---
*PR created automatically by Jules for task [2798760669707392386](https://jules.google.com/task/2798760669707392386) started by @n24q02m*