### PR TITLE
⚡ Bolt: Optimize `findInPath` to avoid array allocations from `split`

### DIFF
--- a/src/godot/detector.ts
+++ b/src/godot/detector.ts
@@ -150,7 +150,10 @@ function findInPath(): string | null {
         stdio: ['pipe', 'pipe', 'pipe'],
         encoding: 'utf-8',
       })
-      const path = result.trim().split('\n')[0].trim()
+      const trimmedResult = result.trim()
+      const newlineIdx = trimmedResult.indexOf('\n')
+      // ⚡ Bolt: Use indexOf and slice instead of split('\n')[0] to avoid array allocation
+      const path = (newlineIdx === -1 ? trimmedResult : trimmedResult.slice(0, newlineIdx)).trim()
       if (path && isExecutable(path)) return path
     } catch {
       // Not found, continue


### PR DESCRIPTION
💡 **What:** Replaced `.split('\n')[0]` with `indexOf('\n')` and `.slice()` in `findInPath` within `src/godot/detector.ts`.
🎯 **Why:** To avoid creating unnecessary array allocations just to access the first line of the output from `where`/`which` child processes.
📊 **Impact:** Reduces array memory allocations and minor garbage collection overhead during binary detection.
🔬 **Measurement:** Code logic functions identically, verified by the existing detector tests which continue to pass smoothly (`bun run test tests/godot/detector.test.ts`).

---
*PR created automatically by Jules for task [2124456362853105679](https://jules.google.com/task/2124456362853105679) started by @n24q02m*