### PR TITLE
🛡️ Sentinel: [HIGH] Fix CLI Argument Injection in project run

### DIFF
--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -117,6 +117,9 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (scenePath && (scenePath.includes('\n') || scenePath.includes('\r'))) {
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain newlines.')
       }
+      if (scenePath && scenePath.startsWith('-')) {
+        throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not start with a hyphen.')
+      }
 
       const { pid } = runGodotProject(
         config.godotPath,

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -117,7 +117,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (scenePath && (scenePath.includes('\n') || scenePath.includes('\r'))) {
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain newlines.')
       }
-      if (scenePath && scenePath.startsWith('-')) {
+      if (scenePath?.startsWith('-')) {
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not start with a hyphen.')
       }
 

--- a/tests/composite/project-run-security.test.ts
+++ b/tests/composite/project-run-security.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { handleProject } from '../../src/tools/composite/project.js'
+import { makeConfig } from '../fixtures.js'
+import { runGodotProject } from '../../src/godot/headless.js'
+
+vi.mock('../../src/godot/headless.js', () => ({
+  execGodotAsync: vi.fn(),
+  execGodotSync: vi.fn(),
+  runGodotProject: vi.fn().mockReturnValue({ pid: 12345 }),
+}))
+
+describe('project run security', () => {
+  let config: ReturnType<typeof makeConfig>;
+
+  beforeEach(() => {
+    config = makeConfig({ projectPath: '/valid/path', godotPath: '/godot' })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should reject scene_path starting with a hyphen', async () => {
+    await expect(
+      handleProject('run', { project_path: '/valid/path', scene_path: '--script=malicious.gd' }, config)
+    ).rejects.toThrow('Invalid scene path')
+
+    expect(runGodotProject).not.toHaveBeenCalled()
+  })
+})

--- a/tests/composite/project-run-security.test.ts
+++ b/tests/composite/project-run-security.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { runGodotProject } from '../../src/godot/headless.js'
 import { handleProject } from '../../src/tools/composite/project.js'
 import { makeConfig } from '../fixtures.js'
-import { runGodotProject } from '../../src/godot/headless.js'
 
 vi.mock('../../src/godot/headless.js', () => ({
   execGodotAsync: vi.fn(),
@@ -10,7 +10,7 @@ vi.mock('../../src/godot/headless.js', () => ({
 }))
 
 describe('project run security', () => {
-  let config: ReturnType<typeof makeConfig>;
+  let config: ReturnType<typeof makeConfig>
 
   beforeEach(() => {
     config = makeConfig({ projectPath: '/valid/path', godotPath: '/godot' })
@@ -22,7 +22,7 @@ describe('project run security', () => {
 
   it('should reject scene_path starting with a hyphen', async () => {
     await expect(
-      handleProject('run', { project_path: '/valid/path', scene_path: '--script=malicious.gd' }, config)
+      handleProject('run', { project_path: '/valid/path', scene_path: '--script=malicious.gd' }, config),
     ).rejects.toThrow('Invalid scene path')
 
     expect(runGodotProject).not.toHaveBeenCalled()


### PR DESCRIPTION
Fixed a vulnerability in the `run` action where an arbitrary scene path starting with `-` could be executed as a CLI argument by the Godot Engine, leading to command injection.

---
*PR created automatically by Jules for task [16231497208115458589](https://jules.google.com/task/16231497208115458589) started by @n24q02m*