### PR TITLE
🛡️ Sentinel: [HIGH] Fix Command Injection Risk in Godot run action

### DIFF
--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -117,6 +117,9 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (scenePath && (scenePath.includes('\n') || scenePath.includes('\r'))) {
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain newlines.')
       }
+      if (typeof scenePath === 'string' && scenePath.startsWith('-')) {
+        throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not start with a hyphen.')
+      }
 
       const { pid } = runGodotProject(
         config.godotPath,

--- a/tests/composite/project-run-security.test.ts
+++ b/tests/composite/project-run-security.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleProject } from '../../src/tools/composite/project.js'
+import { createTmpProject, makeConfig } from '../fixtures.js'
+
+// Mock headless execution
+vi.mock('../../src/godot/headless.js', () => ({
+  execGodotAsync: vi.fn(),
+  execGodotSync: vi.fn(),
+  runGodotProject: vi.fn().mockReturnValue({ pid: 123 }),
+}))
+
+import { runGodotProject } from '../../src/godot/headless.js'
+
+describe('project run security', () => {
+  let projectPath: string
+  let cleanup: () => void
+  let config: GodotConfig
+
+  beforeEach(() => {
+    const tmp = createTmpProject()
+    projectPath = tmp.projectPath
+    cleanup = tmp.cleanup
+    config = makeConfig({ projectPath, godotPath: '/path/to/godot' })
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('should reject scene_path starting with a hyphen', async () => {
+    await expect(
+      handleProject(
+        'run',
+        {
+          project_path: projectPath,
+          scene_path: '--script=malicious.gd',
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid scene path')
+
+    expect(runGodotProject).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Fixed a security issue in the `project.ts` file related to command injection. If the `scene_path` argument provided to the `run` action starts with a hyphen, it is passed to the underlying `godot` command as an argument. By preventing any strings that start with `-` as the scene path, this vector is closed. Added unit tests for this issue.

---
*PR created automatically by Jules for task [4928481471042966539](https://jules.google.com/task/4928481471042966539) started by @n24q02m*