### PR TITLE
🛡️ Sentinel: [HIGH] Fix Argument Injection in project run action

### DIFF
--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -114,6 +114,10 @@ export async function handleProject(action: string, args: Record<string, unknown
       }
 
       const scenePath = args.scene_path as string
+      if (typeof args.scene_path === 'string' && args.scene_path.startsWith('-')) {
+        throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not start with a hyphen.')
+      }
+
       if (scenePath && (scenePath.includes('\n') || scenePath.includes('\r'))) {
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain newlines.')
       }

--- a/tests/composite/project-run-security.test.ts
+++ b/tests/composite/project-run-security.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleProject } from '../../src/tools/composite/project.js'
+import { createTmpProject, makeConfig } from '../fixtures.js'
+
+vi.mock('../../src/godot/headless.js', () => ({
+  execGodotAsync: vi.fn().mockResolvedValue({ success: true, stdout: '', stderr: '', exitCode: 0 }),
+  execGodotSync: vi.fn(),
+  runGodotProject: vi.fn(() => ({ pid: 12345 })),
+}))
+
+import { runGodotProject } from '../../src/godot/headless.js'
+
+describe('project run security', () => {
+  let projectPath: string
+  let cleanup: () => void
+  let config: GodotConfig
+
+  beforeEach(() => {
+    const tmp = createTmpProject()
+    projectPath = tmp.projectPath
+    cleanup = tmp.cleanup
+    config = makeConfig({ projectPath, godotPath: '/path/to/godot' })
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('should reject scene_path starting with a hyphen', async () => {
+    await expect(
+      handleProject(
+        'run',
+        {
+          project_path: projectPath,
+          scene_path: '--script=malicious.gd',
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid scene path')
+
+    expect(runGodotProject).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
- **🛡️ Vulnerability**: Argument Injection. A malicious user could pass a `scene_path` starting with a hyphen (e.g. `--script=malicious.gd`) to the `run` action of the project tool. This string would be passed directly as an argument to the Godot child process, executing arbitrary engine commands.
- **🎯 Impact**: High. Could allow execution of malicious scripts or arbitrary CLI commands within the server's environment context.
- **🔧 Fix**: Added a validation check ensuring that `scene_path` does not begin with a hyphen (`-`). If it does, a `GodotMCPError` is thrown, mirroring the existing protection for `project_path`.
- **✅ Verification**: Included a new unit test in `tests/composite/project-run-security.test.ts` to assert that paths beginning with a hyphen are rejected. All tests pass successfully.

---
*PR created automatically by Jules for task [2961415850038701316](https://jules.google.com/task/2961415850038701316) started by @n24q02m*