### PR TITLE
🛡️ Sentinel: [HIGH] Fix argument injection in project run action

### DIFF
--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -117,6 +117,9 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (scenePath && (scenePath.includes('\n') || scenePath.includes('\r'))) {
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain newlines.')
       }
+      if (typeof scenePath === 'string' && scenePath.startsWith('-')) {
+        throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not start with a hyphen.')
+      }
 
       const { pid } = runGodotProject(
         config.godotPath,

--- a/tests/composite/project-run-security.test.ts
+++ b/tests/composite/project-run-security.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { runGodotProject } from '../../src/godot/headless.js'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleProject } from '../../src/tools/composite/project.js'
+import { createTmpProject, makeConfig } from '../fixtures.js'
+
+vi.mock('../../src/godot/headless.js', () => ({
+  execGodotAsync: vi.fn().mockResolvedValue({ success: true, stdout: '', stderr: '', exitCode: 0 }),
+  execGodotSync: vi.fn(),
+  runGodotProject: vi.fn().mockReturnValue({ pid: 12345 }),
+}))
+
+describe('project run security', () => {
+  let projectPath: string
+  let cleanup: () => void
+  let config: GodotConfig
+
+  beforeEach(() => {
+    const tmp = createTmpProject()
+    projectPath = tmp.projectPath
+    cleanup = tmp.cleanup
+    config = makeConfig({ projectPath, godotPath: '/path/to/godot' })
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('should reject scene_path starting with a hyphen', async () => {
+    await expect(
+      handleProject(
+        'run',
+        {
+          project_path: projectPath,
+          scene_path: '--script=malicious.gd',
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid scene path')
+
+    expect(runGodotProject).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `scene_path` argument in the project's `run` action was passed directly to the `runGodotProject` child process spawner without validating if it started with a hyphen. This allows an attacker to pass a CLI flag (e.g., `--script=malicious.gd`) instead of a valid scene path, leading to argument injection.
🎯 **Impact:** An attacker could execute arbitrary GDScript files or otherwise alter the behavior of the Godot executable by injecting unintended CLI flags.
🔧 **Fix:** Added validation in `src/tools/composite/project.ts` to reject `scene_path` strings that start with a hyphen (`-`), throwing a `GodotMCPError`. Also added a comprehensive test in `tests/composite/project-run-security.test.ts`.
✅ **Verification:** Verified by running the test suite (`bun run test`). All 786 tests across 51 files passed.

---
*PR created automatically by Jules for task [18003998402561986615](https://jules.google.com/task/18003998402561986615) started by @n24q02m*