### PR TITLE
🛡️ Sentinel: [HIGH] Fix argument injection in scene path

### DIFF
--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -114,6 +114,9 @@ export async function handleProject(action: string, args: Record<string, unknown
       }
 
       const scenePath = args.scene_path as string
+      if (typeof scenePath === 'string' && scenePath.startsWith('-')) {
+        throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not start with a hyphen.')
+      }
       if (scenePath && (scenePath.includes('\n') || scenePath.includes('\r'))) {
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain newlines.')
       }

--- a/tests/security/scene-argument-injection.test.ts
+++ b/tests/security/scene-argument-injection.test.ts
@@ -1,6 +1,6 @@
-import { expect, it, vi, describe, beforeEach } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
 import { handleProject } from '../../src/tools/composite/project.js'
-import { runGodotProject } from '../../src/godot/headless.js'
 
 vi.mock('../../src/godot/headless.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/godot/headless.js')>()
@@ -16,7 +16,7 @@ describe('Scene Path Argument Injection', () => {
   })
 
   it('should reject scene_path starting with hyphen', async () => {
-    const config = { godotPath: '/bin/godot', projectPath: '/tmp/proj', activePids: [] }
+    const config = { godotPath: '/bin/godot', projectPath: '/tmp/proj', activePids: [] } as unknown as GodotConfig
 
     // Simulate malicious input
     const args = {
@@ -24,6 +24,6 @@ describe('Scene Path Argument Injection', () => {
       scene_path: '--script=malicious.gd',
     }
 
-    await expect(handleProject('run', args, config as any)).rejects.toThrow('Invalid scene path')
+    await expect(handleProject('run', args, config)).rejects.toThrow('Invalid scene path')
   })
 })

--- a/tests/security/scene-argument-injection.test.ts
+++ b/tests/security/scene-argument-injection.test.ts
@@ -1,0 +1,29 @@
+import { expect, it, vi, describe, beforeEach } from 'vitest'
+import { handleProject } from '../../src/tools/composite/project.js'
+import { runGodotProject } from '../../src/godot/headless.js'
+
+vi.mock('../../src/godot/headless.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/godot/headless.js')>()
+  return {
+    ...actual,
+    runGodotProject: vi.fn().mockReturnValue({ pid: 1234 }),
+  }
+})
+
+describe('Scene Path Argument Injection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should reject scene_path starting with hyphen', async () => {
+    const config = { godotPath: '/bin/godot', projectPath: '/tmp/proj', activePids: [] }
+
+    // Simulate malicious input
+    const args = {
+      action: 'run',
+      scene_path: '--script=malicious.gd',
+    }
+
+    await expect(handleProject('run', args, config as any)).rejects.toThrow('Invalid scene path')
+  })
+})


### PR DESCRIPTION
Fixes an argument injection vulnerability where a user could provide a `scene_path` starting with a hyphen (e.g. `--script=malicious.gd`) to the `run` action, causing the Godot binary to interpret it as a command line flag. The fix validates that the string does not start with a hyphen.

---
*PR created automatically by Jules for task [7681473590800688894](https://jules.google.com/task/7681473590800688894) started by @n24q02m*