### PR TITLE
⚡ Bolt: optimize first-line parsing in findInPath

### DIFF
--- a/src/godot/detector.ts
+++ b/src/godot/detector.ts
@@ -150,7 +150,12 @@ function findInPath(): string | null {
         stdio: ['pipe', 'pipe', 'pipe'],
         encoding: 'utf-8',
       })
-      const path = result.trim().split('\n')[0].trim()
+
+      const trimmedResult = result.trim()
+      // ⚡ Bolt: Replace .split('\n')[0] with indexOf and slice to avoid array allocation
+      const newlineIndex = trimmedResult.indexOf('\n')
+      const path = (newlineIndex === -1 ? trimmedResult : trimmedResult.slice(0, newlineIndex)).trim()
+
       if (path && isExecutable(path)) return path
     } catch {
       // Not found, continue


### PR DESCRIPTION
💡 What: Replaced `.split('\n')[0]` with `.indexOf('\n')` and `.slice()` in `findInPath`.
🎯 Why: To avoid unnecessary array allocations and reduce garbage collection overhead when parsing command outputs.
📊 Impact: Eliminates the creation of a temporary array when retrieving the path output from system commands, making the execution path slightly faster and more memory efficient.
🔬 Measurement: Run `bun run test tests/godot/detector.test.ts` to verify the logic still correctly parses the path outputs.

---
*PR created automatically by Jules for task [13211244374674179648](https://jules.google.com/task/13211244374674179648) started by @n24q02m*