### PR TITLE
⚡ Bolt: Optimize physics layer string replacement

### DIFF
--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -29,9 +29,11 @@ export async function handlePhysics(action: string, args: Record<string, unknown
 
       for (const [key, value] of settings.sections.get('layer_names') || []) {
         if (key.startsWith('2d_physics/layer_')) {
-          layers2d[key] = value.replace(/"/g, '')
+          // ⚡ Bolt: Using replaceAll('"', '') avoids RegExp allocation overhead
+          layers2d[key] = value.replaceAll('"', '')
         } else if (key.startsWith('3d_physics/layer_')) {
-          layers3d[key] = value.replace(/"/g, '')
+          // ⚡ Bolt: Using replaceAll('"', '') avoids RegExp allocation overhead
+          layers3d[key] = value.replaceAll('"', '')
         }
       }
 


### PR DESCRIPTION
💡 What: Replaced `.replace(/"/g, '')` with `.replaceAll('"', '')` in the physics layers parser.
🎯 Why: To eliminate unnecessary RegExp compilation and instantiation overhead during string processing inside the `layers` action iteration loop.
📊 Impact: Minor reduction in memory allocation pressure and execution time for the hot loop handling Godot project settings for physics layer names.
🔬 Measurement: Verified the logic remains identical via `bun run test tests/composite/physics.test.ts`. This is a micro-optimization of the fast-path parser pattern.

---
*PR created automatically by Jules for task [17217114154416368794](https://jules.google.com/task/17217114154416368794) started by @n24q02m*