### PR TITLE
⚡ Bolt: Hoist static valid tools map array to reduce allocations

### DIFF
--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -480,6 +480,7 @@ const P3_TOOLS = [
 ]
 
 const TOOLS = [...P0_TOOLS, ...P1_TOOLS, ...P2_TOOLS, ...P3_TOOLS]
+const VALID_TOOL_NAMES = TOOLS.map((t) => t.name)
 
 type ToolHandler = (
   action: string,
@@ -527,13 +528,12 @@ export function registerTools(server: Server, config: GodotConfig): void {
       } else {
         const handler = TOOL_HANDLERS[name]
         if (!handler) {
-          const validTools = TOOLS.map((t) => t.name)
-          const closest = findClosestMatch(name, validTools)
+          const closest = findClosestMatch(name, VALID_TOOL_NAMES)
           const suggestion = closest ? ` Did you mean '${closest}'?` : ''
           throw new GodotMCPError(
             `Unknown tool: ${name}.${suggestion}`,
             'INVALID_ACTION',
-            `Available tools: ${validTools.join(', ')}`,
+            `Available tools: ${VALID_TOOL_NAMES.join(', ')}`,
           )
         }
         result = await handler(args.action as string, args as Record<string, unknown>, config)


### PR DESCRIPTION
💡 What: Extracted `TOOLS.map((t) => t.name)` into a pre-computed module-level constant `VALID_TOOL_NAMES`.
🎯 Why: Inside the `CallToolRequestSchema` request handler, generating the list of available tools when an unknown tool was called caused a redundant map array allocation and garbage collection overhead.
📊 Impact: Eliminates array allocation on the `INVALID_ACTION` error path, slightly optimizing the server handler's memory footprint when handling malformed requests.
🔬 Measurement: Verify that `bun run test tests/registry-handler.test.ts` still successfully catches invalid tool calls and provides the full list of available tools.

---
*PR created automatically by Jules for task [11198345405956701571](https://jules.google.com/task/11198345405956701571) started by @n24q02m*