### PR TITLE
🛡️ Sentinel: [HIGH] Fix Path Argument Injection in Godot Run Action

### DIFF
--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -117,6 +117,9 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (scenePath && (scenePath.includes('\n') || scenePath.includes('\r'))) {
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain newlines.')
       }
+      if (typeof scenePath === 'string' && scenePath.startsWith('-')) {
+        throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not start with a hyphen.')
+      }
 
       const { pid } = runGodotProject(
         config.godotPath,

--- a/tests/security/scene-argument-injection.test.ts
+++ b/tests/security/scene-argument-injection.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleProject } from '../../src/tools/composite/project.js'
+
+vi.mock('../../src/godot/headless.js', () => ({
+  runGodotProject: vi.fn().mockReturnValue({ pid: 12345 }),
+}))
+
+describe('Scene Argument Injection', () => {
+  it('should reject scene_path starting with a hyphen', async () => {
+    const config = {
+      godotPath: '/path/to/godot',
+      projectPath: '/path/to/project',
+      activePids: [],
+    } as unknown as GodotConfig
+
+    await expect(
+      handleProject('run', { project_path: '/path/to/project', scene_path: '--script=malicious.gd' }, config),
+    ).rejects.toThrow('Invalid scene path')
+  })
+})


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Path Argument Injection
🎯 **Impact:** If an attacker can control the `scene_path` argument, they could pass arbitrary command-line flags to the `spawn`ed Godot executable. For example, providing `--script=malicious.gd` could lead to arbitrary code execution within the context of the Godot engine.
🔧 **Fix:** Added validation to explicitly reject any `scene_path` string that starts with a hyphen (`-`). This matches the existing security checks applied to `project_path`, `preset`, and `output_path`.
✅ **Verification:** Added `tests/security/scene-argument-injection.test.ts` to verify that `handleProject('run', { ... scene_path: '--script=malicious.gd' })` correctly throws an error.

---
*PR created automatically by Jules for task [17232497090573075779](https://jules.google.com/task/17232497090573075779) started by @n24q02m*