### PR TITLE
⚡ Bolt: Optimize valid tool name generation in registry

### DIFF
--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -480,6 +480,8 @@ const P3_TOOLS = [
 ]
 
 const TOOLS = [...P0_TOOLS, ...P1_TOOLS, ...P2_TOOLS, ...P3_TOOLS]
+// ⚡ Bolt: Pre-calculate valid tool names once to avoid array allocation on every unknown tool request
+const VALID_TOOL_NAMES = TOOLS.map((t) => t.name)
 
 type ToolHandler = (
   action: string,
@@ -527,7 +529,7 @@ export function registerTools(server: Server, config: GodotConfig): void {
       } else {
         const handler = TOOL_HANDLERS[name]
         if (!handler) {
-          const validTools = TOOLS.map((t) => t.name)
+          const validTools = VALID_TOOL_NAMES
           const closest = findClosestMatch(name, validTools)
           const suggestion = closest ? ` Did you mean '${closest}'?` : ''
           throw new GodotMCPError(


### PR DESCRIPTION
## What
Hoisted the `TOOLS.map((t) => t.name)` computation in `src/tools/registry.ts` to module-level scope. 

## Why
Previously, the `CallToolRequestSchema` handler in `registry.ts` would calculate `validTools` by mapping the array *inside* the check for an unknown tool. This is a small performance bottleneck on hot paths dealing with parsing requests and throwing errors for unknown tools. 

## Impact
Reduces an Array allocation and loop execution out of the tool invocation code path. 

## Measurement
All unit tests pass and code style constraints are preserved.

---
*PR created automatically by Jules for task [8706974445654398151](https://jules.google.com/task/8706974445654398151) started by @n24q02m*