### PR TITLE
🛡️ Sentinel: [HIGH] Fix Scene Injection vulnerability in scripts and tilemap

### DIFF
--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -9,6 +9,7 @@ import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
 import { escapeRegExp } from '../helpers/scene-parser.js'
+import { validateNoNewlines } from '../helpers/security.js'
 
 const NODE_SECTION_RE = /(\[node [^\]]+\])/
 
@@ -132,7 +133,9 @@ async function createScript(args: Record<string, unknown>, resolvePath: (path: s
   const scriptPath = args.script_path as string
   if (!scriptPath)
     throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path (e.g., "player.gd").')
+  validateNoNewlines(undefined, scriptPath)
   const extendsType = (args.extends as string) || 'Node'
+  validateNoNewlines(undefined, extendsType)
   const content = (args.content as string) || getTemplate(extendsType)
 
   const fullPath = resolvePath(scriptPath)
@@ -152,6 +155,7 @@ async function createScript(args: Record<string, unknown>, resolvePath: (path: s
 async function readScript(args: Record<string, unknown>, resolvePath: (path: string) => string) {
   const scriptPath = args.script_path as string
   if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path.')
+  validateNoNewlines(undefined, scriptPath)
 
   const fullPath = resolvePath(scriptPath)
   if (!(await pathExists(fullPath)))
@@ -164,6 +168,7 @@ async function readScript(args: Record<string, unknown>, resolvePath: (path: str
 async function writeScript(args: Record<string, unknown>, resolvePath: (path: string) => string) {
   const scriptPath = args.script_path as string
   if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path.')
+  validateNoNewlines(undefined, scriptPath)
   const content = args.content as string
   if (content === undefined || content === null)
     throw new GodotMCPError('No content specified', 'INVALID_ARGS', 'Provide content to write.')
@@ -185,6 +190,7 @@ async function attachScript(args: Record<string, unknown>, resolvePath: (path: s
       'Provide scene_path and script_path.',
     )
   }
+  validateNoNewlines(undefined, scenePath, scriptPath, nodeName)
 
   const sceneFullPath = resolvePath(scenePath)
   if (!(await pathExists(sceneFullPath)))
@@ -234,6 +240,7 @@ async function listScripts(baseDir: string, projectPath: string | undefined) {
 async function deleteScript(args: Record<string, unknown>, resolvePath: (path: string) => string) {
   const scriptPath = args.script_path as string
   if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path to delete.')
+  validateNoNewlines(undefined, scriptPath)
 
   const fullPath = resolvePath(scriptPath)
   if (!(await pathExists(fullPath)))

--- a/src/tools/composite/tilemap.ts
+++ b/src/tools/composite/tilemap.ts
@@ -9,6 +9,7 @@ import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
+import { validateNoNewlines } from '../helpers/security.js'
 
 /**
  * Async helper to check file existence without blocking the event loop
@@ -34,6 +35,7 @@ export async function handleTilemap(action: string, args: Record<string, unknown
           'INVALID_ARGS',
           'Provide tileset_path (e.g., "tilesets/main.tres").',
         )
+      validateNoNewlines(undefined, tilesetPath)
       const tileSize = (args.tile_size as number) || 16
 
       const fullPath = safeResolve(projectPath || process.cwd(), tilesetPath)
@@ -66,6 +68,7 @@ export async function handleTilemap(action: string, args: Record<string, unknown
       if (!tilesetPath || !texturePath) {
         throw new GodotMCPError('tileset_path and texture_path required', 'INVALID_ARGS', 'Both are required.')
       }
+      validateNoNewlines(undefined, tilesetPath, texturePath)
 
       const fullPath = safeResolve(projectPath || process.cwd(), tilesetPath)
 
@@ -103,6 +106,7 @@ export async function handleTilemap(action: string, args: Record<string, unknown
       const scenePath = args.scene_path as string
       if (!scenePath)
         throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path with TileMapLayer node.')
+      validateNoNewlines(undefined, scenePath)
 
       return formatSuccess(
         'TileMap painting requires modifying tile_map_data which is binary-encoded.\n' +
@@ -114,6 +118,7 @@ export async function handleTilemap(action: string, args: Record<string, unknown
     case 'list': {
       const scenePath = args.scene_path as string
       if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+      validateNoNewlines(undefined, scenePath)
 
       const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
 


### PR DESCRIPTION
Added `validateNoNewlines` checks for user-provided paths and arguments in `src/tools/composite/scripts.ts` and `src/tools/composite/tilemap.ts`. This security enhancement prevents attackers from injecting arbitrary newlines into `.tscn` and `.tres` templates, thereby defending against Scene Injection attacks.

---
*PR created automatically by Jules for task [12725912526797063181](https://jules.google.com/task/12725912526797063181) started by @n24q02m*