### PR TITLE
fix(security): block argument and scene file injection across tools

### DIFF
--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -114,8 +114,14 @@ export async function handleProject(action: string, args: Record<string, unknown
       }
 
       const scenePath = args.scene_path as string
+      if (scenePath !== undefined && typeof scenePath !== 'string') {
+        throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must be a string.')
+      }
       if (scenePath && (scenePath.includes('\n') || scenePath.includes('\r'))) {
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain newlines.')
+      }
+      if (scenePath?.startsWith('-')) {
+        throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not start with a hyphen.')
       }
 
       const { pid } = runGodotProject(

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -264,8 +264,8 @@ export async function handleScenes(action: string, args: Record<string, unknown>
 
     case 'set_main': {
       // projectPath and scenePath are guaranteed
-      if (scenePath.includes('"')) {
-        throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain quotes.')
+      if (scenePath.includes('"') || scenePath.includes('\n') || scenePath.includes('\r')) {
+        throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain quotes or newlines.')
       }
 
       const configPath = join(safeResolve(baseDir, projectPath as string), 'project.godot')

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -186,6 +186,21 @@ async function attachScript(args: Record<string, unknown>, resolvePath: (path: s
     )
   }
 
+  if (scriptPath.includes('\n') || scriptPath.includes('\r') || scriptPath.includes('"')) {
+    throw new GodotMCPError(
+      'Invalid script path',
+      'INVALID_ARGS',
+      'Script path must not contain newlines or double quotes.',
+    )
+  }
+  if (nodeName && (nodeName.includes('\n') || nodeName.includes('\r') || nodeName.includes('"'))) {
+    throw new GodotMCPError(
+      'Invalid node name',
+      'INVALID_ARGS',
+      'Node name must not contain newlines or double quotes.',
+    )
+  }
+
   const sceneFullPath = resolvePath(scenePath)
   if (!(await pathExists(sceneFullPath)))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')

--- a/src/tools/composite/tilemap.ts
+++ b/src/tools/composite/tilemap.ts
@@ -67,6 +67,14 @@ export async function handleTilemap(action: string, args: Record<string, unknown
         throw new GodotMCPError('tileset_path and texture_path required', 'INVALID_ARGS', 'Both are required.')
       }
 
+      if (texturePath.includes('\n') || texturePath.includes('\r') || texturePath.includes('"')) {
+        throw new GodotMCPError(
+          'Invalid texture path',
+          'INVALID_ARGS',
+          'Texture path must not contain newlines or double quotes.',
+        )
+      }
+
       const fullPath = safeResolve(projectPath || process.cwd(), tilesetPath)
 
       // Performance optimization: using async pathExists instead of existsSync

--- a/tests/composite/project-security.test.ts
+++ b/tests/composite/project-security.test.ts
@@ -11,7 +11,7 @@ import { createTmpProject, makeConfig } from '../fixtures.js'
 vi.mock('../../src/godot/headless.js', () => ({
   execGodotAsync: vi.fn().mockResolvedValue({ success: true, stdout: '', stderr: '', exitCode: 0 }),
   execGodotSync: vi.fn(),
-  runGodotProject: vi.fn(),
+  runGodotProject: vi.fn().mockReturnValue({ pid: 12345 }),
 }))
 
 // Mock child_process for stop command
@@ -19,7 +19,7 @@ vi.mock('node:child_process', () => ({
   execFileSync: vi.fn(),
 }))
 
-import { execGodotAsync } from '../../src/godot/headless.js'
+import { execGodotAsync, runGodotProject } from '../../src/godot/headless.js'
 
 describe('project security', () => {
   let projectPath: string
@@ -101,6 +101,80 @@ describe('project security', () => {
 
       expect(result.content[0].text).toContain('Export complete: build/game.exe')
       expect(execGodotAsync).toHaveBeenCalled()
+    })
+
+    it('should reject scene_path starting with a hyphen on run action', async () => {
+      await expect(
+        handleProject(
+          'run',
+          {
+            project_path: projectPath,
+            scene_path: '--script=malicious.gd',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid scene path')
+
+      expect(runGodotProject).not.toHaveBeenCalled()
+    })
+
+    it('should reject scene_path with a leading hyphen even if it looks pathy', async () => {
+      await expect(
+        handleProject(
+          'run',
+          {
+            project_path: projectPath,
+            scene_path: '-x',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid scene path')
+
+      expect(runGodotProject).not.toHaveBeenCalled()
+    })
+
+    it('should reject scene_path containing a newline on run action', async () => {
+      await expect(
+        handleProject(
+          'run',
+          {
+            project_path: projectPath,
+            scene_path: 'main.tscn\n--script=bad.gd',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid scene path')
+
+      expect(runGodotProject).not.toHaveBeenCalled()
+    })
+
+    it('should reject non-string scene_path on run action', async () => {
+      await expect(
+        handleProject(
+          'run',
+          {
+            project_path: projectPath,
+            scene_path: 42,
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid scene path')
+
+      expect(runGodotProject).not.toHaveBeenCalled()
+    })
+
+    it('should allow a safe scene_path on run action', async () => {
+      const result = await handleProject(
+        'run',
+        {
+          project_path: projectPath,
+          scene_path: 'scenes/main.tscn',
+        },
+        config,
+      )
+
+      expect(result.content[0].text).toContain('Godot project started')
+      expect(runGodotProject).toHaveBeenCalled()
     })
 
     it('should reject preset or output_path that are not strings', async () => {

--- a/tests/composite/scenes-security.test.ts
+++ b/tests/composite/scenes-security.test.ts
@@ -80,4 +80,30 @@ describe('Scenes Tool Security', () => {
       ),
     ).rejects.toThrow('Invalid root type')
   })
+
+  it('should prevent newline injection in scene_path (set_main)', async () => {
+    const maliciousScene = 'main.tscn\n[malicious]\nrun/main_scene="res://evil.tscn"'
+
+    await expect(
+      handleScenes(
+        'set_main',
+        {
+          scene_path: maliciousScene,
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid scene path')
+  })
+
+  it('should still reject quote injection in scene_path (set_main)', async () => {
+    await expect(
+      handleScenes(
+        'set_main',
+        {
+          scene_path: 'main.tscn"\nrun/main_scene="res://evil.tscn',
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid scene path')
+  })
 })

--- a/tests/composite/scripts-security.test.ts
+++ b/tests/composite/scripts-security.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Security tests for Scripts tool - prevent .tscn file injection via attach
+ */
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleScripts } from '../../src/tools/composite/scripts.js'
+import { createTmpProject, createTmpScene, createTmpScript, makeConfig } from '../fixtures.js'
+
+describe('scripts security', () => {
+  let projectPath: string
+  let cleanup: () => void
+  let config: GodotConfig
+
+  beforeEach(() => {
+    const tmp = createTmpProject()
+    projectPath = tmp.projectPath
+    cleanup = tmp.cleanup
+    config = makeConfig({ projectPath })
+
+    createTmpScene(projectPath, 'scenes/main.tscn')
+    createTmpScript(projectPath, 'player.gd')
+  })
+
+  afterEach(() => cleanup())
+
+  describe('attach action - script_path injection prevention', () => {
+    it('rejects script_path with newline', async () => {
+      await expect(
+        handleScripts(
+          'attach',
+          {
+            project_path: projectPath,
+            scene_path: 'scenes/main.tscn',
+            script_path: 'player.gd")\n[node name="Pwn" type="Node"]\nscript = ExtResource("x.gd',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid script path')
+    })
+
+    it('rejects script_path with carriage return', async () => {
+      await expect(
+        handleScripts(
+          'attach',
+          {
+            project_path: projectPath,
+            scene_path: 'scenes/main.tscn',
+            script_path: 'player.gd\r[node name="Pwn"]',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid script path')
+    })
+
+    it('rejects script_path containing double quotes', async () => {
+      await expect(
+        handleScripts(
+          'attach',
+          {
+            project_path: projectPath,
+            scene_path: 'scenes/main.tscn',
+            script_path: 'player.gd") injected="true',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid script path')
+    })
+
+    it('rejects node_name with newline', async () => {
+      await expect(
+        handleScripts(
+          'attach',
+          {
+            project_path: projectPath,
+            scene_path: 'scenes/main.tscn',
+            script_path: 'player.gd',
+            node_name: 'Root\n[node name="Pwn"]',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid node name')
+    })
+
+    it('rejects node_name containing double quotes', async () => {
+      await expect(
+        handleScripts(
+          'attach',
+          {
+            project_path: projectPath,
+            scene_path: 'scenes/main.tscn',
+            script_path: 'player.gd',
+            node_name: 'Root"]\n[node name="Pwn',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid node name')
+    })
+
+    it('still attaches a clean script path successfully', async () => {
+      await handleScripts(
+        'attach',
+        {
+          project_path: projectPath,
+          scene_path: 'scenes/main.tscn',
+          script_path: 'player.gd',
+        },
+        config,
+      )
+
+      const updated = readFileSync(join(projectPath, 'scenes/main.tscn'), 'utf-8')
+      expect(updated).toContain('script = ExtResource("res://player.gd")')
+      // Ensure no extra injected nodes
+      expect(updated.match(/\[node /g)?.length).toBe(1)
+    })
+  })
+})

--- a/tests/composite/tilemap-security.test.ts
+++ b/tests/composite/tilemap-security.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Security tests for Tilemap tool - prevent .tres injection via add_source
+ */
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleTilemap } from '../../src/tools/composite/tilemap.js'
+import { createTmpProject, makeConfig } from '../fixtures.js'
+
+describe('tilemap security', () => {
+  let projectPath: string
+  let cleanup: () => void
+  let config: GodotConfig
+
+  beforeEach(async () => {
+    const tmp = createTmpProject()
+    projectPath = tmp.projectPath
+    cleanup = tmp.cleanup
+    config = makeConfig({ projectPath })
+
+    await handleTilemap('create_tileset', { project_path: projectPath, tileset_path: 'tilesets/main.tres' }, config)
+  })
+
+  afterEach(() => cleanup())
+
+  describe('add_source - texture_path injection prevention', () => {
+    it('rejects texture_path containing a newline', async () => {
+      await expect(
+        handleTilemap(
+          'add_source',
+          {
+            project_path: projectPath,
+            tileset_path: 'tilesets/main.tres',
+            texture_path: 'sprites/grass.png"]\n[ext_resource type="Script" path="res://evil.gd" id="0',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid texture path')
+    })
+
+    it('rejects texture_path containing a carriage return', async () => {
+      await expect(
+        handleTilemap(
+          'add_source',
+          {
+            project_path: projectPath,
+            tileset_path: 'tilesets/main.tres',
+            texture_path: 'sprites/grass.png\r[ext_resource]',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid texture path')
+    })
+
+    it('rejects texture_path containing double quotes', async () => {
+      await expect(
+        handleTilemap(
+          'add_source',
+          {
+            project_path: projectPath,
+            tileset_path: 'tilesets/main.tres',
+            texture_path: 'sprites/grass.png" id="injected',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid texture path')
+    })
+
+    it('still adds clean texture path successfully', async () => {
+      await handleTilemap(
+        'add_source',
+        {
+          project_path: projectPath,
+          tileset_path: 'tilesets/main.tres',
+          texture_path: 'sprites/grass.png',
+        },
+        config,
+      )
+
+      const updated = readFileSync(join(projectPath, 'tilesets/main.tres'), 'utf-8')
+      expect(updated).toContain('[ext_resource type="Texture2D" path="res://sprites/grass.png"')
+      expect(updated.match(/\[ext_resource/g)?.length).toBe(1)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes the family of HIGH/CRITICAL Sentinel reports about CLI argument injection in `project.run` and scene/resource file injection in `scripts.attach`, `tilemap.add_source`, and `scenes.set_main`. Each vector takes a string parameter that was interpolated either into Godot's CLI args or into a `.tscn` / `.tres` / `project.godot` file without the same hardening already applied to neighboring fields.

- `project.run` now rejects `scene_path` that starts with `-` (would otherwise let an attacker smuggle Godot CLI flags like `--script attack.gd` via the scene argument), enforces string type, and keeps the existing newline check.
- `scripts.attach` validates `script_path` and `node_name` to forbid newlines and double quotes before they are interpolated into `script = ExtResource("res://...")` and the surrounding node header.
- `tilemap.add_source` applies the same newline / double-quote check to `texture_path` before it is written into the tileset `.tres`.
- `scenes.set_main` now rejects newlines in `scene_path` in addition to quotes before it is written into `project.godot`.

This supersedes the duplicate Sentinel PRs that each addressed one of these vectors in isolation: #643, #645, #646, #648, #651, #653, #654, #656, #660, #663.

## Test plan

- [x] `bun run test` — 802 tests pass (17 new), 1 skipped.
- [x] `bun run check` — biome + `tsc --noEmit` clean.
- New `tests/composite/scripts-security.test.ts` covers attach injection via `script_path` and `node_name`.
- New `tests/composite/tilemap-security.test.ts` covers `add_source` injection via `texture_path`.
- Extended `tests/composite/project-security.test.ts` with scene_path hyphen / newline / non-string and happy-path cases for `run`.
- Extended `tests/composite/scenes-security.test.ts` with newline + quote cases for `set_main`.

## Release

CD is `workflow_dispatch` and gated on `main`, so after merge dispatch `CD` with `release_type: beta` to cut a beta on top of v1.18.0.

https://claude.ai/code/session_01DZjYPfxExaH8PZSV1Bictx

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZjYPfxExaH8PZSV1Bictx)_