### PR TITLE
🛡️ Sentinel: [HIGH] Fix command argument injection via scene_path

### DIFF
--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -117,6 +117,10 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (scenePath && (scenePath.includes('\n') || scenePath.includes('\r'))) {
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain newlines.')
       }
+      // Security enhancement: Prevent command argument injection by disallowing paths starting with a hyphen
+      if (scenePath && scenePath.startsWith('-')) {
+        throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not start with a hyphen.')
+      }
 
       const { pid } = runGodotProject(
         config.godotPath,

--- a/tests/composite/project-security.test.ts
+++ b/tests/composite/project-security.test.ts
@@ -103,6 +103,21 @@ describe('project security', () => {
       expect(execGodotAsync).toHaveBeenCalled()
     })
 
+    it('should reject run command with scene_path starting with a hyphen', async () => {
+      await expect(
+        handleProject(
+          'run',
+          {
+            project_path: projectPath,
+            scene_path: '--script=malicious.gd',
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid scene path')
+
+      expect(execGodotAsync).not.toHaveBeenCalled()
+    })
+
     it('should reject preset or output_path that are not strings', async () => {
       await expect(
         handleProject(


### PR DESCRIPTION
Added validation to `src/tools/composite/project.ts` to prevent argument injection via `scene_path` in the `run` command. Specifically, verifies that `scenePath` does not start with a hyphen (`-`). Also added security tests to `tests/composite/project-security.test.ts` to verify that `scene_path` starting with a hyphen is rejected.

---
*PR created automatically by Jules for task [4841058846917787457](https://jules.google.com/task/4841058846917787457) started by @n24q02m*