### PR TITLE
⚡ Bolt: optimize first-line extraction from child process output

### DIFF
--- a/src/godot/detector.ts
+++ b/src/godot/detector.ts
@@ -150,7 +150,10 @@ function findInPath(): string | null {
         stdio: ['pipe', 'pipe', 'pipe'],
         encoding: 'utf-8',
       })
-      const path = result.trim().split('\n')[0].trim()
+      const trimmedResult = result.trim()
+      // ⚡ Bolt: Use indexOf and slice to extract the first line without allocating a temporary array
+      const newlineIdx = trimmedResult.indexOf('\n')
+      const path = (newlineIdx === -1 ? trimmedResult : trimmedResult.slice(0, newlineIdx)).trim()
       if (path && isExecutable(path)) return path
     } catch {
       // Not found, continue


### PR DESCRIPTION
💡 What: Replaced `.split('\n')[0]` with `indexOf('\n')` and `slice()` when parsing the output of `which` or `where` commands in `src/godot/detector.ts`.
🎯 Why: Calling `.split()` on the output of a command allocates an unnecessary intermediate array just to extract the first line. By using `indexOf` and `slice`, we extract the string directly without array creation, reducing garbage collection overhead.
📊 Impact: Minor memory optimization in child process output parsing by preventing array allocations.
🔬 Measurement: Verified with `bun run test` that existing functionality remains fully intact.

---
*PR created automatically by Jules for task [5394242458162645804](https://jules.google.com/task/5394242458162645804) started by @n24q02m*