### PR TITLE
⚡ Bolt: pre-compute valid tools and optimize tool wrapping

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-24 - Pre-compute validTools in registry.ts and optimize array allocations
+**Learning:** In `src/tools/registry.ts`, the `validTools` array was being computed using `TOOLS.map((t) => t.name)` dynamically on every tool invocation error path. In `src/tools/helpers/security.ts`, `wrapToolResult` was allocating a new array using `.map` on hot response paths. While the former is an error path, it could be called frequently for invalid tools or autocomplete features. The latter happens on every result returning content.
+**Action:** Extracted `validTools` computation to module scope instead of doing `TOOLS.map()` inside the request handler. Replaced `.map()` with pre-allocated arrays and loops in `wrapToolResult` to avoid garbage collection overhead.

--- a/src/tools/helpers/security.ts
+++ b/src/tools/helpers/security.ts
@@ -43,12 +43,19 @@ export function wrapToolResult<T extends { content: Array<{ type: string; text: 
     return result
   }
 
-  return {
-    ...result,
-    content: result.content.map((item) => ({
+  // ⚡ Bolt: Use pre-allocated array instead of .map() to avoid memory allocations
+  const wrappedContent = new Array(result.content.length)
+  for (let i = 0; i < result.content.length; i++) {
+    const item = result.content[i]
+    wrappedContent[i] = {
       ...item,
       text: `<untrusted_godot_content>\n${item.text}\n</untrusted_godot_content>\n\n${SAFETY_WARNING}`,
-    })),
+    }
+  }
+
+  return {
+    ...result,
+    content: wrappedContent,
   }
 }
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -480,6 +480,7 @@ const P3_TOOLS = [
 ]
 
 const TOOLS = [...P0_TOOLS, ...P1_TOOLS, ...P2_TOOLS, ...P3_TOOLS]
+const VALID_TOOLS = TOOLS.map((t) => t.name)
 
 type ToolHandler = (
   action: string,
@@ -527,13 +528,12 @@ export function registerTools(server: Server, config: GodotConfig): void {
       } else {
         const handler = TOOL_HANDLERS[name]
         if (!handler) {
-          const validTools = TOOLS.map((t) => t.name)
-          const closest = findClosestMatch(name, validTools)
+          const closest = findClosestMatch(name, VALID_TOOLS)
           const suggestion = closest ? ` Did you mean '${closest}'?` : ''
           throw new GodotMCPError(
             `Unknown tool: ${name}.${suggestion}`,
             'INVALID_ACTION',
-            `Available tools: ${validTools.join(', ')}`,
+            `Available tools: ${VALID_TOOLS.join(', ')}`,
           )
         }
         result = await handler(args.action as string, args as Record<string, unknown>, config)


### PR DESCRIPTION
⚡ Bolt: Pre-compute valid tools and optimize tool wrapping array creation.

💡 What:
1. Moved the `validTools` array computation out of the `CallToolRequestSchema` handler in `src/tools/registry.ts` to module scope (`VALID_TOOLS`).
2. Replaced the `result.content.map()` call in `src/tools/helpers/security.ts` (`wrapToolResult`) with a pre-allocated array and a standard `for` loop.

🎯 Why:
1. `validTools` was being re-computed dynamically using `.map()` on every invalid tool invocation. While it's an error path, it can be called frequently (e.g., during autocomplete or fuzzy matching).
2. `wrapToolResult` is called on *every* tool execution that returns file content. The `.map()` method allocates a new array and creates an intermediate callback closure for each element. A pre-allocated array with a `for` loop avoids these hidden allocations, reducing garbage collection pressure on hot response paths.

📊 Impact:
- Eliminates redundant array map allocations during tool invocation error handling.
- Reduces memory allocations and GC overhead on all successful responses returning untrusted file content.

🔬 Measurement:
Run the Vitest test suite (`bun run test`) to ensure all functionality remains identical. Code passes `bun run check`.

---
*PR created automatically by Jules for task [11467631817363812548](https://jules.google.com/task/11467631817363812548) started by @n24q02m*