### PR TITLE
⚡ Bolt: Optimize regex replacement with replaceAll in physics.ts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-27 - [Optimize findInPath split usage]
 **Learning:** In hot paths or frequently executed lookup functions like `findInPath` in `src/godot/detector.ts`, using `.split('\n')[0]` introduces unnecessary array allocations and garbage collection overhead.
 **Action:** Replace `split('\n')[0]` with `indexOf('\n')` and `slice(0, newlineIdx)` to extract the first line without allocating an intermediate array, adhering to the performance patterns observed in `src/tools/helpers/project-settings.ts` and `src/tools/composite/scenes.ts`. Add `// ⚡ Bolt:` comment to denote intentional optimization.
+
+## 2025-03-02 - [Avoid RegExp compilation for exact string replacements]
+**Learning:** Using `.replace(/"/g, '')` incurs overhead due to instantiating and executing a regular expression.
+**Action:** Use `.replaceAll('"', '')` instead when performing simple, exact string replacements. This avoids RegExp allocation overhead entirely.

--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -28,10 +28,11 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       const layers3d: Record<string, string> = {}
 
       for (const [key, value] of settings.sections.get('layer_names') || []) {
+        // ⚡ Bolt: Use .replaceAll('"', '') instead of .replace(/"/g, '') to avoid RegExp compilation overhead
         if (key.startsWith('2d_physics/layer_')) {
-          layers2d[key] = value.replace(/"/g, '')
+          layers2d[key] = value.replaceAll('"', '')
         } else if (key.startsWith('3d_physics/layer_')) {
-          layers3d[key] = value.replace(/"/g, '')
+          layers3d[key] = value.replaceAll('"', '')
         }
       }
 


### PR DESCRIPTION
💡 What: Replaced `.replace(/"/g, '')` with `.replaceAll('"', '')` in the `handlePhysics` action for layers.
🎯 Why: `.replace(/"/g, '')` instantiates and compiles a regular expression which has a performance cost. For simple string replacements, `.replaceAll` is much faster because it does not incur RegExp allocation overhead.
📊 Impact: Minor speedup when parsing physics layer names from project settings.
🔬 Measurement: Run the test suite (`bun run test tests/composite/physics.test.ts`) to ensure nothing breaks, and observe potential microsecond improvements in execution time.

---
*PR created automatically by Jules for task [12222364372489964793](https://jules.google.com/task/12222364372489964793) started by @n24q02m*