### PR TITLE
🎨 Palette: Document backend-only repository constraints

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Backend Only Repository Constraints
+**Learning:** This repository is a pure backend Model Context Protocol (MCP) server written in TypeScript and Node.js for Godot. It does not contain any frontend user interfaces, web applications, HTML, or UI components, rendering visual UI/UX enhancements inapplicable.
+**Action:** Do not attempt to apply frontend UX or accessibility improvements in this repository. Ensure future tasks are aware of the backend-only nature of the codebase.


### PR DESCRIPTION
This PR creates the `.jules/palette.md` file to log the critical finding that this repository (a backend-only MCP server) contains no frontend UI components, rendering standard UX/UI and accessibility enhancements inapplicable.

---
*PR created automatically by Jules for task [1566927841943825684](https://jules.google.com/task/1566927841943825684) started by @n24q02m*