### PR TITLE
🛡️ Sentinel: [HIGH] Fix XPIA Scene Injection in UI Tool Properties

### DIFF
--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -115,9 +115,24 @@ async function handleCreateControl(projectPath: string | null | undefined, args:
   }
 
   // Add custom properties
-  const props = args.properties as Record<string, string> | undefined
-  if (props) {
-    for (const [key, value] of Object.entries(props)) {
+  if (args.properties !== undefined) {
+    if (typeof args.properties !== 'object' || args.properties === null || Array.isArray(args.properties)) {
+      throw new GodotMCPError(
+        'Invalid properties format',
+        'INVALID_ARGS',
+        'properties must be an object with string keys and values.',
+      )
+    }
+    for (const [key, value] of Object.entries(args.properties)) {
+      if (typeof key !== 'string' || typeof value !== 'string') {
+        throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property keys and values must be strings.')
+      }
+      if (key.includes('=') || key.includes('\n') || key.includes('\r')) {
+        throw new GodotMCPError('Invalid property key', 'INVALID_ARGS', 'Property keys must not contain "=", newlines.')
+      }
+      if (value.includes('\n') || value.includes('\r')) {
+        throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property values must not contain newlines.')
+      }
       nodeDecl += `${key} = ${value}\n`
     }
   }

--- a/tests/security/scene-injection.test.ts
+++ b/tests/security/scene-injection.test.ts
@@ -92,4 +92,54 @@ describe('Scene Injection Security Tests', () => {
       ).rejects.toThrow('Invalid characters in parameters')
     })
   })
+  describe('UI Tool', () => {
+    it('should reject newlines in properties for create_control', async () => {
+      const { handleUI } = await import('../../src/tools/composite/ui.js')
+
+      await expect(
+        handleUI(
+          'create_control',
+          {
+            scene_path: 'scene.tscn',
+            name: 'MaliciousControl',
+            type: 'Control',
+            properties: {
+              normal_prop: 'value\n[node name="hacked"]',
+            },
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid property value')
+
+      await expect(
+        handleUI(
+          'create_control',
+          {
+            scene_path: 'scene.tscn',
+            name: 'MaliciousControl2',
+            type: 'Control',
+            properties: {
+              'bad_key\n[node]': 'value',
+            },
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid property key')
+
+      await expect(
+        handleUI(
+          'create_control',
+          {
+            scene_path: 'scene.tscn',
+            name: 'MaliciousControl3',
+            type: 'Control',
+            properties: {
+              'bad_key=': 'value',
+            },
+          },
+          config,
+        ),
+      ).rejects.toThrow('Invalid property key')
+    })
+  })
 })


### PR DESCRIPTION
The Sentinel persona identified a missing newline/carriage return validation when processing `args.properties` in the UI composite tool (`handleCreateControl`). Unsanitized keys or values placed here could directly modify `.tscn` file structures enabling scene injection attacks.

The patch includes:
1. Validation of the `properties` argument format within `src/tools/composite/ui.ts`.
2. Rejection of `=`, `\n`, and `\r` within keys.
3. Rejection of `\n` and `\r` within values.
4. Additional test cases to `tests/security/scene-injection.test.ts` to block such injections via the UI tool.

---
*PR created automatically by Jules for task [9742557152072583446](https://jules.google.com/task/9742557152072583446) started by @n24q02m*