### PR TITLE
[TEST] Missing Error Path Test: execFileSync failure in tryGetVersion

### DIFF
--- a/tests/godot/detector.test.ts
+++ b/tests/godot/detector.test.ts
@@ -340,6 +340,13 @@ describe('detector', () => {
       expect(result?.minor).toBe(7)
     })
 
+    it('should return null if execFileSync throws when skipSignatureCheck is true', () => {
+      vi.mocked(execFileSync).mockImplementation(() => {
+        throw new Error('exec failed')
+      })
+      expect(tryGetVersion('/custom/godot', true)).toBeNull()
+    })
+
     it('should require signature check when skipSignatureCheck is false', () => {
       const mockStats = {
         isFile: () => true,


### PR DESCRIPTION
This PR adds a missing test case to `tests/godot/detector.test.ts` to ensure that `tryGetVersion` handles `execFileSync` failures gracefully even when `skipSignatureCheck` is set to `true`. This improves the robustness of the Godot binary detection logic and ensures complete test coverage for this specific execution path.

---
*PR created automatically by Jules for task [14826306375577804688](https://jules.google.com/task/14826306375577804688) started by @n24q02m*