### PR TITLE
test(helpers): fix quote-aware list parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-09 - [Optimize parseProjectGodot string parsing]
 **Learning:** Parsing `project.godot` (or other INI-like configurations) line-by-line using regular expressions inside a hot loop (e.g., `^\[(.+)\]$`, `/^([^\s=]+)\s*=\s*(.+)$/`) causes severe performance bottlenecks due to RegExp compilation, execution, and extensive GC pressure from intermediary match objects and string allocations.
 **Action:** Replace regular expressions within file parsing loops with manual string operations: use `charCodeAt` to identify section boundaries (e.g., `91` for `[`), `indexOf('=')` for key-value extraction, and direct `.slice()` + `.trim()` for data separation. Apply manual quote removal checking string bounds and `charCodeAt(0) === 34` instead of `.replace(/^"(.*)"$/, '$1')`.
+
+## 2025-05-22 - Optimized Quote-Aware List Parser
+**Learning:** Single-pass character loop can replace multiple `indexOf` calls while adding state tracking for quotes.
+**Action:** Replaced `indexOf` based `parseCommaSeparatedList` with a single-pass loop that handles quotes while maintaining in-place trimming and avoiding extra allocations outside of the final `slice` and `push`.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-22 - Quote-aware Comma-Separated List Parsing
+**Vulnerability:** Broken parser in `parseCommaSeparatedList` which split items on commas even when they were inside quotes (e.g., `"a, b", c` became `["a", "b", "c"]`).
+**Learning:** Fast-path parsers using `indexOf` must be carefully audited for context-sensitive delimiters like commas in quoted strings.
+**Prevention:** Use a single-pass character-by-character loop with state tracking (e.g., `inQuotes`) for robust parsing of delimited strings that allow quoting.

--- a/src/tools/helpers/strings.ts
+++ b/src/tools/helpers/strings.ts
@@ -5,30 +5,36 @@
 /**
  * Fast-path parser for comma-separated lists, avoiding split/map/filter allocations.
  * Uses a single-pass loop to find delimiters, trimming whitespace and quotes in-place.
+ * Handles quoted items containing commas.
  */
 export function parseCommaSeparatedList(str: string): string[] {
   if (!str) return []
   const result: string[] = []
-  let start = 0
   const len = str.length
+  let inQuotes = false
+  let start = 0
 
-  while (start < len) {
-    const commaIdx = str.indexOf(',', start)
-    const end = commaIdx === -1 ? len : commaIdx
+  for (let i = 0; i <= len; i++) {
+    const char = i < len ? str[i] : ','
+    if (char === '"') {
+      inQuotes = !inQuotes
+    } else if (char === ',' && !inQuotes) {
+      // Trim leading whitespace and quotes
+      let itemStart = start
+      let itemEnd = i - 1
 
-    // Trim leading whitespace and quotes
-    let i = start
-    let j = end - 1
+      while (itemStart <= itemEnd && (str.charCodeAt(itemStart) <= 32 || str[itemStart] === '"')) {
+        itemStart++
+      }
+      while (itemEnd >= itemStart && (str.charCodeAt(itemEnd) <= 32 || str[itemEnd] === '"')) {
+        itemEnd--
+      }
 
-    while (i <= j && (str.charCodeAt(i) <= 32 || str[i] === '"')) i++
-    while (j >= i && (str.charCodeAt(j) <= 32 || str[j] === '"')) j--
-
-    if (i <= j) {
-      result.push(str.slice(i, j + 1))
+      if (itemStart <= itemEnd) {
+        result.push(str.slice(itemStart, itemEnd + 1))
+      }
+      start = i + 1
     }
-
-    if (commaIdx === -1) break
-    start = commaIdx + 1
   }
 
   return result

--- a/tests/helpers/strings.test.ts
+++ b/tests/helpers/strings.test.ts
@@ -34,5 +34,26 @@ describe('strings helpers', () => {
     it('should handle items with inner spaces', () => {
       expect(parseCommaSeparatedList('word1 word2, word3 word4')).toEqual(['word1 word2', 'word3 word4'])
     })
+
+    it('should handle commas inside quotes', () => {
+      expect(parseCommaSeparatedList('"a, b", c')).toEqual(['a, b', 'c'])
+    })
+
+    it('should handle multiple quoted items with commas', () => {
+      expect(parseCommaSeparatedList('"a, b", "c, d", e')).toEqual(['a, b', 'c, d', 'e'])
+    })
+
+    it('should handle unquoted items with commas correctly by not over-trimming', () => {
+      expect(parseCommaSeparatedList('a b, c d')).toEqual(['a b', 'c d'])
+    })
+
+    it('should handle empty quotes', () => {
+      expect(parseCommaSeparatedList('"", " ", a')).toEqual(['a'])
+    })
+
+    it('should handle mixed quotes types (if only double quotes are supported)', () => {
+      // Current implementation only handles double quotes as per requirements and previous behavior
+      expect(parseCommaSeparatedList("'a, b', c")).toEqual(["'a", "b'", 'c'])
+    })
   })
 })


### PR DESCRIPTION
The parseCommaSeparatedList function was failing to correctly handle commas enclosed within double quotes, splitting them into separate items.

This change:
- Replaces the indexOf-based logic with a single-pass character loop.
- Adds state tracking for double quotes to treat enclosed commas as literals.
- Maintains fast-path performance by avoiding redundant allocations.
- Adds comprehensive tests covering various quote-related edge cases.

---
*PR created automatically by Jules for task [12557108250038155331](https://jules.google.com/task/12557108250038155331) started by @n24q02m*