### PR TITLE
[FIX] Deep nesting in parseProjectGodot

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-09 - [Optimize parseProjectGodot string parsing]
 **Learning:** Parsing `project.godot` (or other INI-like configurations) line-by-line using regular expressions inside a hot loop (e.g., `^\[(.+)\]$`, `/^([^\s=]+)\s*=\s*(.+)$/`) causes severe performance bottlenecks due to RegExp compilation, execution, and extensive GC pressure from intermediary match objects and string allocations.
 **Action:** Replace regular expressions within file parsing loops with manual string operations: use `charCodeAt` to identify section boundaries (e.g., `91` for `[`), `indexOf('=')` for key-value extraction, and direct `.slice()` + `.trim()` for data separation. Apply manual quote removal checking string bounds and `charCodeAt(0) === 34` instead of `.replace(/^"(.*)"$/, '$1')`.
+
+## 2025-05-10 - [Un-nest parseProjectGodot via early returns and extraction]
+**Learning:** Deep nesting in loops, such as in `parseProjectGodot` within `src/tools/composite/project.ts`, can be mitigated by using early `continue` statements for common cases (empty lines, headers) and extracting specific logic (like `application` section processing) into helper functions. This improves readability and maintainability without sacrificing performance.
+**Action:** Extracted `applyProjectSetting` helper function to handle special fields and settings map updates, and added early `continue` checks in the main parsing loop of `parseProjectGodot`.

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -13,6 +13,34 @@ import { pathExists, safeResolve } from '../helpers/paths.js'
 import { getSetting, parseProjectSettingsAsync, setSettingInContent } from '../helpers/project-settings.js'
 import { parseCommaSeparatedList } from '../helpers/strings.js'
 
+/**
+ * Apply a project setting to the info object, handling special fields like name and config_version.
+ */
+function applyProjectSetting(
+  info: ProjectInfo,
+  currentSection: string,
+  key: string,
+  value: string,
+  rawValue: string,
+): void {
+  if (currentSection === '' || currentSection === 'application') {
+    if (key === 'config/name') info.name = value
+    if (key === 'run/main_scene') info.mainScene = value
+    if (key === 'config/features') {
+      const featMatch = rawValue.match(/PackedStringArray\((.+)\)/)
+      if (featMatch) {
+        info.features = parseCommaSeparatedList(featMatch[1])
+      }
+    }
+  }
+
+  if (key === 'config_version') {
+    info.configVersion = Number.parseInt(value, 10)
+  }
+
+  info.settings[`${currentSection ? `${currentSection}/` : ''}${key}`] = value
+}
+
 async function parseProjectGodot(projectPath: string): Promise<ProjectInfo> {
   const configPath = join(projectPath, 'project.godot')
   // Performance optimization: using async pathExists instead of existsSync
@@ -42,43 +70,37 @@ async function parseProjectGodot(projectPath: string): Promise<ProjectInfo> {
     while (start < end && content.charCodeAt(start) <= 32) start++
     while (end > start && content.charCodeAt(end - 1) <= 32) end--
 
-    if (start < end) {
-      const trimmed = content.slice(start, end)
-      const firstChar = trimmed.charCodeAt(0)
-      const lastChar = trimmed.charCodeAt(trimmed.length - 1)
+    // Skip empty lines or comments (59 is ';')
+    if (start >= end || content.charCodeAt(start) === 59) {
+      pos = nextNewline === -1 ? len : nextNewline + 1
+      continue
+    }
 
-      // Section header
-      if (firstChar === 91 && lastChar === 93) {
-        // '[' and ']'
-        currentSection = trimmed.slice(1, -1)
-      } else {
-        // Key-value pair
-        const eqIdx = trimmed.indexOf('=')
-        if (eqIdx !== -1) {
-          // ⚡ Bolt: Direct string slice and length checks replace expensive RegExp compilation and matching
-          const key = trimmed.slice(0, eqIdx).trimEnd()
-          const rawValue = trimmed.slice(eqIdx + 1).trimStart()
+    const trimmed = content.slice(start, end)
+    const firstChar = trimmed.charCodeAt(0)
+    const lastChar = trimmed.charCodeAt(trimmed.length - 1)
 
-          const value =
-            rawValue.length >= 2 && rawValue.charCodeAt(0) === 34 && rawValue.charCodeAt(rawValue.length - 1) === 34
-              ? rawValue.slice(1, -1)
-              : rawValue
+    // Section header
+    if (firstChar === 91 && lastChar === 93) {
+      // '[' and ']'
+      currentSection = trimmed.slice(1, -1)
+      pos = nextNewline === -1 ? len : nextNewline + 1
+      continue
+    }
 
-          if (currentSection === '' || currentSection === 'application') {
-            if (key === 'config/name') info.name = value
-            if (key === 'run/main_scene') info.mainScene = value
-            if (key === 'config/features') {
-              const featMatch = rawValue.match(/PackedStringArray\((.+)\)/)
-              if (featMatch) {
-                info.features = parseCommaSeparatedList(featMatch[1])
-              }
-            }
-          }
+    // Key-value pair
+    const eqIdx = trimmed.indexOf('=')
+    if (eqIdx !== -1) {
+      // ⚡ Bolt: Direct string slice and length checks replace expensive RegExp compilation and matching
+      const key = trimmed.slice(0, eqIdx).trimEnd()
+      const rawValue = trimmed.slice(eqIdx + 1).trimStart()
 
-          if (key === 'config_version') info.configVersion = Number.parseInt(value, 10)
-          info.settings[`${currentSection ? `${currentSection}/` : ''}${key}`] = value
-        }
-      }
+      const value =
+        rawValue.length >= 2 && rawValue.charCodeAt(0) === 34 && rawValue.charCodeAt(rawValue.length - 1) === 34
+          ? rawValue.slice(1, -1)
+          : rawValue
+
+      applyProjectSetting(info, currentSection, key, value, rawValue)
     }
 
     pos = nextNewline === -1 ? len : nextNewline + 1


### PR DESCRIPTION
This PR refactors the `parseProjectGodot` function in `src/tools/composite/project.ts` to reduce deep nesting, as identified in the code improvement task.

Key changes:
- Extracted a dedicated helper function `applyProjectSetting` to handle the logic for assigning special fields (like `name`, `mainScene`, `features`) and updating the `settings` map.
- Simplified the main `while` loop by using early `continue` statements for empty lines, comments, and section headers.
- Maintained the performance optimizations (manual string traversal) while improving code readability and maintainability.
- Updated the `.jules/bolt.md` performance journal with these learnings.

Verified by running existing tests in `tests/composite/project.test.ts` and `tests/helpers/project-settings.test.ts`, as well as performing type checks with `tsc --noEmit`.

---
*PR created automatically by Jules for task [11887146393587105025](https://jules.google.com/task/11887146393587105025) started by @n24q02m*