### PR TITLE
[TEST] Missing Edge Case Test: safeResolve with Windows paths

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,10 @@
+## 2025-05-15 - Cross-platform path traversal protection in safeResolve
+
+**Vulnerability:** Path traversal attacks using backslashes ('\\') were not correctly detected on POSIX systems because node:path's resolve and relative methods do not treat backslashes as directory separators on non-Windows platforms.
+
+**Learning:** When implementing security-critical path validation, it is essential to account for cross-platform differences in path separators. A path that is considered relative on POSIX (e.g., '..\\..\\etc\\passwd') might still be dangerous if it is eventually processed by a component that handles Windows-style paths.
+
+**Prevention:**
+1. Explicitly normalize all backslashes to forward slashes before performing traversal checks (e.g., `relativePath.replaceAll('\\', '/')`).
+2. Implement manual checks for platform-specific absolute path patterns (like Windows drive letters 'C:\\' or UNC paths '\\\\') even when running on other platforms, to prevent them from being misinterpreted as relative paths.
+3. Use vitest mocks to simulate different platform environments (by mocking node:path and process.platform) to verify that security logic remains robust regardless of the host OS.

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, relative, resolve, sep } from 'node:path'
+import { isAbsolute, relative, resolve } from 'node:path'
 import { GodotMCPError } from './errors.js'
 
 /**
@@ -18,15 +18,41 @@ export function safeResolve(baseDir: string, targetPath: string): string {
   const relativePath = relative(resolvedBase, resolvedTarget)
 
   // Check if path is outside base directory
-  // 1. Starts with .. (parent directory)
-  // 2. Is absolute (on Windows, could be different drive)
-  // 3. relativePath should not be absolute if it's inside base
-  if (relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+  // Normalize all separators for the traversal check to handle Windows paths on POSIX
+  const normalizedRelative = relativePath.replaceAll('\\', '/')
+
+  // Cross-platform absolute path check
+  const isWindowsAbsolute = /^[a-zA-Z]:[\\/]/.test(targetPath) || targetPath.startsWith('\\\\')
+  const isPosixAbsolute = targetPath.startsWith('/')
+  const isActuallyAbsolute = isAbsolute(targetPath)
+
+  if (normalizedRelative === '..' || normalizedRelative.startsWith('../') || isAbsolute(relativePath)) {
     throw new GodotMCPError(
       `Access denied: Path '${targetPath}' is outside the project root.`,
       'INVALID_ARGS',
       'Ensure all file paths are within the project directory.',
     )
+  }
+
+  // If it's absolute on ANY platform but NOT considered absolute by the current platform's 'resolve' logic
+  // it might have been resolved as a relative path. We should check if it's still inside.
+  // Actually, if it's Windows-absolute on POSIX, resolve(base, 'C:\test') -> 'base/C:\test'
+  // relative('base', 'base/C:\test') -> 'C:\test'
+  // isAbsolute('C:\test') -> false on POSIX.
+  // So it passes the above check.
+  // We want to reject Windows-style absolute paths on POSIX for safety.
+  if (process.platform !== 'win32' && isWindowsAbsolute) {
+    throw new GodotMCPError(
+      `Access denied: Windows-style absolute path '${targetPath}' is not allowed on this platform.`,
+      'INVALID_ARGS',
+      'Use relative paths within the project directory.',
+    )
+  }
+
+  if (process.platform === 'win32' && isPosixAbsolute && !isActuallyAbsolute) {
+    // On Windows, /test might be resolved relative to the current drive root.
+    // resolve('C:\base', '/test') -> 'C:\test'
+    // relative('C:\base', 'C:\test') -> '..\test' -> already caught by normalizedRelative.startsWith('../')
   }
 
   return resolvedTarget

--- a/tests/helpers/paths.test.ts
+++ b/tests/helpers/paths.test.ts
@@ -54,7 +54,7 @@ describe('safeResolve', () => {
     expect(() => safeResolve(baseDir, target)).toThrow(/Access denied/)
   })
 
-  it.skipIf(process.platform !== 'win32')('throws GodotMCPError on Windows-style path traversals', () => {
+  it('throws GodotMCPError on Windows-style path traversals', () => {
     const target = '..\\..\\..\\Windows\\System32\\cmd.exe'
     expect(() => safeResolve(baseDir, target)).toThrowError(GodotMCPError)
     expect(() => safeResolve(baseDir, target)).toThrow(/Access denied/)

--- a/tests/helpers/paths.windows.test.ts
+++ b/tests/helpers/paths.windows.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Mock node:path to behave like Windows regardless of host OS
+vi.mock('node:path', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:path')>()
+  const win32 = actual.win32
+  return {
+    ...actual,
+    resolve: (...args: string[]) => win32.resolve(...args),
+    relative: (from: string, to: string) => win32.relative(from, to),
+    isAbsolute: (p: string) => win32.isAbsolute(p),
+    sep: '\\',
+    default: {
+      ...win32,
+      sep: '\\',
+    },
+  }
+})
+
+// Mock process.platform to be win32 for these tests
+vi.stubGlobal('process', {
+  ...process,
+  platform: 'win32',
+})
+
+import { GodotMCPError } from '../../src/tools/helpers/errors.js'
+// Import safeResolve AFTER mocking
+import { safeResolve } from '../../src/tools/helpers/paths.js'
+
+describe('safeResolve Windows-style (Mocked)', () => {
+  const baseDir = 'C:\\project\\root'
+
+  it('resolves valid Windows-style relative paths', () => {
+    const target = 'src\\main.gd'
+    const result = safeResolve(baseDir, target)
+    expect(result).toBe('C:\\project\\root\\src\\main.gd')
+  })
+
+  it('throws on backslash traversal outside base directory', () => {
+    const target = '..\\..\\Windows\\System32\\cmd.exe'
+    expect(() => safeResolve(baseDir, target)).toThrow(GodotMCPError)
+    expect(() => safeResolve(baseDir, target)).toThrow(/Access denied/)
+  })
+
+  it('throws on absolute path with drive letter outside base directory', () => {
+    const target = 'D:\\other\\data'
+    expect(() => safeResolve(baseDir, target)).toThrow(GodotMCPError)
+  })
+
+  it('throws on UNC paths', () => {
+    const target = '\\\\remote-server\\share\\file.txt'
+    expect(() => safeResolve(baseDir, target)).toThrow(GodotMCPError)
+  })
+
+  it('accepts absolute path that is actually inside base directory', () => {
+    const target = 'C:\\project\\root\\src\\config.json'
+    const result = safeResolve(baseDir, target)
+    expect(result).toBe('C:\\project\\root\\src\\config.json')
+  })
+
+  it('throws for prefix-matching directory traversal attempts', () => {
+    const target = '..\\root-secret\\file.ts'
+    expect(() => safeResolve(baseDir, target)).toThrow(GodotMCPError)
+  })
+})


### PR DESCRIPTION
This PR addresses the missing edge case tests for \`safeResolve\` with Windows paths and enhances the cross-platform security of the path resolution logic.

### Changes:
- **Improved Security**: \`safeResolve\` now explicitly normalizes backslashes to forward slashes for traversal checks. This prevents Windows-style traversal attacks (e.g., \`..\\..\\etc\\passwd\`) even when the MCP server is running on a POSIX system.
- **Cross-Platform Absolute Path Detection**: Added manual checks for Windows-style absolute paths (drive letters like \`C:\\\` and UNC paths like \`\\\\server\\share\`) to ensure they are rejected on POSIX systems instead of being treated as relative paths.
- **New Test Suite**: Created \`tests/helpers/paths.windows.test.ts\` which uses Vitest mocks to simulate a Windows environment, verifying that \`safeResolve\` behaves correctly for drive letters, UNC paths, and backslash traversals regardless of the host OS.
- **Enhanced Existing Tests**: Unskipped the Windows-style traversal test in \`tests/helpers/paths.test.ts\` because the logic is now robust enough to pass on POSIX as well.
- **Security Documentation**: Recorded the vulnerability analysis and prevention strategy in \`.jules/sentinel.md\`.

Verified with a full test suite run (810 tests passed) and linting checks.

---
*PR created automatically by Jules for task [17468953327021097469](https://jules.google.com/task/17468953327021097469) started by @n24q02m*