### PR TITLE
[CLEANUP] Commented out input parsing fast path

### DIFF
--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -249,7 +249,6 @@ export async function handleInputMap(action: string, args: Record<string, unknow
       const content = await readFile(configPath, 'utf-8')
       const actions = parseInputActions(content)
 
-      // ⚡ Bolt: Use a pre-allocated array and for...of loop to prevent Array.from() + .map() allocation overhead
       const actionList = new Array(actions.size)
       let idx = 0
       for (const [name, events] of actions) {


### PR DESCRIPTION
Removed the obsolete "Bolt" performance optimization comment in src/tools/composite/input-map.ts to clean up the codebase. The underlying optimization remains intact.

---
*PR created automatically by Jules for task [4227573323000834262](https://jules.google.com/task/4227573323000834262) started by @n24q02m*