### PR TITLE
[FIX] Strip specific prefixes

### DIFF
--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -9,6 +9,7 @@ import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '..
 import { pathExists, safeResolve } from '../helpers/paths.js'
 import {
   getNodeProperty,
+  normalizeNodePath,
   parseSceneContent,
   removeNodeFromContent,
   renameNodeInContent,
@@ -17,24 +18,6 @@ import {
 
 function resolveScenePath(projectPath: string, scenePath: string): string {
   return safeResolve(projectPath, scenePath)
-}
-
-/**
- * Normalize node path: strip common LLM mistakes like "/root/SceneName/" prefix.
- * Returns the corrected path and whether it was auto-corrected.
- */
-function normalizeNodePath(path: string): { path: string; corrected: boolean } {
-  if (!path || path === '.') return { path, corrected: false }
-  // Strip /root/ or /root/SceneName/ prefix that LLMs commonly generate
-  const rootMatch = path.match(/^\/root\/(?:[^/]+\/)?(.+)$/)
-  if (rootMatch) {
-    return { path: rootMatch[1], corrected: true }
-  }
-  // Strip leading slash
-  if (path.startsWith('/')) {
-    return { path: path.slice(1), corrected: false }
-  }
-  return { path, corrected: false }
 }
 
 async function handleAddNode(projectPath: string, args: Record<string, unknown>) {

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -8,7 +8,7 @@ import { dirname, join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
-import { escapeRegExp } from '../helpers/scene-parser.js'
+import { escapeRegExp, normalizeNodePath } from '../helpers/scene-parser.js'
 
 const NODE_SECTION_RE = /(\[node [^\]]+\])/
 
@@ -177,7 +177,7 @@ async function writeScript(args: Record<string, unknown>, resolvePath: (path: st
 async function attachScript(args: Record<string, unknown>, resolvePath: (path: string) => string) {
   const scenePath = args.scene_path as string
   const scriptPath = args.script_path as string
-  const nodeName = args.node_name as string
+  const { path: nodeName } = normalizeNodePath((args.node_name as string) || '')
   if (!scenePath || !scriptPath) {
     throw new GodotMCPError(
       'Both scene_path and script_path required',

--- a/src/tools/composite/signals.ts
+++ b/src/tools/composite/signals.ts
@@ -7,7 +7,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
-import { parseSceneContent } from '../helpers/scene-parser.js'
+import { normalizeNodePath, parseSceneContent } from '../helpers/scene-parser.js'
 
 function validateParameters(...params: unknown[]) {
   for (const param of params) {
@@ -58,8 +58,8 @@ export async function handleSignals(action: string, args: Record<string, unknown
 
     case 'connect': {
       const signal = args.signal as string
-      const from = args.from as string
-      const to = args.to as string
+      const { path: from } = normalizeNodePath((args.from as string) || '')
+      const { path: to } = normalizeNodePath((args.to as string) || '')
       const method = args.method as string
       if (!signal || !from || !to || !method) {
         throw new GodotMCPError(
@@ -102,8 +102,8 @@ export async function handleSignals(action: string, args: Record<string, unknown
 
     case 'disconnect': {
       const signal = args.signal as string
-      const from = args.from as string
-      const to = args.to as string
+      const { path: from } = normalizeNodePath((args.from as string) || '')
+      const { path: to } = normalizeNodePath((args.to as string) || '')
       const method = args.method as string
       if (!signal || !from || !to || !method) {
         throw new GodotMCPError(

--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -103,6 +103,55 @@ export async function parseScene(filePath: string): Promise<ParsedScene> {
 }
 
 /**
+ * Normalize node path: strip common LLM mistakes like "/root/SceneName/" prefix.
+ * Returns the corrected path and whether it was auto-corrected.
+ */
+export function normalizeNodePath(path: string): { path: string; corrected: boolean } {
+  if (!path || path === '.') return { path, corrected: false }
+
+  let current = path
+  let corrected = false
+
+  // Repeatedly strip prefixes that can be combined
+  while (true) {
+    let changed = false
+    // Strip res:// prefix
+    if (current.startsWith('res://')) {
+      current = current.slice(6)
+      changed = true
+      corrected = true
+    }
+    // Strip leading ./
+    if (current.startsWith('./')) {
+      current = current.slice(2)
+      changed = true
+      corrected = true
+    }
+    if (!changed) break
+  }
+
+  if (!current || current === '.') return { path: '.', corrected }
+
+  // Handle case where path IS just /root or /root/SceneName (absolute SceneTree paths)
+  if (current === '/root' || current === '/root/' || current.match(/^\/root\/[^/]+\/?$/)) {
+    return { path: '.', corrected: true }
+  }
+
+  // Strip /root/SceneName/ prefix that LLMs commonly generate
+  const rootMatch = current.match(/^\/root\/[^/]+\/(.+)$/)
+  if (rootMatch) {
+    return { path: rootMatch[1], corrected: true }
+  }
+
+  // Strip leading slash
+  if (current.startsWith('/')) {
+    return { path: current.slice(1), corrected: true }
+  }
+
+  return { path: current, corrected }
+}
+
+/**
  * Parse .tscn content string into structured data
  */
 export function parseSceneContent(content: string): ParsedScene {

--- a/tests/helpers/node-normalization.test.ts
+++ b/tests/helpers/node-normalization.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeNodePath } from '../../src/tools/helpers/scene-parser.js'
+
+/**
+ * Unit tests for node path normalization logic.
+ */
+describe('normalizeNodePath', () => {
+  it('should handle empty or dot path', () => {
+    expect(normalizeNodePath('')).toEqual({ path: '', corrected: false })
+    expect(normalizeNodePath('.')).toEqual({ path: '.', corrected: false })
+  })
+
+  it('should handle /root/SceneName/Node prefix', () => {
+    expect(normalizeNodePath('/root/Main/Player')).toEqual({ path: 'Player', corrected: true })
+    expect(normalizeNodePath('/root/Main/UI/Health')).toEqual({ path: 'UI/Health', corrected: true })
+  })
+
+  it('should handle /root/ prefix (referring to scene root)', () => {
+    expect(normalizeNodePath('/root/Player')).toEqual({ path: '.', corrected: true })
+  })
+
+  it('should handle /root prefix', () => {
+    expect(normalizeNodePath('/root')).toEqual({ path: '.', corrected: true })
+  })
+
+  it('should strip res:// prefix', () => {
+    expect(normalizeNodePath('res://Player')).toEqual({ path: 'Player', corrected: true })
+    expect(normalizeNodePath('res://UI/Label')).toEqual({ path: 'UI/Label', corrected: true })
+  })
+
+  it('should strip leading ./', () => {
+    expect(normalizeNodePath('./Player')).toEqual({ path: 'Player', corrected: true })
+    expect(normalizeNodePath('./UI/Label')).toEqual({ path: 'UI/Label', corrected: true })
+  })
+
+  it('should handle multiple prefixes', () => {
+    // res://./Player -> res://Player -> Player
+    expect(normalizeNodePath('res://./Player')).toEqual({ path: 'Player', corrected: true })
+  })
+
+  it('should strip leading slash', () => {
+    expect(normalizeNodePath('/Sprite')).toEqual({ path: 'Sprite', corrected: true })
+  })
+
+  it('should not correct valid relative paths', () => {
+    expect(normalizeNodePath('Sprite')).toEqual({ path: 'Sprite', corrected: false })
+    expect(normalizeNodePath('UI/Label')).toEqual({ path: 'UI/Label', corrected: false })
+  })
+})


### PR DESCRIPTION
This PR improves node path normalization in the Godot MCP server. It centralizes the logic in \`src/tools/helpers/scene-parser.ts\` and enhances it to handle common LLM mistakes like \`res://\` prefixes, absolute SceneTree paths (e.g., \`/root/SceneName\`), and combined prefixes like \`res://./\`. This ensures that node operations (adding, connecting signals, attaching scripts) work correctly even when the LLM provides slightly incorrect paths.

Key changes:
- Moved \`normalizeNodePath\` to \`scene-parser.ts\` and exported it.
- Improved normalization to handle more edge cases (absolute paths, recursive prefix stripping).
- Updated \`nodes.ts\`, \`signals.ts\`, and \`scripts.ts\` to use the centralized helper.
- Added comprehensive unit tests in \`tests/helpers/node-normalization.test.ts\`.

---
*PR created automatically by Jules for task [15367732746591092497](https://jules.google.com/task/15367732746591092497) started by @n24q02m*