### PR TITLE
[CLEANUP] Commented out recursive import logic

### DIFF
--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -43,10 +43,6 @@ async function findResourceFiles(
     const entries = await readdir(dir, { withFileTypes: true })
     const promises: Promise<void>[] = []
 
-    // ⚡ Bolt: Removed .map() and .flat() in favor of a shared results array and .push()
-    // This reduces intermediate array allocations and garbage collection pressure
-    // during recursive asynchronous directory traversals for Godot projects with many assets.
-
     for (let i = 0; i < entries.length; i++) {
       const entry = entries[i]
       const name = entry.name
@@ -100,13 +96,10 @@ export async function handleResources(action: string, args: Record<string, unkno
 
       const resources = await findResourceFiles(resolvedPath, exts)
 
-      // OPTIMIZATION: Use substring and a pre-allocated array instead of .map() and node:path.relative
-      // for significantly faster execution on large arrays of prefixed paths.
       const prefixLen = resolvedPath.length + (resolvedPath.endsWith('/') || resolvedPath.endsWith('\\') ? 0 : 1)
       const relativePaths = new Array(resources.length)
       for (let i = 0; i < resources.length; i++) {
         const r = resources[i]
-        // ⚡ Bolt: Using replaceAll('\\', '/') avoids RegExp allocation overhead
         relativePaths[i] = {
           path: r.path.substring(prefixLen).replaceAll('\\', '/'),
           ext: extname(r.path),

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -203,12 +203,9 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       const resolvedPath = safeResolve(baseDir, projectPath as string)
       const scenes = await findSceneFiles(resolvedPath)
 
-      // OPTIMIZATION: Use substring and a pre-allocated array instead of .map() and node:path.relative
-      // for significantly faster execution on large arrays of prefixed paths.
       const prefixLen = resolvedPath.length + (resolvedPath.endsWith('/') || resolvedPath.endsWith('\\') ? 0 : 1)
       const relativePaths = new Array(scenes.length)
       for (let i = 0; i < scenes.length; i++) {
-        // ⚡ Bolt: Using replaceAll('\\', '/') avoids RegExp allocation overhead
         relativePaths[i] = scenes[i].substring(prefixLen).replaceAll('\\', '/')
       }
 
@@ -273,7 +270,6 @@ export async function handleScenes(action: string, args: Record<string, unknown>
         throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')
       }
 
-      // ⚡ Bolt: Using replaceAll('\\', '/') avoids RegExp allocation overhead
       const resPath = `res://${scenePath.replaceAll('\\', '/')}`
       const content = await readFile(configPath, 'utf-8')
       const updated = setSettingInContent(content, 'application/run/main_scene', `"${resPath}"`)

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -206,7 +206,6 @@ async function attachScript(args: Record<string, unknown>, resolvePath: (path: s
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
 
   let content = await readFile(sceneFullPath, 'utf-8')
-  // ⚡ Bolt: Using replaceAll('\\', '/') avoids RegExp allocation overhead
   const resPath = `res://${scriptPath.replaceAll('\\', '/')}`
 
   if (nodeName) {
@@ -234,12 +233,9 @@ async function listScripts(baseDir: string, projectPath: string | undefined) {
   const resolvedPath = safeResolve(baseDir, projectPath)
   const scripts = await findScriptFiles(resolvedPath)
 
-  // OPTIMIZATION: Use substring and a pre-allocated array instead of .map() and node:path.relative
-  // for significantly faster execution on large arrays of prefixed paths.
   const prefixLen = resolvedPath.length + (resolvedPath.endsWith('/') || resolvedPath.endsWith('\\') ? 0 : 1)
   const relativePaths = new Array(scripts.length)
   for (let i = 0; i < scripts.length; i++) {
-    // ⚡ Bolt: Using replaceAll('\\', '/') avoids RegExp allocation overhead
     relativePaths[i] = scripts[i].substring(prefixLen).replaceAll('\\', '/')
   }
 

--- a/src/tools/composite/shader.ts
+++ b/src/tools/composite/shader.ts
@@ -180,12 +180,9 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const resolvedPath = safeResolve(baseDir, projectPath)
       const shaders = await findShaderFiles(resolvedPath)
 
-      // OPTIMIZATION: Use substring and a pre-allocated array instead of .map() and node:path.relative
-      // for significantly faster execution on large arrays of prefixed paths.
       const prefixLen = resolvedPath.length + (resolvedPath.endsWith('/') || resolvedPath.endsWith('\\') ? 0 : 1)
       const relativePaths = new Array(shaders.length)
       for (let i = 0; i < shaders.length; i++) {
-        // ⚡ Bolt: Using replaceAll('\\', '/') avoids RegExp allocation overhead
         relativePaths[i] = shaders[i].substring(prefixLen).replaceAll('\\', '/')
       }
 


### PR DESCRIPTION
Removed obsolete implementation notes (comments describing what was replaced by optimizations) from src/tools/composite/resources.ts, src/tools/composite/scripts.ts, src/tools/composite/shader.ts, and src/tools/composite/scenes.ts. These comments were noise as they described code that no longer exists.

---
*PR created automatically by Jules for task [8869270730562523622](https://jules.google.com/task/8869270730562523622) started by @n24q02m*