### PR TITLE
fix: harden safeResolve against symlink/firmlink path traversal

### DIFF
--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,8 +1,45 @@
-import { isAbsolute, relative, resolve, sep } from 'node:path'
+import { realpathSync } from 'node:fs'
+import { dirname, isAbsolute, relative, resolve, sep } from 'node:path'
 import { GodotMCPError } from './errors.js'
 
 /**
+ * Canonicalizes a path by resolving symlinks/firmlinks on the longest existing
+ * ancestor, then re-appending any not-yet-created lexical remainder.
+ *
+ * A plain lexical `resolve()` cannot see through symlinks or the macOS firmlink
+ * layout (e.g. `/tmp` -> `/private/tmp`), so a containment check on lexical
+ * paths alone can be bypassed. `realpathSync` would throw for paths that do not
+ * exist yet (the common "create a new file" case), so we canonicalize only the
+ * portion that exists on disk and keep the rest lexical.
+ */
+function canonicalize(targetPath: string): string {
+  let current = resolve(targetPath)
+  const tail: string[] = []
+  // Walk up until we hit a component that exists on disk (or the filesystem root).
+  for (;;) {
+    try {
+      const real = realpathSync(current)
+      // Re-attach the non-existent remainder (if any) to the real prefix.
+      return tail.length > 0 ? resolve(real, ...tail.reverse()) : real
+    } catch {
+      const parent = dirname(current)
+      if (parent === current) {
+        // Reached the root without finding an existing ancestor; fall back to
+        // the lexical resolution so brand-new trees still validate.
+        return resolve(targetPath)
+      }
+      tail.push(current.slice(parent.length + 1))
+      current = parent
+    }
+  }
+}
+
+/**
  * Safely resolves a path relative to a base directory, preventing path traversal.
+ *
+ * Both the base directory and the candidate are canonicalized (symlinks and
+ * macOS firmlinks resolved) before the containment check so that traversal
+ * cannot be hidden behind a symlinked component.
  *
  * @param baseDir The trusted base directory (e.g. project root)
  * @param targetPath The untrusted path provided by user
@@ -10,17 +47,23 @@ import { GodotMCPError } from './errors.js'
  * @throws GodotMCPError if the path attempts to traverse outside the base directory
  */
 export function safeResolve(baseDir: string, targetPath: string): string {
-  // Normalize paths to remove .. and .
+  // Lexically resolve the requested target first; this is what callers expect
+  // back (it keeps not-yet-created paths intact for downstream file writes).
   const resolvedBase = resolve(baseDir)
   const resolvedTarget = resolve(resolvedBase, targetPath)
 
-  // Calculate relative path from base to target
-  const relativePath = relative(resolvedBase, resolvedTarget)
+  // Canonicalize BOTH sides (realpath the existing portions) so the containment
+  // check sees through symlinks/firmlinks rather than trusting lexical strings.
+  const canonicalBase = canonicalize(resolvedBase)
+  const canonicalTarget = canonicalize(resolvedTarget)
 
-  // Check if path is outside base directory
-  // 1. Starts with .. (parent directory)
-  // 2. Is absolute (on Windows, could be different drive)
-  // 3. relativePath should not be absolute if it's inside base
+  // Calculate relative path from canonical base to canonical target.
+  const relativePath = relative(canonicalBase, canonicalTarget)
+
+  // Path is outside the base directory when the relative form:
+  // 1. Equals ".." (the parent itself)
+  // 2. Starts with "..<sep>" (escapes upward)
+  // 3. Is absolute (different drive on Windows, or otherwise unrelated root)
   if (relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
     throw new GodotMCPError(
       `Access denied: Path '${targetPath}' is outside the project root.`,

--- a/tests/helpers/paths.test.ts
+++ b/tests/helpers/paths.test.ts
@@ -1,6 +1,6 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { dirname, join, relative, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { GodotMCPError } from '../../src/tools/helpers/errors.js'
 import { pathExists, safeResolve } from '../../src/tools/helpers/paths.js'
@@ -71,6 +71,62 @@ describe('safeResolve', () => {
     expect(() => safeResolve(baseDir, target)).toThrowError(GodotMCPError)
     expect(() => safeResolve(baseDir, target)).toThrow(/Access denied/)
   })
+})
+
+describe('safeResolve canonicalization (symlink / firmlink hardening)', () => {
+  let realBase: string
+  let outsideDir: string
+
+  beforeAll(async () => {
+    // realpath the temp dir up front so assertions are not confused by the
+    // macOS firmlink layout (/var -> /private/var) of the OS temp location.
+    const root = await realpath(await mkdtemp(join(tmpdir(), 'godot-mcp-safe-resolve-')))
+    realBase = join(root, 'project')
+    outsideDir = join(root, 'outside')
+    await mkdir(realBase)
+    await mkdir(outsideDir)
+    await writeFile(join(outsideDir, 'secret.txt'), 'top secret')
+  })
+
+  afterAll(async () => {
+    await rm(dirname(realBase), { recursive: true, force: true })
+  })
+
+  it('allows a legitimate path inside the real base directory', () => {
+    const result = safeResolve(realBase, 'scenes/level.tscn')
+    expect(result).toBe(resolve(realBase, 'scenes/level.tscn'))
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'blocks traversal that escapes via a symlinked directory component',
+    async () => {
+      // Create a symlink INSIDE the base that points to a sibling outside dir.
+      // A purely lexical check would treat `escape/secret.txt` as in-base, but
+      // canonicalization reveals it resolves to the outside directory.
+      const link = join(realBase, 'escape')
+      await symlink(outsideDir, link, 'dir')
+
+      expect(() => safeResolve(realBase, 'escape/secret.txt')).toThrowError(GodotMCPError)
+      expect(() => safeResolve(realBase, 'escape/secret.txt')).toThrow(/Access denied/)
+    },
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'allows a symlinked directory component that still points inside the base',
+    async () => {
+      const innerReal = join(realBase, 'real-inner')
+      await mkdir(innerReal)
+      const innerLink = join(realBase, 'inner-link')
+      await symlink(innerReal, innerLink, 'dir')
+
+      // inner-link -> real-inner, both inside base, so this must be allowed.
+      expect(() => safeResolve(realBase, 'inner-link/file.tscn')).not.toThrow()
+      const result = safeResolve(realBase, 'inner-link/file.tscn')
+      // The returned (lexical) path is still inside the base directory.
+      const rel = relative(realBase, result)
+      expect(rel.startsWith('..')).toBe(false)
+    },
+  )
 })
 
 describe('pathExists', () => {


### PR DESCRIPTION
## Summary
- `safeResolve` ran its containment check on lexically-resolved paths only. A symlinked directory component inside the project root (or the macOS firmlink layout, e.g. `/tmp` -> `/private/tmp`) could resolve outside the base while still passing the `relative()` + `startsWith('..')` check.
- Canonicalize BOTH the base and the candidate with `realpath` before comparing. To preserve the "create a new file" use case (callers pass paths that do not exist yet), only the longest existing ancestor is canonicalized and the lexical remainder is re-appended; containment is then asserted on the canonical paths.

## Test plan
- [x] Added tests in `tests/helpers/paths.test.ts`: a symlinked-escape attempt is blocked, a legitimate in-base symlink is allowed, and a legit non-existent in-base path still resolves. (Symlink cases `skipIf` win32 — they run on CI Linux; verified locally on Windows via directory junctions: escape blocked, in-base allowed.)
- [x] All existing `safeResolve`/`pathExists` tests still pass (15 passed, 2 symlink skipped on Windows).
- [x] `bun run check` (biome + tsc --noEmit) clean.

Surgical change to the resolver only.

Generated with [Claude Code](https://claude.com/claude-code)