### PR TITLE
⚡ Bolt: Cache docs directory path to eliminate redundant I/O during help requests

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2025-03-09 - [Optimize parseProjectGodot string parsing]
 **Learning:** Parsing `project.godot` (or other INI-like configurations) line-by-line using regular expressions inside a hot loop (e.g., `^\[(.+)\]$`, `/^([^\s=]+)\s*=\s*(.+)$/`) causes severe performance bottlenecks due to RegExp compilation, execution, and extensive GC pressure from intermediary match objects and string allocations.
 **Action:** Replace regular expressions within file parsing loops with manual string operations: use `charCodeAt` to identify section boundaries (e.g., `91` for `[`), `indexOf('=')` for key-value extraction, and direct `.slice()` + `.trim()` for data separation. Apply manual quote removal checking string bounds and `charCodeAt(0) === 34` instead of `.replace(/^"(.*)"$/, '$1')`.
+## 2025-03-10 - Redundant I/O on Tool Invocations
+**Learning:** Found that discovery patterns checking multiple directory candidates for documentation triggers parallel filesystem `stat` checks every time the tool is invoked, causing redundant event loop blocking.
+**Action:** Cache the successfully resolved paths in module-level constants or variables immediately after the first successful lookup, ensuring subsequent tool invocations skip the disk I/O entirely.

--- a/src/tools/composite/help.ts
+++ b/src/tools/composite/help.ts
@@ -29,10 +29,17 @@ const VALID_TOPICS = [
 ] as const
 type TopicName = (typeof VALID_TOPICS)[number]
 
+// ⚡ Bolt: Cache resolved docs dir to avoid redundant I/O on every help request
+let cachedDocsDir: string | null = null
+
 /**
  * Get the docs directory path
  */
 async function getDocsDir(): Promise<string> {
+  if (cachedDocsDir !== null) {
+    return cachedDocsDir
+  }
+
   const candidates = [
     join(import.meta.dirname || '', '..', '..', 'docs'),
     // Bundled CLI at bin/cli.mjs -> ../build/src/docs/
@@ -53,9 +60,14 @@ async function getDocsDir(): Promise<string> {
   )
 
   const found = results.find((res) => res !== null)
-  if (found) return found
 
-  return join(process.cwd(), 'src', 'docs')
+  if (found) {
+    cachedDocsDir = found
+    return found
+  }
+
+  cachedDocsDir = join(process.cwd(), 'src', 'docs')
+  return cachedDocsDir
 }
 
 /**


### PR DESCRIPTION
### 💡 What
Added a module-level variable `cachedDocsDir` in `src/tools/composite/help.ts` to cache the successful path resolution of the documentation directory.

### 🎯 Why
Previously, calling the `help` tool would trigger `pathExists` (which delegates to async `stat`) for 5 different fallback directories simultaneously via `Promise.all` and `.map()`. This caused unnecessary event loop blocking and filesystem I/O for static documentation paths on every single help request.

### 📊 Impact
Reduces disk I/O operations for `help` requests from 5 directory scans to 0 after the first invocation.

### 🔬 Measurement
Run `bun run vitest tests/composite/help.test.ts`. Help requests after the initial load should resolve immediately without executing disk operations for directory lookups.

*(Addressed code review feedback by keeping the clear `Promise.all(candidates.map(...))` pattern rather than introducing a clunky micro-optimized loop.)*

---
*PR created automatically by Jules for task [8386246935168690263](https://jules.google.com/task/8386246935168690263) started by @n24q02m*