### PR TITLE
⚡ Bolt: Cache help tool documentation directory to prevent redundant I/O

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2025-03-09 - [Optimize parseProjectGodot string parsing]
 **Learning:** Parsing `project.godot` (or other INI-like configurations) line-by-line using regular expressions inside a hot loop (e.g., `^\[(.+)\]$`, `/^([^\s=]+)\s*=\s*(.+)$/`) causes severe performance bottlenecks due to RegExp compilation, execution, and extensive GC pressure from intermediary match objects and string allocations.
 **Action:** Replace regular expressions within file parsing loops with manual string operations: use `charCodeAt` to identify section boundaries (e.g., `91` for `[`), `indexOf('=')` for key-value extraction, and direct `.slice()` + `.trim()` for data separation. Apply manual quote removal checking string bounds and `charCodeAt(0) === 34` instead of `.replace(/^"(.*)"$/, '$1')`.
+## 2024-05-24 - Caching Filesystem Discovery Results
+**Learning:** In Node.js, repeated filesystem operations (like searching multiple directories for a documentation path) block the event loop and introduce significant latency, especially when serving frequent requests. Static paths like the documentation directory don't change during the application lifecycle.
+**Action:** Always cache the results of static filesystem discovery operations (like identifying resource directories) in module-level variables upon the first successful lookup to eliminate redundant I/O in hot paths.

--- a/src/tools/composite/help.ts
+++ b/src/tools/composite/help.ts
@@ -29,10 +29,15 @@ const VALID_TOPICS = [
 ] as const
 type TopicName = (typeof VALID_TOPICS)[number]
 
+// ⚡ Bolt: Cache docs directory to avoid redundant I/O
+let cachedDocsDir: string | null = null
+
 /**
  * Get the docs directory path
  */
 async function getDocsDir(): Promise<string> {
+  if (cachedDocsDir) return cachedDocsDir
+
   const candidates = [
     join(import.meta.dirname || '', '..', '..', 'docs'),
     // Bundled CLI at bin/cli.mjs -> ../build/src/docs/
@@ -53,9 +58,13 @@ async function getDocsDir(): Promise<string> {
   )
 
   const found = results.find((res) => res !== null)
-  if (found) return found
+  if (found) {
+    cachedDocsDir = found
+    return found
+  }
 
-  return join(process.cwd(), 'src', 'docs')
+  cachedDocsDir = join(process.cwd(), 'src', 'docs')
+  return cachedDocsDir
 }
 
 /**


### PR DESCRIPTION
💡 What: Added caching for the `getDocsDir()` function in `src/tools/composite/help.ts` via a module-level variable `cachedDocsDir`.
🎯 Why: Looking up the docs directory required 5 async filesystem checks against different potential locations. Since this location doesn't change during execution, evaluating it repeatedly blocks the event loop with unnecessary I/O.
📊 Impact: Reduces redundant filesystem checks and memory allocations to 0 after the first lookup. Expected to shave milliseconds of overhead off every subsequent `help` tool execution.
🔬 Measurement: Verify by executing the `help` tool multiple times. The first execution finds the directory; subsequent executions bypass the filesystem lookup logic.

---
*PR created automatically by Jules for task [4703339031931867137](https://jules.google.com/task/4703339031931867137) started by @n24q02m*