### PR TITLE
⚡ Bolt: Cache docs directory path in help tool

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-09 - [Optimize parseProjectGodot string parsing]
 **Learning:** Parsing `project.godot` (or other INI-like configurations) line-by-line using regular expressions inside a hot loop (e.g., `^\[(.+)\]$`, `/^([^\s=]+)\s*=\s*(.+)$/`) causes severe performance bottlenecks due to RegExp compilation, execution, and extensive GC pressure from intermediary match objects and string allocations.
 **Action:** Replace regular expressions within file parsing loops with manual string operations: use `charCodeAt` to identify section boundaries (e.g., `91` for `[`), `indexOf('=')` for key-value extraction, and direct `.slice()` + `.trim()` for data separation. Apply manual quote removal checking string bounds and `charCodeAt(0) === 34` instead of `.replace(/^"(.*)"$/, '$1')`.
+
+## 2024-05-15 - Cache Filesystem Discovery Operations
+**Learning:** In Node.js applications, repeated filesystem discovery operations (like searching for a documentation directory using `pathExists` across multiple candidate paths) can unnecessarily block the event loop and cause redundant I/O, even if done asynchronously.
+**Action:** When a path or configuration is static for the lifetime of the process, cache the result of the initial discovery in a module-level variable to optimize subsequent access and minimize I/O overhead.

--- a/src/tools/composite/help.ts
+++ b/src/tools/composite/help.ts
@@ -29,10 +29,15 @@ const VALID_TOPICS = [
 ] as const
 type TopicName = (typeof VALID_TOPICS)[number]
 
+// ⚡ Bolt: Cache docs directory to minimize event loop blocking and redundant I/O
+let cachedDocsDir: string | null = null
+
 /**
  * Get the docs directory path
  */
 async function getDocsDir(): Promise<string> {
+  if (cachedDocsDir) return cachedDocsDir
+
   const candidates = [
     join(import.meta.dirname || '', '..', '..', 'docs'),
     // Bundled CLI at bin/cli.mjs -> ../build/src/docs/
@@ -53,9 +58,13 @@ async function getDocsDir(): Promise<string> {
   )
 
   const found = results.find((res) => res !== null)
-  if (found) return found
+  if (found) {
+    cachedDocsDir = found
+    return found
+  }
 
-  return join(process.cwd(), 'src', 'docs')
+  cachedDocsDir = join(process.cwd(), 'src', 'docs')
+  return cachedDocsDir
 }
 
 /**


### PR DESCRIPTION
## ⚡ Bolt: Cache docs directory path in help tool

### 💡 What
Added a module-level cache (`cachedDocsDir`) for the `getDocsDir` function in `src/tools/composite/help.ts`. 

### 🎯 Why
When the `help` tool is repeatedly invoked (or accessed internally), it recursively searches multiple candidate paths on the filesystem using `pathExists`. Since the documentation directory path remains static for the lifetime of the process, these repeated filesystem discovery operations cause unnecessary I/O overhead and unnecessarily block the Node.js event loop, even if executed asynchronously.

### 📊 Impact
Eliminates redundant filesystem `pathExists` checks for the documentation path after the initial invocation, resulting in faster subsequent executions of the help tool and reduced event loop pressure.

### 🔬 Measurement
Tests (`bun run test`) passed successfully. Repeated help requests will skip filesystem iteration after the first resolution.

---
*PR created automatically by Jules for task [11790338127096620030](https://jules.google.com/task/11790338127096620030) started by @n24q02m*