### PR TITLE
⚡ Bolt: Cache docs directory path in help tool

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-09 - [Optimize parseProjectGodot string parsing]
 **Learning:** Parsing `project.godot` (or other INI-like configurations) line-by-line using regular expressions inside a hot loop (e.g., `^\[(.+)\]$`, `/^([^\s=]+)\s*=\s*(.+)$/`) causes severe performance bottlenecks due to RegExp compilation, execution, and extensive GC pressure from intermediary match objects and string allocations.
 **Action:** Replace regular expressions within file parsing loops with manual string operations: use `charCodeAt` to identify section boundaries (e.g., `91` for `[`), `indexOf('=')` for key-value extraction, and direct `.slice()` + `.trim()` for data separation. Apply manual quote removal checking string bounds and `charCodeAt(0) === 34` instead of `.replace(/^"(.*)"$/, '$1')`.
+
+## 2026-06-03 - [Cache static directory discovery]
+**Learning:** Tools that depend on filesystem discovery (like identifying the documentation path in `src/tools/composite/help.ts`) should not repeat the discovery process on every call, as it involves multiple redundant async checks (like `Promise.all` and `pathExists`) which block the Node.js event loop unnecessarily.
+**Action:** When a path or configuration is static for the lifetime of the process, cache the discovered result in a module-level variable to minimize event loop blocking and redundant I/O.

--- a/src/tools/composite/help.ts
+++ b/src/tools/composite/help.ts
@@ -29,10 +29,15 @@ const VALID_TOPICS = [
 ] as const
 type TopicName = (typeof VALID_TOPICS)[number]
 
+// ⚡ Bolt: Cache docs directory to prevent redundant I/O and Promise.all event loop blocking
+let cachedDocsDir: string | null = null
+
 /**
  * Get the docs directory path
  */
 async function getDocsDir(): Promise<string> {
+  if (cachedDocsDir) return cachedDocsDir
+
   const candidates = [
     join(import.meta.dirname || '', '..', '..', 'docs'),
     // Bundled CLI at bin/cli.mjs -> ../build/src/docs/
@@ -53,9 +58,13 @@ async function getDocsDir(): Promise<string> {
   )
 
   const found = results.find((res) => res !== null)
-  if (found) return found
+  if (found) {
+    cachedDocsDir = found
+    return found
+  }
 
-  return join(process.cwd(), 'src', 'docs')
+  cachedDocsDir = join(process.cwd(), 'src', 'docs')
+  return cachedDocsDir
 }
 
 /**


### PR DESCRIPTION
💡 **What:** Added a module-level variable to cache the result of `getDocsDir()` in the help tool handler.
🎯 **Why:** To prevent redundant filesystem operations and asynchronous event loop blocking when resolving the documentation directory on every documentation request. The docs directory path is static for the lifetime of the process, making it an ideal candidate for caching.
📊 **Impact:** Reduces redundant I/O operations and prevents unnecessary event loop delays.
🔬 **Measurement:** Can be verified by running the `bun run test` suite to ensure help tool functionality is unchanged and reviewing the `src/tools/composite/help.ts` file for the `cachedDocsDir` implementation.

---
*PR created automatically by Jules for task [7075809303121517923](https://jules.google.com/task/7075809303121517923) started by @n24q02m*