### PR TITLE
[FIX] Refactor prefix match

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,10 @@
 ## 2025-03-09 - [Optimize parseProjectGodot string parsing]
 **Learning:** Parsing `project.godot` (or other INI-like configurations) line-by-line using regular expressions inside a hot loop (e.g., `^\[(.+)\]$`, `/^([^\s=]+)\s*=\s*(.+)$/`) causes severe performance bottlenecks due to RegExp compilation, execution, and extensive GC pressure from intermediary match objects and string allocations.
 **Action:** Replace regular expressions within file parsing loops with manual string operations: use `charCodeAt` to identify section boundaries (e.g., `91` for `[`), `indexOf('=')` for key-value extraction, and direct `.slice()` + `.trim()` for data separation. Apply manual quote removal checking string bounds and `charCodeAt(0) === 34` instead of `.replace(/^"(.*)"$/, '$1')`.
+## 2025-05-22 - [Optimized Prefix Matching]
+**Learning:** Returning the first prefix match in a list of valid options can lead to incorrect results if a longer, more specific prefix or an exact match exists later in the list.
+**Action:** Refactored `findClosestMatch` in `src/tools/helpers/errors.ts` to use a prioritized hierarchy:
+1. Case-insensitive exact match (early return).
+2. Best prefix/containment match, defined as the one with the smallest absolute length difference relative to the input.
+3. Fuzzy bigram similarity (Dice coefficient) with a threshold > 0.4.
+This ensures that "create" matches "create" even if "create_node" appears earlier in the options list, and "cre" matches "create" over "create_node".

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-22 - [Correct Tool Suggestion]
+**Vulnerability:** Weak matching logic in error suggestions can mislead users or automated agents into calling unintended tools if they make a typo that partially matches multiple tool names.
+**Learning:** Prioritizing exact matches and closer prefix matches reduces the risk of incorrect "Did you mean...?" suggestions.
+**Prevention:** Implemented a length-difference based tie-breaker for prefix matches in `findClosestMatch` to ensure the most specific match is suggested.

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -75,7 +75,10 @@ export function formatJSON(data: unknown): { content: Array<{ type: 'text'; text
 
 /**
  * Find the closest matching string from a list of valid options.
- * Uses bigram similarity for fuzzy matching.
+ * Uses a prioritized hierarchy:
+ * 1. Case-insensitive exact match
+ * 2. Best prefix/containment match (closest in length)
+ * 3. Fuzzy bigram similarity (Dice coefficient)
  */
 export function findClosestMatch(input: string, validOptions: string[]): string | null {
   if (!input || validOptions.length === 0) return null
@@ -83,7 +86,36 @@ export function findClosestMatch(input: string, validOptions: string[]): string 
   // Truncate to prevent CPU exhaustion from excessively long inputs
   const safeInput = input.length > 100 ? input.slice(0, 100) : input
   const lower = safeInput.toLowerCase()
-  let bestMatch: string | null = null
+
+  // 1. Priority: Exact match (case-insensitive)
+  for (const option of validOptions) {
+    if (option.toLowerCase() === lower) {
+      return option
+    }
+  }
+
+  // 2. Priority: Prefix/containment match
+  // We want the one with the smallest absolute length difference
+  let bestPrefixMatch: string | null = null
+  let minLenDiff = Number.POSITIVE_INFINITY
+
+  for (const option of validOptions) {
+    const optionLower = option.toLowerCase()
+    if (optionLower.startsWith(lower) || lower.startsWith(optionLower)) {
+      const lenDiff = Math.abs(optionLower.length - lower.length)
+      if (lenDiff < minLenDiff) {
+        minLenDiff = lenDiff
+        bestPrefixMatch = option
+      }
+    }
+  }
+
+  if (bestPrefixMatch !== null) {
+    return bestPrefixMatch
+  }
+
+  // 3. Fallback: Fuzzy matching using bigram similarity
+  let bestFuzzyMatch: string | null = null
   let bestScore = 0
 
   const inputBigrams = new Set<string>()
@@ -93,11 +125,6 @@ export function findClosestMatch(input: string, validOptions: string[]): string 
 
   for (const option of validOptions) {
     const optionLower = option.toLowerCase()
-    // Quick prefix/containment match
-    if (optionLower.startsWith(lower) || lower.startsWith(optionLower)) {
-      return option
-    }
-
     const optionBigrams = new Set<string>()
     for (let i = 0; i < optionLower.length - 1; i++) {
       optionBigrams.add(optionLower.slice(i, i + 2))
@@ -114,11 +141,11 @@ export function findClosestMatch(input: string, validOptions: string[]): string 
     const score = (2 * overlap) / total
     if (score > bestScore && score > 0.4) {
       bestScore = score
-      bestMatch = option
+      bestFuzzyMatch = option
     }
   }
 
-  return bestMatch
+  return bestFuzzyMatch
 }
 
 /**

--- a/tests/helpers/errors.test.ts
+++ b/tests/helpers/errors.test.ts
@@ -182,6 +182,14 @@ describe('errors', () => {
       // 0.5: (2 * 2) / (4 + 4) = 0.5. Should match.
       expect(findClosestMatch('12345', ['123xy'])).toBe('123xy')
     })
+
+    it('should return exact match even if a prefix match comes first', () => {
+      expect(findClosestMatch('create', ['create_node', 'create'])).toBe('create')
+    })
+
+    it('should return the closest prefix match by length', () => {
+      expect(findClosestMatch('cre', ['create_node', 'create'])).toBe('create')
+    })
   })
 
   // ==========================================


### PR DESCRIPTION
Refactored the `findClosestMatch` function in `src/tools/helpers/errors.ts` to follow a prioritized matching hierarchy: 
1. Case-insensitive exact match (early return)
2. Best prefix/containment match (defined as the one with the smallest absolute length difference relative to the input)
3. Fuzzy bigram similarity (Dice coefficient) fallback with a threshold > 0.4.

This improvement ensures more accurate tool suggestions in error messages, correctly prioritizing specific or exact matches over the first partial match found in the valid options list. 

Unit tests in `tests/helpers/errors.test.ts` were updated to include these priority scenarios.

---
*PR created automatically by Jules for task [13697489219193967193](https://jules.google.com/task/13697489219193967193) started by @n24q02m*