### PR TITLE
[SECURITY] Command Injection via pid in taskkill

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2025-05-24 - PID Injection in taskkill
+
+**Vulnerability:** Command Injection via pid in taskkill
+**Learning:** Tracked process IDs in `activePids` (number[]) could be manipulated if the type system is bypassed (e.g., via `any` or external input that doesn't respect the interface). On Windows, these PIDs are passed to `taskkill` via `execFileSync`.
+**Prevention:** Strictly validate that every PID is a safe positive integer (`typeof pid === "number" && Number.isSafeInteger(pid) && pid > 0`) before passing it to `process.kill` or `taskkill`.

--- a/src/tools/composite/editor.ts
+++ b/src/tools/composite/editor.ts
@@ -15,6 +15,7 @@ function getGodotProcesses(config: GodotConfig): Array<{ pid: string; name: stri
   const activeProcesses: Array<{ pid: string; name: string }> = []
 
   for (const pid of config.activePids) {
+    if (typeof pid !== 'number' || !Number.isSafeInteger(pid) || pid <= 0) continue
     try {
       process.kill(pid, 0)
       activeProcesses.push({ pid: pid.toString(), name: 'godot' })

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -152,6 +152,12 @@ export async function handleProject(action: string, args: Record<string, unknown
 
       let stoppedCount = 0
       for (const pid of config.activePids) {
+        // Security: strictly validate that pid is a positive integer before using it in any shell-like commands
+        if (typeof pid !== 'number' || !Number.isSafeInteger(pid) || pid <= 0) {
+          console.error(`[project] Skipping invalid PID in stop action: ${pid}`)
+          continue
+        }
+
         try {
           if (process.platform === 'win32') {
             // Check if process exists before attempting to kill
@@ -170,7 +176,6 @@ export async function handleProject(action: string, args: Record<string, unknown
           // Process might have already terminated
         }
       }
-
       config.activePids = []
       return formatSuccess(`Godot processes stopped (Stopped ${stoppedCount} tracked processes)`)
     }

--- a/tests/security/pid-injection.test.ts
+++ b/tests/security/pid-injection.test.ts
@@ -1,0 +1,83 @@
+import { execFileSync } from 'node:child_process'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleEditor } from '../../src/tools/composite/editor.js'
+import { handleProject } from '../../src/tools/composite/project.js'
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}))
+
+vi.mock('../../src/godot/headless.js', () => ({
+  runGodotProject: vi.fn(),
+  launchGodotEditor: vi.fn(),
+  execGodotAsync: vi.fn(),
+}))
+
+describe('PID Injection Security', () => {
+  let config: GodotConfig
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    config = {
+      godotPath: '/path/to/godot',
+      godotVersion: { major: 4, minor: 0, patch: 0, label: 'stable', raw: '4.0.stable' },
+      projectPath: '/path/to/project',
+      activePids: [],
+    }
+  })
+
+  describe('handleProject stop', () => {
+    it('should only call taskkill with valid integer PIDs on Windows', async () => {
+      const originalPlatform = process.platform
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+
+      // Inject a malicious "PID" (bypassing type system)
+      // biome-ignore lint/suspicious/noExplicitAny: needed for testing security bypass
+      ;(config.activePids as any).push('1234; calc.exe')
+
+      const processKillSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+        return true
+      })
+
+      await handleProject('stop', {}, config)
+
+      // Check if taskkill was called with the malicious string
+      expect(execFileSync).not.toHaveBeenCalledWith(
+        'taskkill',
+        expect.arrayContaining(['1234; calc.exe']),
+        expect.anything(),
+      )
+
+      processKillSpy.mockRestore()
+      Object.defineProperty(process, 'platform', { value: originalPlatform })
+    })
+
+    it('should skip non-numeric PIDs', async () => {
+      // biome-ignore lint/suspicious/noExplicitAny: needed for testing security bypass
+      ;(config.activePids as any).push('not-a-pid')
+      const processKillSpy = vi.spyOn(process, 'kill')
+
+      await handleProject('stop', {}, config)
+
+      expect(processKillSpy).not.toHaveBeenCalled()
+      processKillSpy.mockRestore()
+    })
+  })
+
+  describe('handleEditor status', () => {
+    it('should skip invalid PIDs in getGodotProcesses', async () => {
+      // biome-ignore lint/suspicious/noExplicitAny: needed for testing security bypass
+      ;(config.activePids as any).push('1234; calc.exe')
+      const processKillSpy = vi.spyOn(process, 'kill')
+
+      const result = await handleEditor('status', {}, config)
+      const data = JSON.parse(result.content[0].text)
+
+      expect(processKillSpy).not.toHaveBeenCalledWith('1234; calc.exe', 0)
+      expect(data.processes).toHaveLength(0)
+
+      processKillSpy.mockRestore()
+    })
+  })
+})


### PR DESCRIPTION
Addresses a command injection vulnerability on Windows where potentially manipulated process IDs were passed to `taskkill`. Added strict integer validation for all PIDs before use.

---
*PR created automatically by Jules for task [17693726949034586390](https://jules.google.com/task/17693726949034586390) started by @n24q02m*