### PR TITLE
[PERF] Sequential Read/Stat operations without parallelization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2025-03-09 - [Optimize parseProjectGodot string parsing]
 **Learning:** Parsing `project.godot` (or other INI-like configurations) line-by-line using regular expressions inside a hot loop (e.g., `^\[(.+)\]$`, `/^([^\s=]+)\s*=\s*(.+)$/`) causes severe performance bottlenecks due to RegExp compilation, execution, and extensive GC pressure from intermediary match objects and string allocations.
 **Action:** Replace regular expressions within file parsing loops with manual string operations: use `charCodeAt` to identify section boundaries (e.g., `91` for `[`), `indexOf('=')` for key-value extraction, and direct `.slice()` + `.trim()` for data separation. Apply manual quote removal checking string bounds and `charCodeAt(0) === 34` instead of `.replace(/^"(.*)"$/, '$1')`.
+## 2025-05-15 - [Optimization] Redundant pathExists checks in resources tool
+**Learning:** Sequential `pathExists` and `stat`/`readFile`/`unlink` operations result in redundant filesystem calls. Direct execution with `try-catch` handling for `ENOENT` is more efficient for existing files.
+**Action:** Replaced `pathExists` followed by I/O operations in `handleResources` with direct calls and `NodeJS.ErrnoException` code checks.

--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -7,7 +7,7 @@ import { readdir, readFile, stat, unlink } from 'node:fs/promises'
 import { extname, join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { pathExists, safeResolve } from '../helpers/paths.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const RESOURCE_EXTENSIONS = new Set([
   '.tres',
@@ -121,41 +121,55 @@ export async function handleResources(action: string, args: Record<string, unkno
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
       const fullPath = safeResolve(projectPath || process.cwd(), resPath)
-      if (!(await pathExists(fullPath)))
-        throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
-      const fileStat = await stat(fullPath)
-      const ext = extname(fullPath)
-      const info: Record<string, unknown> = {
-        path: resPath,
-        extension: ext,
-        size: fileStat.size,
-        modified: fileStat.mtime.toISOString(),
+      try {
+        const fileStat = await stat(fullPath)
+        const ext = extname(fullPath)
+        const info: Record<string, unknown> = {
+          path: resPath,
+          extension: ext,
+          size: fileStat.size,
+          modified: fileStat.mtime.toISOString(),
+        }
+
+        // Parse .tres/.import files for metadata
+        if (ext === '.tres' || ext === '.import') {
+          const content = await readFile(fullPath, 'utf-8')
+          const typeMatch = content.match(/type="([^"]*)"/)
+          if (typeMatch) info.type = typeMatch[1]
+          const pathMatch = content.match(/path="([^"]*)"/)
+          if (pathMatch) info.importPath = pathMatch[1]
+        }
+
+        return formatJSON(info)
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
+        }
+        throw err
       }
-
-      // Parse .tres/.import files for metadata
-      if (ext === '.tres' || ext === '.import') {
-        const content = await readFile(fullPath, 'utf-8')
-        const typeMatch = content.match(/type="([^"]*)"/)
-        if (typeMatch) info.type = typeMatch[1]
-        const pathMatch = content.match(/path="([^"]*)"/)
-        if (pathMatch) info.importPath = pathMatch[1]
-      }
-
-      return formatJSON(info)
     }
 
     case 'delete': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
       const fullPath = safeResolve(projectPath || process.cwd(), resPath)
-      if (!(await pathExists(fullPath)))
-        throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
-      await unlink(fullPath)
+      try {
+        await unlink(fullPath)
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
+        }
+        throw err
+      }
+
       // Also delete .import file if exists
-      const importFile = `${fullPath}.import`
-      if (await pathExists(importFile)) await unlink(importFile)
+      try {
+        await unlink(`${fullPath}.import`)
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+      }
 
       return formatSuccess(`Deleted resource: ${resPath}`)
     }
@@ -166,12 +180,15 @@ export async function handleResources(action: string, args: Record<string, unkno
 
       const importPath = safeResolve(projectPath || process.cwd(), `${resPath}.import`)
 
-      if (!(await pathExists(importPath))) {
-        return formatJSON({ path: resPath, imported: false, message: 'No .import file found.' })
+      try {
+        const content = await readFile(importPath, 'utf-8')
+        return formatSuccess(`Import config for ${resPath}:\n\n${content}`)
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          return formatJSON({ path: resPath, imported: false, message: 'No .import file found.' })
+        }
+        throw err
       }
-
-      const content = await readFile(importPath, 'utf-8')
-      return formatSuccess(`Import config for ${resPath}:\n\n${content}`)
     }
 
     default:


### PR DESCRIPTION
This PR optimizes the resources tool by reducing redundant filesystem calls.

Previously, the 'info', 'delete', and 'import_config' actions would perform a `pathExists` check before calling `stat`, `unlink`, or `readFile`. This resulted in two filesystem operations for every successful request.

By replacing these checks with direct filesystem calls and handling the `ENOENT` error code using `try-catch` blocks, we cut the number of filesystem calls in half for existing files.

Changes:
- In `info` action: Replaced `pathExists` + `stat` with `stat` + `try-catch`.
- In `delete` action: Replaced `pathExists` + `unlink` with `unlink` + `try-catch`.
- In `import_config` action: Replaced `pathExists` + `readFile` with `readFile` + `try-catch`.
- Fixed linting issues by removing unused `pathExists` import and using `NodeJS.ErrnoException` type for error casting.

---
*PR created automatically by Jules for task [13672930889804482761](https://jules.google.com/task/13672930889804482761) started by @n24q02m*