### PR TITLE
[PERF] Unnecessary Object.keys allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2025-03-09 - [Optimize parseProjectGodot string parsing]
 **Learning:** Parsing `project.godot` (or other INI-like configurations) line-by-line using regular expressions inside a hot loop (e.g., `^\[(.+)\]$`, `/^([^\s=]+)\s*=\s*(.+)$/`) causes severe performance bottlenecks due to RegExp compilation, execution, and extensive GC pressure from intermediary match objects and string allocations.
 **Action:** Replace regular expressions within file parsing loops with manual string operations: use `charCodeAt` to identify section boundaries (e.g., `91` for `[`), `indexOf('=')` for key-value extraction, and direct `.slice()` + `.trim()` for data separation. Apply manual quote removal checking string bounds and `charCodeAt(0) === 34` instead of `.replace(/^"(.*)"$/, '$1')`.
+## 2025-05-15 - [PERF] Unnecessary Object.keys allocation
+**Learning:** Replacing `Object.keys(obj).forEach` or `for (const key of Object.keys(obj))` with `for (const key in obj)` avoids creating an intermediate array of strings. This is a micro-optimization that can add up in hot paths like scene parsing.
+**Action:** Refactored `updateNodeInScene` in `src/tools/helpers/scene-parser.ts` to use `for...in` instead of `Object.keys`.

--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -386,14 +386,13 @@ export function updateNodeInScene(
   }
 
   const updatedProperties = new Set<string>()
-  const keys = Object.keys(updates)
-
+  // ⚡ Bolt: Use for...in to avoid Object.keys allocation
   const newContent = transformSceneContent(content, nodeName, {
     processLine: (line, inTargetNode, isSectionHeader) => {
       if (inTargetNode && !isSectionHeader) {
         // Find if this line is one of our target properties
         const trimmed = line.trimStart()
-        for (const key of keys) {
+        for (const key in updates) {
           if (trimmed.startsWith(`${key} `) || trimmed.startsWith(`${key}=`)) {
             updatedProperties.add(key)
             return `${key} = ${updates[key]}`
@@ -404,7 +403,7 @@ export function updateNodeInScene(
     },
     onTargetNodeEnd: () => {
       const added: string[] = []
-      for (const key of keys) {
+      for (const key in updates) {
         if (!updatedProperties.has(key)) {
           added.push(`${key} = ${updates[key]}`)
         }


### PR DESCRIPTION
### Overview
This PR optimizes the `updateNodeInScene` function in `src/tools/helpers/scene-parser.ts` by removing an unnecessary `Object.keys()` call and replacing it with `for...in` loops.

### Rationale
Creating an array of strings via `Object.keys()` allocates memory that can be avoided by iterating directly over the object's properties using `for...in`. This is a micro-optimization that improves performance in hot paths where scene content is frequently updated.

### Changes
- Removed `const keys = Object.keys(updates)` in `updateNodeInScene`.
- Updated `processLine` callback to use `for (const key in updates)`.
- Updated `onTargetNodeEnd` callback to use `for (const key in updates)`.
- Added a `// ⚡ Bolt:` performance comment to the code.
- Recorded the learning in `.jules/bolt.md`.

### Verification
- Ran `bun run test tests/helpers/scene-parser.test.ts` (37/37 tests passed).
- Ran `bun run check` (Linting and Type checking passed).

---
*PR created automatically by Jules for task [412262225506774613](https://jules.google.com/task/412262225506774613) started by @n24q02m*