### PR TITLE
[PERF] Synchronous pathExists checking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2025-03-09 - [Optimize parseProjectGodot string parsing]
 **Learning:** Parsing `project.godot` (or other INI-like configurations) line-by-line using regular expressions inside a hot loop (e.g., `^\[(.+)\]$`, `/^([^\s=]+)\s*=\s*(.+)$/`) causes severe performance bottlenecks due to RegExp compilation, execution, and extensive GC pressure from intermediary match objects and string allocations.
 **Action:** Replace regular expressions within file parsing loops with manual string operations: use `charCodeAt` to identify section boundaries (e.g., `91` for `[`), `indexOf('=')` for key-value extraction, and direct `.slice()` + `.trim()` for data separation. Apply manual quote removal checking string bounds and `charCodeAt(0) === 34` instead of `.replace(/^"(.*)"$/, '$1')`.
+## 2025-05-22 - [PERF] Optimized file existence checks in Audio tool
+**Learning:** Checking for file existence with `pathExists` before calling `readFile` is an anti-pattern that results in double file system interaction. Using a `try-catch` block around `readFile` is more efficient as it handles the "missing file" case as an exception while avoiding the redundant check.
+**Action:** Replaced `pathExists` + `readFile` patterns with `try-catch` blocks in `src/tools/composite/audio.ts` across all action handlers.

--- a/src/tools/composite/audio.ts
+++ b/src/tools/composite/audio.ts
@@ -7,7 +7,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { pathExists, safeResolve } from '../helpers/paths.js'
+import { safeResolve } from '../helpers/paths.js'
 
 /**
  * Helper to resolve the default bus layout path.
@@ -28,11 +28,13 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
     case 'list_buses': {
       const busLayoutPath = resolveBusLayoutPath(projectPath, baseDir)
 
-      if (!(await pathExists(busLayoutPath))) {
+      let content: string
+      try {
+        content = await readFile(busLayoutPath, 'utf-8')
+      } catch {
         return formatJSON({ buses: [{ name: 'Master', volume: 0, effects: [] }], note: 'Using default bus layout.' })
       }
 
-      const content = await readFile(busLayoutPath, 'utf-8')
       const buses: { name: string; volume?: string; solo?: boolean; mute?: boolean }[] = []
 
       // Parse bus entries
@@ -68,9 +70,9 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
 
       let content: string
 
-      if (await pathExists(busLayoutPath)) {
+      try {
         content = await readFile(busLayoutPath, 'utf-8')
-      } else {
+      } catch {
         content = [
           '[gd_resource type="AudioBusLayout" format=3]',
           '',
@@ -134,9 +136,9 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
 
       let content: string
 
-      if (await pathExists(busLayoutPath)) {
+      try {
         content = await readFile(busLayoutPath, 'utf-8')
-      } else {
+      } catch {
         content = [
           '[gd_resource type="AudioBusLayout" format=3]',
           '',
@@ -218,10 +220,13 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       }
 
       const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
-      if (!(await pathExists(fullPath)))
+      let content: string
+      try {
+        content = await readFile(fullPath, 'utf-8')
+      } catch {
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
+      }
 
-      let content = await readFile(fullPath, 'utf-8')
       const nodeType =
         streamType === '3D' ? 'AudioStreamPlayer3D' : streamType === '2D' ? 'AudioStreamPlayer2D' : 'AudioStreamPlayer'
       const parentAttr = parent === '.' ? '' : ` parent="${parent}"`


### PR DESCRIPTION
Optimized the Audio tool by replacing the `pathExists` + `readFile` pattern with a `try-catch` block around `readFile`. This reduces redundant file system interactions.

Changes:
- Refactored `list_buses`, `add_bus`, `add_effect`, and `create_stream` in `src/tools/composite/audio.ts`.
- Removed unused `pathExists` import.
- Added performance optimization learning to `.jules/bolt.md`.

---
*PR created automatically by Jules for task [3813712759352311405](https://jules.google.com/task/3813712759352311405) started by @n24q02m*