### PR TITLE
[PERF] Use pre-allocated array instead of filter().length

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-09 - [Optimize parseProjectGodot string parsing]
 **Learning:** Parsing `project.godot` (or other INI-like configurations) line-by-line using regular expressions inside a hot loop (e.g., `^\[(.+)\]$`, `/^([^\s=]+)\s*=\s*(.+)$/`) causes severe performance bottlenecks due to RegExp compilation, execution, and extensive GC pressure from intermediary match objects and string allocations.
 **Action:** Replace regular expressions within file parsing loops with manual string operations: use `charCodeAt` to identify section boundaries (e.g., `91` for `[`), `indexOf('=')` for key-value extraction, and direct `.slice()` + `.trim()` for data separation. Apply manual quote removal checking string bounds and `charCodeAt(0) === 34` instead of `.replace(/^"(.*)"$/, '$1')`.
+
+## 2025-05-14 - [Performance] Optimized match().length pattern
+**Learning:** Using `(str.match(/regex/g) || []).length` is inefficient as it creates an intermediate array and an fallback array just to count occurrences.
+**Action:** Implemented `countMatches` using `matchAll()` and `countString` using `indexOf()` in `src/tools/helpers/strings.ts`. Replaced inefficient patterns in `src/tools/composite/tilemap.ts` and `src/tools/composite/audio.ts` with these specialized counting utilities to reduce memory allocation and GC pressure.

--- a/src/tools/composite/audio.ts
+++ b/src/tools/composite/audio.ts
@@ -8,6 +8,7 @@ import { join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
+import { countMatches } from '../helpers/strings.js'
 
 /**
  * Helper to resolve the default bus layout path.
@@ -85,7 +86,8 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       }
 
       // Count existing buses
-      const busCount = (content.match(/bus\/\d+\/name/g) || []).length
+      // ⚡ Bolt: Using countMatches avoids intermediate array allocation
+      const busCount = countMatches(content, /bus\/\d+\/name/g)
 
       const newBus = [
         `bus/${busCount}/name = "${busName}"`,
@@ -165,8 +167,8 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
 
       // Count existing effects on this bus
       const effectCountRegex = new RegExp(`bus/${busIndex}/effect/\\d+/effect`, 'g')
-      const existingEffects = content.match(effectCountRegex) || []
-      const effectIndex = existingEffects.length
+      // ⚡ Bolt: Using countMatches avoids intermediate array allocation
+      const effectIndex = countMatches(content, effectCountRegex)
 
       // Generate unique sub_resource id
       const subResId = `${fullEffectType}_${Date.now()}`

--- a/src/tools/composite/tilemap.ts
+++ b/src/tools/composite/tilemap.ts
@@ -9,6 +9,7 @@ import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
+import { countString } from '../helpers/strings.js'
 
 /**
  * Async helper to check file existence without blocking the event loop
@@ -87,7 +88,8 @@ export async function handleTilemap(action: string, args: Record<string, unknown
       const resPath = `res://${texturePath.replaceAll('\\', '/')}`
 
       // Count existing sources to get next ID
-      const sourceCount = (content.match(/\[ext_resource/g) || []).length
+      // ⚡ Bolt: Using countString avoids intermediate array allocation from match()
+      const sourceCount = countString(content, '[ext_resource')
       const sourceId = `source_${sourceCount}`
 
       // Add ext_resource reference

--- a/src/tools/helpers/strings.ts
+++ b/src/tools/helpers/strings.ts
@@ -33,3 +33,31 @@ export function parseCommaSeparatedList(str: string): string[] {
 
   return result
 }
+
+/**
+ * Efficiently counts occurrences of a regular expression in a string.
+ * Uses matchAll to avoid creating an intermediate array of all matches.
+ * Note: The regex MUST have the 'g' flag.
+ */
+export function countMatches(str: string, regex: RegExp): number {
+  let count = 0
+  for (const _ of str.matchAll(regex)) {
+    count++
+  }
+  return count
+}
+
+/**
+ * Efficiently counts occurrences of a substring in a string.
+ * Uses indexOf in a loop to avoid RegExp overhead and array allocations.
+ */
+export function countString(str: string, substr: string): number {
+  if (substr.length === 0) return 0
+  let count = 0
+  let pos = str.indexOf(substr)
+  while (pos !== -1) {
+    count++
+    pos = str.indexOf(substr, pos + substr.length)
+  }
+  return count
+}

--- a/tests/helpers/strings.test.ts
+++ b/tests/helpers/strings.test.ts
@@ -36,3 +36,34 @@ describe('strings helpers', () => {
     })
   })
 })
+
+import { countMatches, countString } from '../../src/tools/helpers/strings.js'
+
+describe('countMatches', () => {
+  it('should count occurrences of a regex', () => {
+    expect(countMatches('abcabcabc', /a/g)).toBe(3)
+    expect(countMatches('abcabcabc', /abc/g)).toBe(3)
+    expect(countMatches('abcabcabc', /d/g)).toBe(0)
+  })
+
+  it('should handle complex regex', () => {
+    expect(countMatches('bus/0/name = "Master"\nbus/1/name = "SFX"', /bus\/\d+\/name/g)).toBe(2)
+  })
+})
+
+describe('countString', () => {
+  it('should count occurrences of a substring', () => {
+    expect(countString('abcabcabc', 'a')).toBe(3)
+    expect(countString('abcabcabc', 'abc')).toBe(3)
+    expect(countString('abcabcabc', 'd')).toBe(0)
+  })
+
+  it('should handle overlapping strings if specified (standard behavior is non-overlapping start positions)', () => {
+    // indexOf(substr, pos + substr.length) means non-overlapping
+    expect(countString('aaaaa', 'aa')).toBe(2)
+  })
+
+  it('should return 0 for empty substring', () => {
+    expect(countString('abc', '')).toBe(0)
+  })
+})


### PR DESCRIPTION
This PR optimizes the `(match() || []).length` pattern by introducing specialized counting utilities in `src/tools/helpers/strings.ts`. 

The previous implementation created intermediate arrays with `.match()` and fallback arrays `|| []` just to get the length, which is inefficient. The new implementation uses `matchAll()` for regex counting and `indexOf()` for fixed-string counting, significantly reducing memory allocations and GC pressure in hot paths like TileMap and Audio bus management.

Key changes:
- Added `countMatches` and `countString` to `src/tools/helpers/strings.ts`.
- Optimized `sourceCount` calculation in `src/tools/composite/tilemap.ts`.
- Optimized `busCount` and `effectIndex` calculations in `src/tools/composite/audio.ts`.
- Added comprehensive unit tests in `tests/helpers/strings.test.ts`.
- Documented learnings in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [10045415208040696234](https://jules.google.com/task/10045415208040696234) started by @n24q02m*