### PR TITLE
[PERF] Redundant Sequential Read/Stat Operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-09 - [Optimize parseProjectGodot string parsing]
 **Learning:** Parsing `project.godot` (or other INI-like configurations) line-by-line using regular expressions inside a hot loop (e.g., `^\[(.+)\]$`, `/^([^\s=]+)\s*=\s*(.+)$/`) causes severe performance bottlenecks due to RegExp compilation, execution, and extensive GC pressure from intermediary match objects and string allocations.
 **Action:** Replace regular expressions within file parsing loops with manual string operations: use `charCodeAt` to identify section boundaries (e.g., `91` for `[`), `indexOf('=')` for key-value extraction, and direct `.slice()` + `.trim()` for data separation. Apply manual quote removal checking string bounds and `charCodeAt(0) === 34` instead of `.replace(/^"(.*)"$/, '$1')`.
+
+## 2025-05-13 - [Eliminate Redundant Sequential Filesystem Operations]
+**Learning:** Calling `pathExists` (which internally calls `fs.access`) immediately followed by `fs.readFile` performs two sequential filesystem operations. This is redundant because `readFile` will naturally fail if the file does not exist.
+**Action:** Remove `pathExists` checks before `readFile` (or helpers like `parseProjectSettingsAsync` that perform a read). Wrap the read operation in a try-catch block and handle the `ENOENT` error code to throw the same custom application errors. This reduces the number of syscalls in core tool handlers.

--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -8,8 +8,8 @@ import { join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { toGodotValue } from '../helpers/godot-types.js'
-import { pathExists, safeResolve } from '../helpers/paths.js'
-import { parseProjectSettingsAsync, setSettingInContent } from '../helpers/project-settings.js'
+import { safeResolve } from '../helpers/paths.js'
+import { type ProjectSettings, parseProjectSettingsAsync, setSettingInContent } from '../helpers/project-settings.js'
 import { escapeRegExp } from '../helpers/scene-parser.js'
 import { validateNoNewlines } from '../helpers/security.js'
 
@@ -20,10 +20,17 @@ export async function handlePhysics(action: string, args: Record<string, unknown
     case 'layers': {
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
       const configPath = join(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
-      if (!(await pathExists(configPath)))
-        throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify project path.')
 
-      const settings = await parseProjectSettingsAsync(configPath)
+      let settings: ProjectSettings
+      try {
+        settings = await parseProjectSettingsAsync(configPath)
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify project path.')
+        }
+        throw error
+      }
+
       const layers2d: Record<string, string> = {}
       const layers3d: Record<string, string> = {}
 
@@ -51,10 +58,17 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       const collisionMask = args.collision_mask
 
       const fullPath = safeResolve(safeResolve(config.projectPath || process.cwd(), projectPath), scenePath)
-      if (!(await pathExists(fullPath)))
-        throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 
-      let content = await readFile(fullPath, 'utf-8')
+      let content: string
+      try {
+        content = await readFile(fullPath, 'utf-8')
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
+        }
+        throw error
+      }
+
       const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
       const match = content.match(nodeRegex)
       if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
@@ -91,10 +105,17 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       validateNoNewlines(undefined, scenePath, nodeName)
 
       const fullPath = safeResolve(safeResolve(config.projectPath || process.cwd(), projectPath), scenePath)
-      if (!(await pathExists(fullPath)))
-        throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 
-      let content = await readFile(fullPath, 'utf-8')
+      let content: string
+      try {
+        content = await readFile(fullPath, 'utf-8')
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
+        }
+        throw error
+      }
+
       const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
       const match = content.match(nodeRegex)
       if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
@@ -133,10 +154,17 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       }
 
       const configPath = join(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
-      if (!(await pathExists(configPath)))
-        throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify project path.')
 
-      const content = await readFile(configPath, 'utf-8')
+      let content: string
+      try {
+        content = await readFile(configPath, 'utf-8')
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify project path.')
+        }
+        throw error
+      }
+
       const key = `layer_names/${dimension}_physics/layer_${layerNum}`
       const updated = setSettingInContent(content, key, `"${name}"`)
       await writeFile(configPath, updated, 'utf-8')


### PR DESCRIPTION
Optimized src/tools/composite/physics.ts by removing redundant pathExists calls before readFile and parseProjectSettingsAsync. These actions now use try-catch blocks to handle ENOENT errors, reducing filesystem syscalls in core tool handlers.

Changes:
- In `layers`, `collision_setup`, `body_config`, and `set_layer_name` actions, removed `pathExists` checks.
- Wrapped read operations in try-catch blocks to catch `ENOENT` and throw the appropriate `GodotMCPError`.
- Fixed linting issues (implicit any, unused imports) in the modified file.
- Updated performance journal `.jules/bolt.md`.

---
*PR created automatically by Jules for task [10275403179489037197](https://jules.google.com/task/10275403179489037197) started by @n24q02m*