### PR TITLE
[CLEANUP] Potential ReDoS via RegExp in Audio effects matching

### DIFF
--- a/src/tools/composite/audio.ts
+++ b/src/tools/composite/audio.ts
@@ -8,6 +8,7 @@ import { join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
+import { escapeRegExp } from '../helpers/scene-parser.js'
 
 /**
  * Helper to resolve the default bus layout path.
@@ -159,12 +160,13 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
           break
         }
       }
-      if (busIndex === -1) {
+      if (busIndex === -1 || !Number.isFinite(busIndex)) {
         throw new GodotMCPError(`Bus "${busName}" not found`, 'AUDIO_ERROR', 'Add the bus first with add_bus.')
       }
 
       // Count existing effects on this bus
-      const effectCountRegex = new RegExp(`bus/${busIndex}/effect/\\d+/effect`, 'g')
+      const escapedBusIndex = escapeRegExp(busIndex.toString())
+      const effectCountRegex = new RegExp(`bus/${escapedBusIndex}/effect/\\d+/effect`, 'g')
       const existingEffects = content.match(effectCountRegex) || []
       const effectIndex = existingEffects.length
 

--- a/tests/composite/audio.test.ts
+++ b/tests/composite/audio.test.ts
@@ -257,4 +257,39 @@ describe('audio', () => {
   it('should throw for unknown action', async () => {
     await expect(handleAudio('invalid_action', { project_path: projectPath }, config)).rejects.toThrow('Unknown action')
   })
+
+  describe('safety', () => {
+    it('should handle extremely large bus indices correctly by escaping scientific notation', async () => {
+      // Create a layout file with a large bus index
+      const layoutPath = join(projectPath, 'default_bus_layout.tres')
+      const largeIndex = '1000000000000000000000' // 1e+21
+      const content = `[gd_resource type="AudioBusLayout" format=3]\n\n[resource]\nbus/${largeIndex}/name = "LargeBus"\n`
+      const { writeFileSync } = await import('node:fs')
+      writeFileSync(layoutPath, content, 'utf-8')
+
+      const result = await handleAudio(
+        'add_effect',
+        {
+          project_path: projectPath,
+          bus_name: 'LargeBus',
+          effect_type: 'Reverb',
+        },
+        config,
+      )
+
+      expect(result.content[0].text).toContain('Added AudioEffectReverb to bus "LargeBus"')
+      const { readFileSync } = await import('node:fs')
+      const updatedContent = readFileSync(layoutPath, 'utf-8')
+      // If escaped correctly, it should find 0 existing effects (as the regex matches '1e+21' literally)
+      // and use effect index 0.
+      expect(updatedContent).toContain('bus/1e+21/effect/0/effect')
+    })
+  })
+
+  // ==========================================
+  // Invalid Action
+  // ==========================================
+  it('should throw for unknown action', async () => {
+    await expect(handleAudio('invalid_action', { project_path: projectPath }, config)).rejects.toThrow('Unknown action')
+  })
 })


### PR DESCRIPTION
This PR addresses a potential ReDoS vulnerability in the audio tool's effect matching logic.

When adding an effect to an audio bus, the code constructs a Regular Expression using the `busIndex`. If `busIndex` is very large (>= 10^21), it stringifies to scientific notation (e.g., '1e+21'). The '+' character in this string is interpreted as a regex quantifier, which could lead to ReDoS or incorrect matching.

Changes:
1.  **Validation**: Added `Number.isFinite(busIndex)` check to ensure we have a valid numeric index.
2.  **Escaping**: Imported and used `escapeRegExp` to escape the stringified `busIndex` before interpolating it into the `effectCountRegex`.
3.  **Testing**: Added a new test case in `tests/composite/audio.test.ts` that simulates a large bus index and verifies the fix.

Verified with `bun run check:fix`, `bun run test`, and `bun x tsc --noEmit`.

---
*PR created automatically by Jules for task [8076086625825473049](https://jules.google.com/task/8076086625825473049) started by @n24q02m*