### PR TITLE
[CLEANUP] ReDoS via Unsafe Dynamic RegExp in Physics body config

### DIFF
--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -10,7 +10,7 @@ import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '..
 import { toGodotValue } from '../helpers/godot-types.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
 import { parseProjectSettingsAsync, setSettingInContent } from '../helpers/project-settings.js'
-import { escapeRegExp } from '../helpers/scene-parser.js'
+import { updateNodeInScene } from '../helpers/scene-parser.js'
 import { validateNoNewlines } from '../helpers/security.js'
 
 export async function handlePhysics(action: string, args: Record<string, unknown>, config: GodotConfig) {
@@ -55,26 +55,22 @@ export async function handlePhysics(action: string, args: Record<string, unknown
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 
       let content = await readFile(fullPath, 'utf-8')
-      const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-      const match = content.match(nodeRegex)
-      if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-
-      if (match.index === undefined)
-        throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-      const insertPoint = match.index + match[0].length
-      let props = ''
+      const updates: Record<string, string> = {}
       if (collisionLayer !== undefined) {
         const val = toGodotValue(collisionLayer)
         validateNoNewlines('Invalid collision_layer: newlines not allowed', val)
-        props += `\ncollision_layer = ${val}`
+        updates.collision_layer = val
       }
       if (collisionMask !== undefined) {
         const val = toGodotValue(collisionMask)
         validateNoNewlines('Invalid collision_mask: newlines not allowed', val)
-        props += `\ncollision_mask = ${val}`
+        updates.collision_mask = val
       }
 
-      content = `${content.slice(0, insertPoint)}${props}${content.slice(insertPoint)}`
+      const { content: updatedContent, updated } = updateNodeInScene(content, nodeName, updates)
+      if (!updated) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+      content = updatedContent
+
       await writeFile(fullPath, content, 'utf-8')
 
       return formatSuccess(
@@ -95,24 +91,20 @@ export async function handlePhysics(action: string, args: Record<string, unknown
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 
       let content = await readFile(fullPath, 'utf-8')
-      const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-      const match = content.match(nodeRegex)
-      if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-
-      let props = ''
+      const updates: Record<string, string> = {}
       const physicsProps = ['gravity_scale', 'mass', 'linear_damp', 'angular_damp', 'freeze']
       for (const prop of physicsProps) {
         if (args[prop] !== undefined) {
           const val = toGodotValue(args[prop])
           validateNoNewlines(`Invalid ${prop}: newlines not allowed`, val)
-          props += `\n${prop} = ${val}`
+          updates[prop] = val
         }
       }
 
-      if (match.index === undefined)
-        throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-      const insertPoint = match.index + match[0].length
-      content = `${content.slice(0, insertPoint)}${props}${content.slice(insertPoint)}`
+      const { content: updatedContent, updated } = updateNodeInScene(content, nodeName, updates)
+      if (!updated) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+      content = updatedContent
+
       await writeFile(fullPath, content, 'utf-8')
 
       return formatSuccess(`Configured physics body: ${nodeName}`)

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -1,6 +1,6 @@
 /**
- * Scripts tool - GDScript file management
- * Actions: create | read | write | attach | list | delete
+ * Scripts tool - Script attachment and management
+ * Actions: attach | list | delete | edit
  */
 
 import { mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/promises'
@@ -8,7 +8,7 @@ import { dirname, join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
-import { escapeRegExp } from '../helpers/scene-parser.js'
+import { updateNodeInScene } from '../helpers/scene-parser.js'
 
 const NODE_SECTION_RE = /(\[node [^\]]+\])/
 
@@ -210,16 +210,17 @@ async function attachScript(args: Record<string, unknown>, resolvePath: (path: s
   const resPath = `res://${scriptPath.replaceAll('\\', '/')}`
 
   if (nodeName) {
-    const nodePattern = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-    const match = content.match(nodePattern)
-    if (!match)
+    const updates = { script: `ExtResource("${resPath}")` }
+    const { content: updatedContent, updated } = updateNodeInScene(content, nodeName, updates)
+    if (!updated)
       throw new GodotMCPError(
         `Node "${nodeName}" not found in scene`,
         'NODE_ERROR',
         'Check node name with nodes.list action.',
       )
-    content = content.replace(nodePattern, (_match, p1) => `${p1}\nscript = ExtResource("${resPath}")`)
+    content = updatedContent
   } else {
+    // If no node name, attach to the first node in the scene (root)
     content = content.replace(NODE_SECTION_RE, (_match, p1) => `${p1}\nscript = ExtResource("${resPath}")`)
   }
 
@@ -262,12 +263,6 @@ export async function handleScripts(action: string, args: Record<string, unknown
   const baseDir = config.projectPath || process.cwd()
   // Validate args.project_path against the trusted baseDir to prevent path traversal vulnerabilities
   const projectPath = args.project_path ? safeResolve(baseDir, args.project_path as string) : config.projectPath
-
-  if (!projectPath && action !== 'list') {
-    // List handles missing projectPath internally, but others need it for safeResolve base
-    // Though list also throws if missing. Let's rely on standard checks inside but ensure projectPath is available for resolution.
-    // Actually, all actions check projectPath. We can resolve it early.
-  }
 
   // Helper to resolve path securely
   const resolvePath = (path: string) => {

--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -8,7 +8,7 @@ import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
-import { escapeRegExp, parseScene } from '../helpers/scene-parser.js'
+import { parseScene, updateNodeInScene } from '../helpers/scene-parser.js'
 
 const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
   Button: { text: '"Click"' },
@@ -187,33 +187,49 @@ async function handleLayout(projectPath: string | null | undefined, args: Record
   const fullPath = await resolveScene(projectPath, scenePath)
   let content = await readFile(fullPath, 'utf-8')
 
-  const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-  const match = content.match(nodeRegex)
-  if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-
-  let layoutProps = ''
+  const updates: Record<string, string> = {}
   switch (preset) {
     case 'full_rect':
-      layoutProps =
-        '\nanchors_preset = 15\nanchor_right = 1.0\nanchor_bottom = 1.0\ngrow_horizontal = 2\ngrow_vertical = 2'
+      updates.anchors_preset = '15'
+      updates.anchor_right = '1.0'
+      updates.anchor_bottom = '1.0'
+      updates.grow_horizontal = '2'
+      updates.grow_vertical = '2'
       break
     case 'center':
-      layoutProps =
-        '\nanchors_preset = 8\nanchor_left = 0.5\nanchor_top = 0.5\nanchor_right = 0.5\nanchor_bottom = 0.5\ngrow_horizontal = 2\ngrow_vertical = 2'
+      updates.anchors_preset = '8'
+      updates.anchor_left = '0.5'
+      updates.anchor_top = '0.5'
+      updates.anchor_right = '0.5'
+      updates.anchor_bottom = '0.5'
+      updates.grow_horizontal = '2'
+      updates.grow_vertical = '2'
       break
     case 'top_wide':
-      layoutProps = '\nanchors_preset = 10\nanchor_right = 1.0\ngrow_horizontal = 2'
+      updates.anchors_preset = '10'
+      updates.anchor_right = '1.0'
+      updates.grow_horizontal = '2'
       break
     case 'bottom_wide':
-      layoutProps =
-        '\nanchors_preset = 12\nanchor_top = 1.0\nanchor_right = 1.0\nanchor_bottom = 1.0\ngrow_horizontal = 2\ngrow_vertical = 0'
+      updates.anchors_preset = '12'
+      updates.anchor_top = '1.0'
+      updates.anchor_right = '1.0'
+      updates.anchor_bottom = '1.0'
+      updates.grow_horizontal = '2'
+      updates.grow_vertical = '0'
       break
     case 'left_wide':
-      layoutProps = '\nanchors_preset = 9\nanchor_bottom = 1.0\ngrow_vertical = 2'
+      updates.anchors_preset = '9'
+      updates.anchor_bottom = '1.0'
+      updates.grow_vertical = '2'
       break
     case 'right_wide':
-      layoutProps =
-        '\nanchors_preset = 11\nanchor_left = 1.0\nanchor_right = 1.0\nanchor_bottom = 1.0\ngrow_horizontal = 0\ngrow_vertical = 2'
+      updates.anchors_preset = '11'
+      updates.anchor_left = '1.0'
+      updates.anchor_right = '1.0'
+      updates.anchor_bottom = '1.0'
+      updates.grow_horizontal = '0'
+      updates.grow_vertical = '2'
       break
     default:
       throw new GodotMCPError(
@@ -223,10 +239,10 @@ async function handleLayout(projectPath: string | null | undefined, args: Record
       )
   }
 
-  if (match.index === undefined)
-    throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-  const insertPoint = match.index + match[0].length
-  content = `${content.slice(0, insertPoint)}${layoutProps}${content.slice(insertPoint)}`
+  const { content: updatedContent, updated } = updateNodeInScene(content, nodeName, updates)
+  if (!updated) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+  content = updatedContent
+
   await writeFile(fullPath, content, 'utf-8')
 
   return formatSuccess(`Set layout preset "${preset}" on ${nodeName}`)


### PR DESCRIPTION
Fixed ReDoS vulnerabilities by replacing unsafe dynamic regular expressions with the `updateNodeInScene` utility in `physics.ts`, `ui.ts`, and `scripts.ts`. This also improves robustness by preventing property duplication in scene files.

---
*PR created automatically by Jules for task [16891891465034755021](https://jules.google.com/task/16891891465034755021) started by @n24q02m*