### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection vulnerability in PID handling

### DIFF
--- a/src/tools/composite/editor.ts
+++ b/src/tools/composite/editor.ts
@@ -15,6 +15,10 @@ function getGodotProcesses(config: GodotConfig): Array<{ pid: string; name: stri
   const activeProcesses: Array<{ pid: string; name: string }> = []
 
   for (const pid of config.activePids) {
+    if (typeof pid !== 'number' || !Number.isSafeInteger(pid) || pid <= 0) {
+      continue
+    }
+
     try {
       process.kill(pid, 0)
       activeProcesses.push({ pid: pid.toString(), name: 'godot' })

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -152,6 +152,10 @@ export async function handleProject(action: string, args: Record<string, unknown
 
       let stoppedCount = 0
       for (const pid of config.activePids) {
+        if (typeof pid !== 'number' || !Number.isSafeInteger(pid) || pid <= 0) {
+          continue
+        }
+
         try {
           if (process.platform === 'win32') {
             // Check if process exists before attempting to kill

--- a/tests/security/pid-injection.test.ts
+++ b/tests/security/pid-injection.test.ts
@@ -1,0 +1,66 @@
+import { execFileSync } from 'node:child_process'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleEditor } from '../../src/tools/composite/editor.js'
+import { handleProject } from '../../src/tools/composite/project.js'
+
+vi.mock('node:child_process')
+
+describe('PID Validation Security', () => {
+  let originalPlatform: string
+  let processKillSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    processKillSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform })
+    processKillSpy.mockRestore()
+  })
+
+  it('should ignore malicious non-integer PIDs when stopping project', async () => {
+    const config: GodotConfig = {
+      godotPath: '/path/to/godot',
+      godotVersion: null,
+      projectPath: '/path/to/project',
+      // @ts-expect-error - simulating malicious injection
+      activePids: ['123";calc.exe', -1, 0, 3.14, NaN, Infinity, 1234],
+    }
+
+    const result = await handleProject('stop', {}, config)
+
+    // Only the valid PID (1234) should have been processed
+    expect(processKillSpy).toHaveBeenCalledTimes(1)
+    expect(processKillSpy).toHaveBeenCalledWith(1234, 0)
+
+    expect(execFileSync).toHaveBeenCalledTimes(1)
+    expect(execFileSync).toHaveBeenCalledWith('taskkill', ['/F', '/PID', '1234', '/T'], expect.anything())
+
+    expect(config.activePids).toHaveLength(0)
+    expect(result.content[0].text).toContain('Stopped 1 tracked processes')
+  })
+
+  it('should ignore malicious non-integer PIDs when checking editor status', async () => {
+    const config: GodotConfig = {
+      godotPath: '/path/to/godot',
+      godotVersion: null,
+      projectPath: '/path/to/project',
+      // @ts-expect-error - simulating malicious injection
+      activePids: ['123";calc.exe', -1, 0, 3.14, NaN, Infinity, 5678],
+    }
+
+    const result = await handleEditor('status', {}, config)
+    const json = JSON.parse(result.content[0].text)
+
+    // Only the valid PID (5678) should have been processed
+    expect(processKillSpy).toHaveBeenCalledTimes(1)
+    expect(processKillSpy).toHaveBeenCalledWith(5678, 0)
+
+    expect(json.processes).toHaveLength(1)
+    expect(json.processes[0].pid).toBe('5678')
+  })
+})


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** PID values pulled from an externally manipulable configuration object (`config.activePids`) were passed directly into system `execFileSync('taskkill')` on Windows and `process.kill(pid)` on all platforms without ensuring they were positive integers. This allowed for potential Command Injection (via unescaped characters in the PID string) or process termination exploits (passing 0 or -1 to `process.kill` to kill process groups or arbitrary processes).
🎯 **Impact:** Allowed for potential Command Injection via `taskkill` or terminating critical Godot processes by poisoning the `activePids` array.
🔧 **Fix:** Added strict integer validation in `editor.ts` and `project.ts`: `if (typeof pid !== 'number' || !Number.isSafeInteger(pid) || pid <= 0) continue;`.
✅ **Verification:** Created `tests/security/pid-injection.test.ts` to ensure malicious, non-integer, or negative PIDs injected into `activePids` are safely ignored by both project stop and editor status actions. Run `bun run test tests/security/pid-injection.test.ts` to verify.

---
*PR created automatically by Jules for task [7134828324920672591](https://jules.google.com/task/7134828324920672591) started by @n24q02m*