### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Command Injection risk in PID handling

### DIFF
--- a/src/tools/composite/editor.ts
+++ b/src/tools/composite/editor.ts
@@ -15,6 +15,9 @@ function getGodotProcesses(config: GodotConfig): Array<{ pid: string; name: stri
   const activeProcesses: Array<{ pid: string; name: string }> = []
 
   for (const pid of config.activePids) {
+    // Prevent Command Injection and invalid kills
+    if (typeof pid !== 'number' || !Number.isSafeInteger(pid) || pid <= 0) continue
+
     try {
       process.kill(pid, 0)
       activeProcesses.push({ pid: pid.toString(), name: 'godot' })

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -152,6 +152,9 @@ export async function handleProject(action: string, args: Record<string, unknown
 
       let stoppedCount = 0
       for (const pid of config.activePids) {
+        // Prevent Command Injection and invalid kills
+        if (typeof pid !== 'number' || !Number.isSafeInteger(pid) || pid <= 0) continue
+
         try {
           if (process.platform === 'win32') {
             // Check if process exists before attempting to kill

--- a/tests/security/pid-injection.test.ts
+++ b/tests/security/pid-injection.test.ts
@@ -1,0 +1,124 @@
+import * as child_process from 'node:child_process'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleEditor } from '../../src/tools/composite/editor.js'
+import { handleProject } from '../../src/tools/composite/project.js'
+
+// Mock dependencies
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+  spawn: vi.fn(),
+  spawnSync: vi.fn(),
+}))
+
+vi.mock('../../src/godot/headless.js', () => ({
+  execGodotAsync: vi.fn(),
+  runGodotProject: vi.fn(),
+  launchGodotEditor: vi.fn(),
+}))
+
+describe('PID Injection Security Tests', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('project stop action should ignore invalid PIDs to prevent command injection', async () => {
+    // Save original kill
+    const originalKill = process.kill
+    const killMock = vi.fn()
+    process.kill = killMock as unknown as typeof process.kill
+
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    const maliciousPids: unknown[] = [
+      '1234 & echo pwned', // String injection
+      '1234; rm -rf /', // String injection
+      -1, // Negative number
+      0, // Zero
+      NaN, // NaN
+      Infinity, // Infinity
+      3.14, // Float
+      {}, // Object
+      null, // null
+      undefined, // undefined
+    ]
+
+    const config: GodotConfig = {
+      godotPath: '/path/to/godot',
+      godotVersion: null,
+      projectPath: '/path/to/project',
+      activePids: maliciousPids,
+    }
+
+    const result = (await handleProject('stop', {}, config)) as { content: { text: string }[] }
+
+    // Process.kill should not be called at all
+    expect(killMock).not.toHaveBeenCalled()
+    // execFileSync should not be called (which uses taskkill)
+    expect(child_process.execFileSync).not.toHaveBeenCalled()
+    expect(result.content[0].text).toContain('Godot processes stopped')
+    expect(config.activePids).toEqual([])
+
+    // Restore platform and kill
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+    process.kill = originalKill
+  })
+
+  it('editor status action should ignore invalid PIDs', async () => {
+    // Save original kill
+    const originalKill = process.kill
+    const killMock = vi.fn()
+    process.kill = killMock as unknown as typeof process.kill
+
+    const maliciousPids: unknown[] = ['1234 & echo pwned', -1, 0, NaN, Infinity]
+
+    const config: GodotConfig = {
+      godotPath: '/path/to/godot',
+      godotVersion: null,
+      projectPath: '/path/to/project',
+      activePids: maliciousPids,
+    }
+
+    const response = (await handleEditor('status', {}, config)) as { content: { text: string }[] }
+    const result = JSON.parse(response.content[0].text)
+
+    expect(killMock).not.toHaveBeenCalled()
+    expect(result.running).toBe(false)
+    expect(result.processes).toEqual([])
+
+    // Restore kill
+    process.kill = originalKill
+  })
+
+  it('should process valid PIDs correctly', async () => {
+    const originalKill = process.kill
+    const killMock = vi.fn()
+    process.kill = killMock as unknown as typeof process.kill
+
+    const config: GodotConfig = {
+      godotPath: '/path/to/godot',
+      godotVersion: null,
+      projectPath: '/path/to/project',
+      activePids: [1234, 5678],
+    }
+
+    const response = (await handleEditor('status', {}, config)) as { content: { text: string }[] }
+    const result = JSON.parse(response.content[0].text)
+
+    expect(killMock).toHaveBeenCalledTimes(2)
+    expect(killMock).toHaveBeenCalledWith(1234, 0)
+    expect(killMock).toHaveBeenCalledWith(5678, 0)
+
+    // In our mock kill doesn't throw, so processes are considered running
+    expect(result.running).toBe(true)
+    expect(result.processes).toEqual([
+      { pid: '1234', name: 'godot' },
+      { pid: '5678', name: 'godot' },
+    ])
+
+    process.kill = originalKill
+  })
+})


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Command Injection risk in PID handling

🚨 Severity: CRITICAL
💡 Vulnerability: Command injection was possible on Windows systems via the `stop` action in `src/tools/composite/project.ts`. The `pid` from `config.activePids` was used directly in `execFileSync('taskkill', ['/F', '/PID', pid.toString(), '/T'], ...)` without verifying it was a valid numeric process ID. Malicious manipulation of `config.activePids` (e.g. `1234 & command`) could result in executing arbitrary shell commands or causing unhandled exceptions.
🎯 Impact: Remote Code Execution (RCE) via command injection on Windows machines running the MCP server, and DoS via exception on Linux/Mac.
🔧 Fix: Added strict type and bounds validation (`typeof pid === 'number' && Number.isSafeInteger(pid) && pid > 0`) before any process killing or inspection logic in both `project.ts` and `editor.ts`.
✅ Verification: Created comprehensive security tests in `tests/security/pid-injection.test.ts` to verify injection attempts and invalid PID types are safely ignored. Tests run via `pnpm test`.

---
*PR created automatically by Jules for task [14677085776007545236](https://jules.google.com/task/14677085776007545236) started by @n24q02m*