### PR TITLE
⚡ Bolt: Optimize documentation directory discovery

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-09 - [Optimize parseProjectGodot string parsing]
 **Learning:** Parsing `project.godot` (or other INI-like configurations) line-by-line using regular expressions inside a hot loop (e.g., `^\[(.+)\]$`, `/^([^\s=]+)\s*=\s*(.+)$/`) causes severe performance bottlenecks due to RegExp compilation, execution, and extensive GC pressure from intermediary match objects and string allocations.
 **Action:** Replace regular expressions within file parsing loops with manual string operations: use `charCodeAt` to identify section boundaries (e.g., `91` for `[`), `indexOf('=')` for key-value extraction, and direct `.slice()` + `.trim()` for data separation. Apply manual quote removal checking string bounds and `charCodeAt(0) === 34` instead of `.replace(/^"(.*)"$/, '$1')`.
+
+## 2025-03-09 - [Optimize documentation directory discovery]
+**Learning:** Using `Promise.all` with `map` for file system discovery operations (like finding the documentation path) executes redundant parallel I/O checks even after a valid path is found. Furthermore, repeating this discovery process on every command blocks the event loop unnecessarily.
+**Action:** Replace parallel `Promise.all(array.map(...))` I/O lookups with a sequential `for...of` loop with an early return, and store the result in a module-level variable to cache the result, preventing redundant file system operations on subsequent invocations.

--- a/src/tools/composite/help.ts
+++ b/src/tools/composite/help.ts
@@ -29,10 +29,14 @@ const VALID_TOPICS = [
 ] as const
 type TopicName = (typeof VALID_TOPICS)[number]
 
+let cachedDocsDir: string | null = null
+
 /**
  * Get the docs directory path
  */
 async function getDocsDir(): Promise<string> {
+  if (cachedDocsDir) return cachedDocsDir
+
   const candidates = [
     join(import.meta.dirname || '', '..', '..', 'docs'),
     // Bundled CLI at bin/cli.mjs -> ../build/src/docs/
@@ -43,19 +47,19 @@ async function getDocsDir(): Promise<string> {
     join(process.cwd(), 'build', 'src', 'docs'),
   ]
 
-  const results = await Promise.all(
-    candidates.map(async (candidate) => {
-      // Validate candidate contains actual tool docs (not a random 'docs' directory)
-      const markerFile = join(candidate, 'help.md')
-      const exists = await pathExists(markerFile)
-      return exists ? candidate : null
-    }),
-  )
+  // ⚡ Bolt: Cache docs dir discovery and use a sequential for-of loop with early return
+  // to avoid redundant I/O operations and array allocations.
+  for (const candidate of candidates) {
+    // Validate candidate contains actual tool docs (not a random 'docs' directory)
+    const markerFile = join(candidate, 'help.md')
+    if (await pathExists(markerFile)) {
+      cachedDocsDir = candidate
+      return cachedDocsDir
+    }
+  }
 
-  const found = results.find((res) => res !== null)
-  if (found) return found
-
-  return join(process.cwd(), 'src', 'docs')
+  cachedDocsDir = join(process.cwd(), 'src', 'docs')
+  return cachedDocsDir
 }
 
 /**


### PR DESCRIPTION
**💡 What:** Refactored the `getDocsDir` function in `src/tools/composite/help.ts` to use a sequential `for...of` loop with an early return instead of parallel `Promise.all` mapping, and introduced caching via a module-level variable.

**🎯 Why:** The previous implementation executed `await pathExists(markerFile)` for every candidate directory simultaneously, even if the correct directory had already been found. It also re-ran this check on every invocation. In an I/O constrained environment, unnecessary file system calls block the event loop and degrade performance.

**📊 Impact:** Eliminates O(N) redundant filesystem `stat` calls per command execution and avoids allocating intermediate result arrays. Caching reduces the discovery cost for subsequent documentation lookups to nearly zero, providing a measurable performance gain for users repeatedly requesting help documentation.

**🔬 Measurement:** Verified by the unchanged behavior in `tests/composite/help.test.ts`. All test suites, formatting, and type-checks passed cleanly.

---
*PR created automatically by Jules for task [10524654113630806115](https://jules.google.com/task/10524654113630806115) started by @n24q02m*