### PR TITLE
🛡️ Sentinel: [CRITICAL] Prevent Command Injection via unvalidated PIDs

### DIFF
--- a/src/tools/composite/editor.ts
+++ b/src/tools/composite/editor.ts
@@ -15,6 +15,11 @@ function getGodotProcesses(config: GodotConfig): Array<{ pid: string; name: stri
   const activeProcesses: Array<{ pid: string; name: string }> = []
 
   for (const pid of config.activePids) {
+    // Prevent Command Injection by strictly validating the PID
+    if (typeof pid !== 'number' || !Number.isSafeInteger(pid) || pid <= 0) {
+      continue
+    }
+
     try {
       process.kill(pid, 0)
       activeProcesses.push({ pid: pid.toString(), name: 'godot' })

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -152,6 +152,11 @@ export async function handleProject(action: string, args: Record<string, unknown
 
       let stoppedCount = 0
       for (const pid of config.activePids) {
+        // Prevent Command Injection by strictly validating the PID
+        if (typeof pid !== 'number' || !Number.isSafeInteger(pid) || pid <= 0) {
+          continue
+        }
+
         try {
           if (process.platform === 'win32') {
             // Check if process exists before attempting to kill

--- a/tests/security/pid-injection.test.ts
+++ b/tests/security/pid-injection.test.ts
@@ -1,0 +1,69 @@
+import { execFileSync } from 'node:child_process'
+import { describe, expect, it, vi } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleEditor } from '../../src/tools/composite/editor.js'
+import { handleProject } from '../../src/tools/composite/project.js'
+
+vi.mock('node:child_process')
+
+describe('PID Injection Security', () => {
+  it('should prevent command injection via activePids in project stop', async () => {
+    // We inject a string that would exploit taskkill if it wasn't validated
+    // But since GodotConfig activePids expects number[], we can force a malicious cast
+    // biome-ignore lint/suspicious/noExplicitAny: Required to bypass type system for security injection testing
+    const maliciousPid = '1234 /T & echo injected' as any
+    const config: GodotConfig = {
+      projectPath: '/tmp/project',
+      godotPath: '/usr/bin/godot',
+      godotVersion: null,
+      activePids: [maliciousPid],
+    }
+
+    // Fake win32 platform for this test
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', {
+      value: 'win32',
+    })
+
+    // Mock process.kill to not throw
+    const originalKill = process.kill
+    process.kill = vi.fn()
+
+    await handleProject('stop', {}, config)
+
+    // execFileSync should not be called with the malicious payload because of validation
+    expect(execFileSync).not.toHaveBeenCalledWith(
+      'taskkill',
+      ['/F', '/PID', maliciousPid.toString(), '/T'],
+      expect.anything(),
+    )
+
+    // Restore platform
+    Object.defineProperty(process, 'platform', {
+      value: originalPlatform,
+    })
+    process.kill = originalKill
+  })
+
+  it('should prevent command injection via activePids in editor status', async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: Required to bypass type system for security injection testing
+    const maliciousPid = '1234 /T & echo injected' as any
+    const config: GodotConfig = {
+      projectPath: '/tmp/project',
+      godotPath: '/usr/bin/godot',
+      godotVersion: null,
+      activePids: [maliciousPid],
+    }
+
+    const originalKill = process.kill
+    process.kill = vi.fn()
+
+    const resultObj = await handleEditor('status', {}, config)
+    const result = JSON.parse(resultObj.content[0].text)
+
+    // The malicious PID should be ignored due to validation
+    expect(result.processes).toEqual([])
+
+    process.kill = originalKill
+  })
+})


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The application was vulnerable to Command Injection on Windows. Process IDs (PIDs) from the `activePids` array were passed directly into `taskkill` via `execFileSync`. While typed as `number[]`, any runtime bypass (e.g. malformed config files) could inject strings with shell metacharacters.
🎯 **Impact:** An attacker could execute arbitrary OS commands under the context of the running application.
🔧 **Fix:** Implemented strict runtime validation to enforce that PIDs are positive safe integers (`typeof pid === 'number' && Number.isSafeInteger(pid) && pid > 0`) before executing `taskkill` or `process.kill`.
✅ **Verification:** A new test suite was added (`tests/security/pid-injection.test.ts`) that asserts malicious payloads injected into `activePids` are correctly rejected and do not invoke OS termination tools. Checked using `bun run test`.

---
*PR created automatically by Jules for task [2690640458537963579](https://jules.google.com/task/2690640458537963579) started by @n24q02m*