### PR TITLE
[PERF] Redundant Array creation in Promise.all

### DIFF
--- a/src/tools/composite/help.ts
+++ b/src/tools/composite/help.ts
@@ -30,9 +30,16 @@ const VALID_TOPICS = [
 type TopicName = (typeof VALID_TOPICS)[number]
 
 /**
+ * Cached documentation directory path to avoid redundant filesystem checks.
+ */
+let cachedDocsDir: string | null = null
+
+/**
  * Get the docs directory path
  */
 async function getDocsDir(): Promise<string> {
+  if (cachedDocsDir) return cachedDocsDir
+
   const candidates = [
     join(import.meta.dirname || '', '..', '..', 'docs'),
     // Bundled CLI at bin/cli.mjs -> ../build/src/docs/
@@ -43,19 +50,17 @@ async function getDocsDir(): Promise<string> {
     join(process.cwd(), 'build', 'src', 'docs'),
   ]
 
-  const results = await Promise.all(
-    candidates.map(async (candidate) => {
-      // Validate candidate contains actual tool docs (not a random 'docs' directory)
-      const markerFile = join(candidate, 'help.md')
-      const exists = await pathExists(markerFile)
-      return exists ? candidate : null
-    }),
-  )
+  for (const candidate of candidates) {
+    // Validate candidate contains actual tool docs (not a random 'docs' directory)
+    const markerFile = join(candidate, 'help.md')
+    if (await pathExists(markerFile)) {
+      cachedDocsDir = candidate
+      return candidate
+    }
+  }
 
-  const found = results.find((res) => res !== null)
-  if (found) return found
-
-  return join(process.cwd(), 'src', 'docs')
+  cachedDocsDir = join(process.cwd(), 'src', 'docs')
+  return cachedDocsDir
 }
 
 /**


### PR DESCRIPTION
Optimized getDocsDir in src/tools/composite/help.ts by replacing Promise.all with a sequential for...of loop and implementing caching to avoid redundant filesystem checks. This improves performance by avoiding simultaneous path checks and caching the result for subsequent calls.

---
*PR created automatically by Jules for task [2121603814479779418](https://jules.google.com/task/2121603814479779418) started by @n24q02m*