### PR TITLE
[PERF] Use pre-allocated array instead of filter().length

### DIFF
--- a/src/tools/composite/tilemap.ts
+++ b/src/tools/composite/tilemap.ts
@@ -9,6 +9,7 @@ import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
+import { countString } from '../helpers/strings.js'
 
 /**
  * Async helper to check file existence without blocking the event loop
@@ -87,7 +88,7 @@ export async function handleTilemap(action: string, args: Record<string, unknown
       const resPath = `res://${texturePath.replaceAll('\\', '/')}`
 
       // Count existing sources to get next ID
-      const sourceCount = (content.match(/\[ext_resource/g) || []).length
+      const sourceCount = countString(content, '[ext_resource')
       const sourceId = `source_${sourceCount}`
 
       // Add ext_resource reference

--- a/src/tools/helpers/strings.ts
+++ b/src/tools/helpers/strings.ts
@@ -33,3 +33,30 @@ export function parseCommaSeparatedList(str: string): string[] {
 
   return result
 }
+
+/**
+ * Efficiently counts occurrences of a regex in a string without allocating an intermediate array.
+ * Uses matchAll to avoid the overhead of match().length which creates an intermediate array.
+ */
+export function countMatches(str: string, regex: RegExp): number {
+  let count = 0
+  for (const _ of str.matchAll(regex)) {
+    count++
+  }
+  return count
+}
+
+/**
+ * Efficiently counts occurrences of a substring in a string without allocating an intermediate array.
+ * Uses indexOf in a loop to avoid the overhead of match().length or split().length.
+ */
+export function countString(str: string, search: string): number {
+  if (!search) return 0
+  let count = 0
+  let pos = str.indexOf(search)
+  while (pos !== -1) {
+    count++
+    pos = str.indexOf(search, pos + search.length)
+  }
+  return count
+}

--- a/tests/helpers/strings.test.ts
+++ b/tests/helpers/strings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseCommaSeparatedList } from '../../src/tools/helpers/strings.js'
+import { countMatches, countString, parseCommaSeparatedList } from '../../src/tools/helpers/strings.js'
 
 describe('strings helpers', () => {
   describe('parseCommaSeparatedList', () => {
@@ -33,6 +33,39 @@ describe('strings helpers', () => {
 
     it('should handle items with inner spaces', () => {
       expect(parseCommaSeparatedList('word1 word2, word3 word4')).toEqual(['word1 word2', 'word3 word4'])
+    })
+  })
+
+  describe('countMatches', () => {
+    it('should count occurrences of a regex', () => {
+      expect(countMatches('apple banana apple cherry apple', /apple/g)).toBe(3)
+    })
+
+    it('should return 0 when no matches are found', () => {
+      expect(countMatches('apple banana cherry', /durian/g)).toBe(0)
+    })
+
+    it('should handle complex regexes', () => {
+      expect(countMatches('abc1 def2 ghi3', /\d/g)).toBe(3)
+    })
+  })
+
+  describe('countString', () => {
+    it('should count occurrences of a substring', () => {
+      expect(countString('apple banana apple cherry apple', 'apple')).toBe(3)
+    })
+
+    it('should return 0 when no matches are found', () => {
+      expect(countString('apple banana cherry', 'durian')).toBe(0)
+    })
+
+    it('should return 0 for an empty search string', () => {
+      expect(countString('apple', '')).toBe(0)
+    })
+
+    it('should handle overlapping occurrences (non-overlapping count)', () => {
+      // Standard countString usually counts non-overlapping occurrences
+      expect(countString('aaaaa', 'aa')).toBe(2)
     })
   })
 })

--- a/tilemap.diff
+++ b/tilemap.diff
@@ -1,0 +1,17 @@
+<<<<<<< SEARCH
+import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
+=======
+import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
+import { safeResolve } from '../helpers/paths.js'
+import { countString } from '../helpers/strings.js'
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+      // Count existing sources to get next ID
+      const sourceCount = (content.match(/\[ext_resource/g) || []).length
+      const sourceId = `source_${sourceCount}`
+=======
+      // Count existing sources to get next ID
+      const sourceCount = countString(content, '[ext_resource')
+      const sourceId = `source_${sourceCount}`
+>>>>>>> REPLACE


### PR DESCRIPTION
This PR improves the performance of the TileMap tool by replacing inefficient regex matching with a manual string counting loop. 

Changes:
- Added `countMatches` (using `matchAll`) and `countString` (using `indexOf`) to `src/tools/helpers/strings.ts`.
- Updated `src/tools/composite/tilemap.ts` to use `countString` instead of `(content.match(...) || []).length`.
- Added comprehensive unit tests for the new helpers in `tests/helpers/strings.test.ts`.

Rationale:
Using `.match()` with a global flag creates an intermediate array of all matches, which is then immediately discarded after getting the `.length`. For large files, this creates unnecessary memory pressure and GC overhead. `countString` avoids this by iterating through the string without allocations.

---
*PR created automatically by Jules for task [5074027811099129092](https://jules.google.com/task/5074027811099129092) started by @n24q02m*