### PR TITLE
[PERF] Sequential Read/Stat operations without parallelization

### DIFF
--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -7,7 +7,7 @@ import { readdir, readFile, stat, unlink } from 'node:fs/promises'
 import { extname, join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { pathExists, safeResolve } from '../helpers/paths.js'
+import { safeResolve } from '../helpers/paths.js'
 
 const RESOURCE_EXTENSIONS = new Set([
   '.tres',
@@ -121,11 +121,18 @@ export async function handleResources(action: string, args: Record<string, unkno
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
       const fullPath = safeResolve(projectPath || process.cwd(), resPath)
-      if (!(await pathExists(fullPath)))
-        throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
-
-      const fileStat = await stat(fullPath)
       const ext = extname(fullPath)
+
+      let fileStat: import('node:fs').Stats
+      try {
+        fileStat = await stat(fullPath)
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
+        }
+        throw err
+      }
+
       const info: Record<string, unknown> = {
         path: resPath,
         extension: ext,
@@ -149,13 +156,24 @@ export async function handleResources(action: string, args: Record<string, unkno
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
       const fullPath = safeResolve(projectPath || process.cwd(), resPath)
-      if (!(await pathExists(fullPath)))
-        throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
-      await unlink(fullPath)
+      try {
+        await unlink(fullPath)
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
+        }
+        throw err
+      }
+
       // Also delete .import file if exists
-      const importFile = `${fullPath}.import`
-      if (await pathExists(importFile)) await unlink(importFile)
+      try {
+        await unlink(`${fullPath}.import`)
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+          throw err
+        }
+      }
 
       return formatSuccess(`Deleted resource: ${resPath}`)
     }
@@ -166,12 +184,15 @@ export async function handleResources(action: string, args: Record<string, unkno
 
       const importPath = safeResolve(projectPath || process.cwd(), `${resPath}.import`)
 
-      if (!(await pathExists(importPath))) {
-        return formatJSON({ path: resPath, imported: false, message: 'No .import file found.' })
+      try {
+        const content = await readFile(importPath, 'utf-8')
+        return formatSuccess(`Import config for ${resPath}:\n\n${content}`)
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          return formatJSON({ path: resPath, imported: false, message: 'No .import file found.' })
+        }
+        throw err
       }
-
-      const content = await readFile(importPath, 'utf-8')
-      return formatSuccess(`Import config for ${resPath}:\n\n${content}`)
     }
 
     default:


### PR DESCRIPTION
This PR optimizes the `resources` tool in the Better Godot MCP server by reducing redundant filesystem operations. 

Previously, several actions (`info`, `delete`, `import_config`) followed a "check-then-act" pattern using `pathExists` before performing the actual operation. This resulted in two filesystem calls for every request.

The refactored code now attempts the primary operation directly and handles `ENOENT` errors, effectively cutting the number of filesystem calls in half for existing resources. 

Additionally:
- Type safety is improved by explicitly typing the `fileStat` variable.
- The `pathExists` utility import was removed as it was no longer used in this module.
- Error handling for sidecar `.import` file deletion was refined to specifically ignore `ENOENT` while propagating other potential errors.

All tests passed and lint checks are clean.

---
*PR created automatically by Jules for task [2669348802340569212](https://jules.google.com/task/2669348802340569212) started by @n24q02m*