### PR TITLE
[CLEANUP] console.error usage for diagnostics

### DIFF
--- a/src/init-server.ts
+++ b/src/init-server.ts
@@ -15,6 +15,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import pkg from '../package.json' with { type: 'json' }
 import { detectGodot } from './godot/detector.js'
 import type { GodotConfig } from './godot/types.js'
+import { logger } from './tools/helpers/logger.js'
 import { registerTools } from './tools/registry.js'
 
 const SERVER_NAME = 'better-godot-mcp'
@@ -28,12 +29,10 @@ export function createGodotServer(): Server {
   const detection = detectGodot()
 
   if (detection) {
-    console.error(
-      `[${SERVER_NAME}] Godot detected: ${detection.version.raw} at ${detection.path} (${detection.source})`,
-    )
+    logger.info(`Godot detected: ${detection.version.raw} at ${detection.path} (${detection.source})`)
   } else {
-    console.error(`[${SERVER_NAME}] Godot not found. CLI headless tools will be limited.`)
-    console.error(`[${SERVER_NAME}] Set GODOT_PATH env var or install Godot.`)
+    logger.warn('Godot not found. CLI headless tools will be limited.')
+    logger.warn('Set GODOT_PATH env var or install Godot.')
   }
 
   // Resolve project path from env var (tools also accept project_path per call)
@@ -76,7 +75,7 @@ export async function initServer(): Promise<void> {
       const server = createGodotServer()
       const transport = new StdioServerTransport()
       await server.connect(transport)
-      console.error(`[${SERVER_NAME}] Server started in stdio mode (v${getVersion()})`)
+      logger.info(`Server started in stdio mode (v${getVersion()})`)
       return
     } else {
       const { runHttpServer } = await import('@n24q02m/mcp-core')
@@ -93,9 +92,7 @@ export async function initServer(): Promise<void> {
           // No relaySchema -> no auth, no credential form (godot has no credentials).
         },
       )
-      console.error(
-        `[${SERVER_NAME}] Server started in HTTP mode (v${getVersion()}) on http://${handle.host}:${handle.port}/mcp`,
-      )
+      logger.info(`Server started in HTTP mode (v${getVersion()}) on http://${handle.host}:${handle.port}/mcp`)
       // Keep process alive until SIGINT/SIGTERM.
       await new Promise<void>((resolve) => {
         const shutdown = async (): Promise<void> => {
@@ -107,7 +104,7 @@ export async function initServer(): Promise<void> {
       })
     }
   } catch (error) {
-    console.error('Failed to initialize server:', error)
+    logger.error('Failed to initialize server:', error)
     throw error
   }
 }

--- a/src/tools/helpers/logger.ts
+++ b/src/tools/helpers/logger.ts
@@ -1,0 +1,41 @@
+/**
+ * Centralized logger utility for Better Godot MCP.
+ * All logs are written to stderr to avoid interfering with MCP JSON-RPC on stdout.
+ */
+
+const SERVER_NAME = 'better-godot-mcp'
+const PREFIX = `[${SERVER_NAME}]`
+
+const isDebugEnabled = process.env.DEBUG === 'true' || process.env.NODE_ENV === 'development'
+
+export const logger = {
+  /**
+   * Log an info message.
+   */
+  info: (message: string, ...args: unknown[]) => {
+    console.error(`${PREFIX} ${message}`, ...args)
+  },
+
+  /**
+   * Log a warning message.
+   */
+  warn: (message: string, ...args: unknown[]) => {
+    console.error(`${PREFIX} WARN: ${message}`, ...args)
+  },
+
+  /**
+   * Log an error message.
+   */
+  error: (message: string, ...args: unknown[]) => {
+    console.error(`${PREFIX} ERROR: ${message}`, ...args)
+  },
+
+  /**
+   * Log a debug message (only if debug mode is enabled).
+   */
+  debug: (message: string, ...args: unknown[]) => {
+    if (isDebugEnabled) {
+      console.error(`${PREFIX} DEBUG: ${message}`, ...args)
+    }
+  },
+}

--- a/tests/init-server.test.ts
+++ b/tests/init-server.test.ts
@@ -118,7 +118,9 @@ describe('initServer', () => {
 
       expect(mockStartHttp).toHaveBeenCalledOnce()
       expect(mockStdioTransportConstructor).not.toHaveBeenCalled()
-      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('HTTP mode'))
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('[better-godot-mcp] Server started in HTTP mode'),
+      )
     })
 
     it('should use HTTP mode when MCP_TRANSPORT=http', async () => {
@@ -174,7 +176,7 @@ describe('initServer', () => {
 
       const { registerTools } = await import('../src/tools/registry.js')
       expect(registerTools).toHaveBeenCalledOnce()
-      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Godot detected'))
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('[better-godot-mcp] Godot detected'))
     })
 
     it('should initialize server when Godot is not found', async () => {
@@ -186,7 +188,7 @@ describe('initServer', () => {
 
       const { registerTools } = await import('../src/tools/registry.js')
       expect(registerTools).toHaveBeenCalledOnce()
-      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Godot not found'))
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('[better-godot-mcp] WARN: Godot not found'))
     })
 
     it('should instantiate Server with correct name, version, and capabilities', async () => {
@@ -222,7 +224,7 @@ describe('initServer', () => {
       const { initServer } = await import('../src/init-server.js')
 
       await expect(initServer()).rejects.toThrow('Connect failed')
-      expect(console.error).toHaveBeenCalledWith('Failed to initialize server:', testError)
+      expect(console.error).toHaveBeenCalledWith('[better-godot-mcp] ERROR: Failed to initialize server:', testError)
     })
 
     it('should handle errors during HTTP startup', async () => {
@@ -236,7 +238,7 @@ describe('initServer', () => {
       const { initServer } = await import('../src/init-server.js')
 
       await expect(initServer()).rejects.toThrow('Port in use')
-      expect(console.error).toHaveBeenCalledWith('Failed to initialize server:', testError)
+      expect(console.error).toHaveBeenCalledWith('[better-godot-mcp] ERROR: Failed to initialize server:', testError)
     })
   })
 


### PR DESCRIPTION
This PR implements a centralized logger utility in `src/tools/helpers/logger.ts` and replaces direct `console.error` usage in `src/init-server.ts` for diagnostics and error reporting. 

Key changes:
- Introduced `logger` with support for `info`, `warn`, `error`, and `debug` levels.
- Ensured all logs are written to `stderr` to avoid interfering with MCP JSON-RPC on `stdout`.
- Added a standard `[better-godot-mcp]` prefix to all log messages.
- Updated existing tests in `tests/init-server.test.ts` to verify the new log format and ensure correctness.

---
*PR created automatically by Jules for task [6475119748009079842](https://jules.google.com/task/6475119748009079842) started by @n24q02m*