### PR TITLE
[TEST] Missing error path test for pathExists

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-09 - [Optimize parseProjectGodot string parsing]
 **Learning:** Parsing `project.godot` (or other INI-like configurations) line-by-line using regular expressions inside a hot loop (e.g., `^\[(.+)\]$`, `/^([^\s=]+)\s*=\s*(.+)$/`) causes severe performance bottlenecks due to RegExp compilation, execution, and extensive GC pressure from intermediary match objects and string allocations.
 **Action:** Replace regular expressions within file parsing loops with manual string operations: use `charCodeAt` to identify section boundaries (e.g., `91` for `[`), `indexOf('=')` for key-value extraction, and direct `.slice()` + `.trim()` for data separation. Apply manual quote removal checking string bounds and `charCodeAt(0) === 34` instead of `.replace(/^"(.*)"$/, '$1')`.
+
+### testing
+- When mocking `node:fs/promises` in Vitest for ESM projects, use `vi.mock('node:fs/promises', () => ({ access: vi.fn() }))` to avoid issues with module namespace immutability.
+- Separate tests that require deep filesystem mocking into their own files to avoid side effects on other tests that rely on the real filesystem.

--- a/tests/helpers/paths-error.test.ts
+++ b/tests/helpers/paths-error.test.ts
@@ -1,0 +1,34 @@
+import { access } from 'node:fs/promises'
+import { describe, expect, it, vi } from 'vitest'
+import { pathExists } from '../../src/tools/helpers/paths.js'
+
+/**
+ * Unit tests for the error handling path of pathExists.
+ * This separate file is used because mocking node:fs/promises
+ * can interfere with other tests that rely on the real filesystem.
+ */
+
+vi.mock('node:fs/promises', () => ({
+  access: vi.fn(),
+}))
+
+describe('pathExists error path', () => {
+  it('returns false when access throws an error', async () => {
+    const mockedAccess = vi.mocked(access)
+    // Simulate any error (e.g., EPERM, EACCES, or just a generic Error)
+    mockedAccess.mockRejectedValueOnce(new Error('Permission denied'))
+
+    const result = await pathExists('/any/path/that/might/fail')
+    expect(result).toBe(false)
+    expect(mockedAccess).toHaveBeenCalledWith('/any/path/that/might/fail')
+  })
+
+  it('returns true when access succeeds', async () => {
+    const mockedAccess = vi.mocked(access)
+    mockedAccess.mockResolvedValueOnce(undefined)
+
+    const result = await pathExists('/any/existing/path')
+    expect(result).toBe(true)
+    expect(mockedAccess).toHaveBeenCalledWith('/any/existing/path')
+  })
+})


### PR DESCRIPTION
Added a new test file tests/helpers/paths-error.test.ts to cover the error path of the pathExists function in src/tools/helpers/paths.ts. This ensures that any error thrown by the underlying access call is caught and handled, returning false as expected.

---
*PR created automatically by Jules for task [16025454902252245945](https://jules.google.com/task/16025454902252245945) started by @n24q02m*