### PR TITLE
[CLEANUP] ReDoS via Unsafe Dynamic RegExp in Physics body config

### DIFF
--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -10,7 +10,7 @@ import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '..
 import { toGodotValue } from '../helpers/godot-types.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
 import { parseProjectSettingsAsync, setSettingInContent } from '../helpers/project-settings.js'
-import { escapeRegExp } from '../helpers/scene-parser.js'
+import { updateNodeInScene } from '../helpers/scene-parser.js'
 import { validateNoNewlines } from '../helpers/security.js'
 
 export async function handlePhysics(action: string, args: Record<string, unknown>, config: GodotConfig) {
@@ -54,28 +54,23 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       if (!(await pathExists(fullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 
-      let content = await readFile(fullPath, 'utf-8')
-      const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-      const match = content.match(nodeRegex)
-      if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-
-      if (match.index === undefined)
-        throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-      const insertPoint = match.index + match[0].length
-      let props = ''
+      const content = await readFile(fullPath, 'utf-8')
+      const updates: Record<string, string> = {}
       if (collisionLayer !== undefined) {
         const val = toGodotValue(collisionLayer)
         validateNoNewlines('Invalid collision_layer: newlines not allowed', val)
-        props += `\ncollision_layer = ${val}`
+        updates.collision_layer = val
       }
       if (collisionMask !== undefined) {
         const val = toGodotValue(collisionMask)
         validateNoNewlines('Invalid collision_mask: newlines not allowed', val)
-        props += `\ncollision_mask = ${val}`
+        updates.collision_mask = val
       }
 
-      content = `${content.slice(0, insertPoint)}${props}${content.slice(insertPoint)}`
-      await writeFile(fullPath, content, 'utf-8')
+      const { content: newContent, updated } = updateNodeInScene(content, nodeName, updates)
+      if (!updated) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+
+      await writeFile(fullPath, newContent, 'utf-8')
 
       return formatSuccess(
         `Set collision on ${nodeName}: layer=${collisionLayer ?? 'unchanged'}, mask=${collisionMask ?? 'unchanged'}`,
@@ -94,26 +89,21 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       if (!(await pathExists(fullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 
-      let content = await readFile(fullPath, 'utf-8')
-      const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-      const match = content.match(nodeRegex)
-      if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-
-      let props = ''
+      const content = await readFile(fullPath, 'utf-8')
+      const updates: Record<string, string> = {}
       const physicsProps = ['gravity_scale', 'mass', 'linear_damp', 'angular_damp', 'freeze']
       for (const prop of physicsProps) {
         if (args[prop] !== undefined) {
           const val = toGodotValue(args[prop])
           validateNoNewlines(`Invalid ${prop}: newlines not allowed`, val)
-          props += `\n${prop} = ${val}`
+          updates[prop] = val
         }
       }
 
-      if (match.index === undefined)
-        throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-      const insertPoint = match.index + match[0].length
-      content = `${content.slice(0, insertPoint)}${props}${content.slice(insertPoint)}`
-      await writeFile(fullPath, content, 'utf-8')
+      const { content: newContent, updated } = updateNodeInScene(content, nodeName, updates)
+      if (!updated) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+
+      await writeFile(fullPath, newContent, 'utf-8')
 
       return formatSuccess(`Configured physics body: ${nodeName}`)
     }


### PR DESCRIPTION
Fixed a potential ReDoS vulnerability in `src/tools/composite/physics.ts` where dynamic regular expressions were used to find node sections in Godot `.tscn` files.
The fix replaces these regexes with the `updateNodeInScene` utility from `src/tools/helpers/scene-parser.ts`, which uses a safer line-by-line manual string scanning approach.
Additionally, this refactor:
- Prevents property duplication by updating existing properties if they exist.
- Ensures properties are correctly appended to the targeted node section.
- Maintains existing security validations using `validateNoNewlines`.
- Preserves the behavior of throwing a `GodotMCPError` if the node is not found.

Tests in `tests/composite/physics.test.ts` were run and passed. The full test suite and lint checks also passed.

---
*PR created automatically by Jules for task [11427239069355335795](https://jules.google.com/task/11427239069355335795) started by @n24q02m*