### PR TITLE
[PERF] O(N) search inside loop during Scene Parsing

### DIFF
--- a/src/tools/composite/signals.ts
+++ b/src/tools/composite/signals.ts
@@ -7,7 +7,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
-import { parseSceneContent } from '../helpers/scene-parser.js'
+import { getConnectionKey, parseSceneContent } from '../helpers/scene-parser.js'
 
 function validateParameters(...params: unknown[]) {
   for (const param of params) {
@@ -80,9 +80,7 @@ export async function handleSignals(action: string, args: Record<string, unknown
 
       // Check for duplicate
       const scene = parseSceneContent(content)
-      const existing = scene.connections.find(
-        (c) => c.signal === signal && c.from === from && c.to === to && c.method === method,
-      )
+      const existing = scene.connectionKeys.has(getConnectionKey({ signal, from, to, method }))
       if (existing) {
         throw new GodotMCPError(
           'Connection already exists',

--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -91,7 +91,15 @@ export interface ParsedScene {
   subResources: SubResource[]
   nodes: SceneNodeInfo[]
   connections: SignalConnection[]
+  connectionKeys: Set<string>
   raw: string
+}
+
+/**
+ * Get a unique key for a signal connection for fast lookups
+ */
+export function getConnectionKey(conn: { signal: string; from: string; to: string; method: string }): string {
+  return `${conn.signal}\0${conn.from}\0${conn.to}\0${conn.method}`
 }
 
 /**
@@ -111,6 +119,7 @@ export function parseSceneContent(content: string): ParsedScene {
   const subResources: SubResource[] = []
   const nodes: SceneNodeInfo[] = []
   const connections: SignalConnection[] = []
+  const connectionKeys = new Set<string>()
 
   let currentSection: 'header' | 'ext_resource' | 'sub_resource' | 'node' | 'connection' | null = null
   let currentNode: SceneNodeInfo | null = null
@@ -171,7 +180,10 @@ export function parseSceneContent(content: string): ParsedScene {
             // 'c' -> [connection
             currentSection = 'connection'
             const conn = parseConnection(line)
-            if (conn) connections.push(conn)
+            if (conn) {
+              connections.push(conn)
+              connectionKeys.add(getConnectionKey(conn))
+            }
           }
         } else if (currentSection === 'node' || currentSection === 'sub_resource') {
           const target = currentSection === 'node' ? currentNode?.properties : currentSubResource?.properties
@@ -189,7 +201,7 @@ export function parseSceneContent(content: string): ParsedScene {
   if (currentNode) nodes.push(currentNode)
   if (currentSubResource) subResources.push(currentSubResource)
 
-  return { header, extResources, subResources, nodes, connections, raw: content }
+  return { header, extResources, subResources, nodes, connections, connectionKeys, raw: content }
 }
 
 /**


### PR DESCRIPTION
Optimized signal connection lookup in .tscn files by introducing a connectionKeys Set in the ParsedScene interface. This reduces the complexity of duplicate checking from O(N) to O(1) in the signals tool. Added a getConnectionKey helper for consistent key generation using a null separator to avoid collisions. Verified with existing tests.

---
*PR created automatically by Jules for task [7785365189907928351](https://jules.google.com/task/7785365189907928351) started by @n24q02m*