### PR TITLE
[CLEANUP] ReDoS via Unsafe Dynamic RegExp in Input Map Event Append

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,8 @@
 ## 2025-03-09 - [Optimize parseProjectGodot string parsing]
 **Learning:** Parsing `project.godot` (or other INI-like configurations) line-by-line using regular expressions inside a hot loop (e.g., `^\[(.+)\]$`, `/^([^\s=]+)\s*=\s*(.+)$/`) causes severe performance bottlenecks due to RegExp compilation, execution, and extensive GC pressure from intermediary match objects and string allocations.
 **Action:** Replace regular expressions within file parsing loops with manual string operations: use `charCodeAt` to identify section boundaries (e.g., `91` for `[`), `indexOf('=')` for key-value extraction, and direct `.slice()` + `.trim()` for data separation. Apply manual quote removal checking string bounds and `charCodeAt(0) === 34` instead of `.replace(/^"(.*)"$/, '$1')`.
+
+## Input Map ReDoS Mitigation (2025-05-14)
+- **Problem**: Dynamic `RegExp` construction with `[^}]*` and `[^\]]*` in `input-map.ts` was vulnerable to ReDoS.
+- **Solution**: Implemented `transformInputMap`, a manual string scanner that splits the file into lines and identifies `[input]` section action blocks without using complex regex.
+- **Benefit**: Linear time complexity for file transformations, eliminating ReDoS risks from malicious or complex `project.godot` files.

--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -9,7 +9,6 @@ import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { serializeGodotObject } from '../helpers/godot-types.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
-import { escapeRegExp } from '../helpers/scene-parser.js'
 
 /**
  * Godot 4.x Key enum numeric values (@GlobalScope.Key)
@@ -239,6 +238,93 @@ function parseInputActions(content: string): Map<string, string[]> {
   return actions
 }
 
+/**
+ * Safely transform the [input] section of project.godot
+ * @param content Full content of project.godot
+ * @param targetAction Action name to find and transform
+ * @param transform Callback that receives the action block and returns the replacement (or null to remove)
+ */
+function transformInputMap(content: string, targetAction: string, transform: (block: string) => string | null): string {
+  const lines = content.split('\n')
+  const result: string[] = []
+  let inInputSection = false
+  let currentActionName: string | null = null
+  let currentActionLines: string[] = []
+  let found = false
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const trimmed = line.trim()
+
+    if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+      if (currentActionName !== null) {
+        result.push(...currentActionLines)
+        currentActionName = null
+        currentActionLines = []
+      }
+      inInputSection = trimmed === '[input]'
+      result.push(line)
+      continue
+    }
+
+    if (!inInputSection) {
+      result.push(line)
+      continue
+    }
+
+    if (currentActionName !== null) {
+      currentActionLines.push(line)
+      if (trimmed.endsWith('}')) {
+        if (currentActionName === targetAction) {
+          const updated = transform(currentActionLines.join('\n'))
+          if (updated !== null) {
+            result.push(updated)
+          }
+          found = true
+        } else {
+          result.push(...currentActionLines)
+        }
+        currentActionName = null
+        currentActionLines = []
+      }
+    } else {
+      const eqIdx = line.indexOf('=')
+      if (eqIdx !== -1) {
+        const name = line.slice(0, eqIdx).trim()
+        const rest = line.slice(eqIdx + 1).trim()
+        if (rest.startsWith('{')) {
+          currentActionName = name
+          currentActionLines.push(line)
+          if (rest.endsWith('}')) {
+            if (currentActionName === targetAction) {
+              const updated = transform(currentActionLines.join('\n'))
+              if (updated !== null) {
+                result.push(updated)
+              }
+              found = true
+            } else {
+              result.push(...currentActionLines)
+            }
+            currentActionName = null
+            currentActionLines = []
+          }
+        } else {
+          result.push(line)
+        }
+      } else {
+        result.push(line)
+      }
+    }
+  }
+
+  if (currentActionName !== null) {
+    result.push(...currentActionLines)
+  }
+
+  if (!found) return content
+  return result.join('\n')
+}
+
 export async function handleInputMap(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const baseDir = config.projectPath || process.cwd()
   const projectPath = (args.project_path as string) || config.projectPath
@@ -309,8 +395,7 @@ export async function handleInputMap(action: string, args: Record<string, unknow
 
       const content = await readFile(configPath, 'utf-8')
       // Remove the action line(s) - handles multi-line format
-      const pattern = new RegExp(`${escapeRegExp(actionName)}=\\{[^}]*\\}\\n?`, 'g')
-      const updated = content.replace(pattern, '')
+      const updated = transformInputMap(content, actionName, () => null)
 
       if (updated === content) {
         throw new GodotMCPError(`Action "${actionName}" not found`, 'INPUT_ERROR', 'Check action name with list.')
@@ -410,19 +495,22 @@ export async function handleInputMap(action: string, args: Record<string, unknow
       }
 
       // Find existing events array and append
-      const actionRegex = new RegExp(`(${escapeRegExp(actionName)}=\\{[^}]*"events":\\s*\\[)([^\\]]*)\\]`)
-      const match = content.match(actionRegex)
-      if (!match) {
+      const updated = transformInputMap(content, actionName, (block) => {
+        const eventsMatch = block.match(/"events":\s*\[([^\]]*)\]/)
+        if (!eventsMatch) return block // Should not happen with valid Godot files
+
+        const existingEvents = eventsMatch[1].trim()
+        const newEvents = existingEvents ? `${existingEvents}, ${eventObj}` : eventObj
+        return block.replace(eventsMatch[0], `"events": [${newEvents}]`)
+      })
+
+      if (updated === content) {
         throw new GodotMCPError(
           `Action "${actionName}" not found`,
           'INPUT_ERROR',
           'Add the action first with add_action.',
         )
       }
-
-      const existingEvents = match[2].trim()
-      const newEvents = existingEvents ? `${existingEvents}, ${eventObj}` : eventObj
-      const updated = content.replace(actionRegex, (_match, p1) => `${p1}${newEvents}]`)
 
       await writeFile(configPath, updated, 'utf-8')
       return formatSuccess(`Added ${eventType} event to action: ${actionName}`)


### PR DESCRIPTION
This PR addresses a ReDoS (Regular Expression Denial of Service) vulnerability in the Input Map tool. 

The previous implementation used dynamic `RegExp` objects with unsafe patterns (specifically `[^}]*` and `[^\]]*`) to modify the `[input]` section of `project.godot`. 

I have implemented a new `transformInputMap` utility that performs line-by-line scanning to identify and transform action blocks within the `[input]` section. This approach avoids the use of complex regex for structural parsing.

Key changes:
- Added `transformInputMap` helper function for safe file modification.
- Refactored `remove_action` and `add_event` to use the new utility.
- Removed unused `escapeRegExp` import.
- Verified all changes with the full test suite and linting.

---
*PR created automatically by Jules for task [10310254525597518233](https://jules.google.com/task/10310254525597518233) started by @n24q02m*