### PR TITLE
[SECURITY] Command Injection via pid in taskkill

### DIFF
--- a/src/tools/composite/editor.ts
+++ b/src/tools/composite/editor.ts
@@ -15,6 +15,11 @@ function getGodotProcesses(config: GodotConfig): Array<{ pid: string; name: stri
   const activeProcesses: Array<{ pid: string; name: string }> = []
 
   for (const pid of config.activePids) {
+    // Security: strictly validate pid is a positive safe integer before using in process.kill
+    if (typeof pid !== 'number' || !Number.isSafeInteger(pid) || pid <= 0) {
+      continue
+    }
+
     try {
       process.kill(pid, 0)
       activeProcesses.push({ pid: pid.toString(), name: 'godot' })

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -152,6 +152,11 @@ export async function handleProject(action: string, args: Record<string, unknown
 
       let stoppedCount = 0
       for (const pid of config.activePids) {
+        // Security: strictly validate pid is a positive safe integer before using in shell commands or process.kill
+        if (typeof pid !== 'number' || !Number.isSafeInteger(pid) || pid <= 0) {
+          continue
+        }
+
         try {
           if (process.platform === 'win32') {
             // Check if process exists before attempting to kill

--- a/tests/security/pid-injection.test.ts
+++ b/tests/security/pid-injection.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleEditor } from '../../src/tools/composite/editor.js'
+import { handleProject } from '../../src/tools/composite/project.js'
+import { makeConfig } from '../fixtures.js'
+
+// Need to mock node:child_process properly to avoid breaking promisify(execFile) in headless.ts
+vi.mock('node:child_process', async (importOriginal) => {
+  // biome-ignore lint/suspicious/noExplicitAny: needed for mocking
+  const actual = (await importOriginal()) as any
+  return {
+    ...actual,
+    execFileSync: vi.fn(),
+  }
+})
+
+import { execFileSync } from 'node:child_process'
+
+describe('PID Injection Security', () => {
+  let config: GodotConfig
+
+  beforeEach(() => {
+    config = makeConfig({ projectPath: '/tmp/project', godotPath: '/path/to/godot' })
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('handleProject stop action', () => {
+    it('should NOT call taskkill or process.kill with non-numeric PIDs', async () => {
+      const maliciousPid = '123; calc.exe'
+      // biome-ignore lint/suspicious/noExplicitAny: explicitly testing injection
+      config.activePids = [maliciousPid as any]
+
+      const processKillSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      const originalPlatform = process.platform
+
+      // Test Windows path
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+
+      await handleProject('stop', {}, config)
+
+      expect(processKillSpy).not.toHaveBeenCalledWith(maliciousPid, expect.anything())
+      expect(execFileSync).not.toHaveBeenCalledWith(
+        'taskkill',
+        expect.arrayContaining([maliciousPid]),
+        expect.anything(),
+      )
+
+      // Test Unix path
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+      vi.clearAllMocks()
+      // biome-ignore lint/suspicious/noExplicitAny: explicitly testing injection
+      config.activePids = [maliciousPid as any]
+
+      await handleProject('stop', {}, config)
+      expect(processKillSpy).not.toHaveBeenCalledWith(maliciousPid, expect.anything())
+
+      processKillSpy.mockRestore()
+      Object.defineProperty(process, 'platform', { value: originalPlatform })
+    })
+
+    it('should NOT call taskkill or process.kill with non-integer PIDs', async () => {
+      const maliciousPid = 123.456
+      // biome-ignore lint/suspicious/noExplicitAny: explicitly testing injection
+      config.activePids = [maliciousPid as any]
+
+      const processKillSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+
+      await handleProject('stop', {}, config)
+
+      expect(processKillSpy).not.toHaveBeenCalledWith(maliciousPid, expect.anything())
+      expect(execFileSync).not.toHaveBeenCalledWith(
+        'taskkill',
+        expect.arrayContaining([maliciousPid.toString()]),
+        expect.anything(),
+      )
+
+      processKillSpy.mockRestore()
+    })
+  })
+
+  describe('handleEditor status action', () => {
+    it('should NOT call process.kill with non-numeric PIDs', async () => {
+      const maliciousPid = '123; calc.exe'
+      // biome-ignore lint/suspicious/noExplicitAny: explicitly testing injection
+      config.activePids = [maliciousPid as any]
+
+      const processKillSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+
+      await handleEditor('status', {}, config)
+
+      expect(processKillSpy).not.toHaveBeenCalledWith(maliciousPid, expect.anything())
+
+      processKillSpy.mockRestore()
+    })
+  })
+})


### PR DESCRIPTION
This PR fixes a security vulnerability where process IDs (PIDs) were used in shell commands (`taskkill` on Windows) and `process.kill` without proper validation. 

By strictly validating that PIDs are positive safe integers (`typeof pid === 'number' && Number.isSafeInteger(pid) && pid > 0`), we prevent malicious strings (e.g., `123; calc.exe`) from being injected into shell commands or causing unintended behavior in system calls.

Changes:
- Added PID validation in `src/tools/composite/project.ts` and `src/tools/composite/editor.ts`.
- Created a new test file `tests/security/pid-injection.test.ts` to reproduce the vulnerability and verify the fix across different platforms.
- Verified that all existing tests pass and linting/type checking is clean.

---
*PR created automatically by Jules for task [16703501676322459526](https://jules.google.com/task/16703501676322459526) started by @n24q02m*