### PR TITLE
[FIX] Extremely long description string

### DIFF
--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -57,8 +57,18 @@ function createAnnotations(
 const P0_TOOLS = [
   {
     name: 'project',
-    description:
-      'Godot project operations.\n\nActions (required params -> optional):\n- info (-> project_path): project metadata\n- version: Godot engine version\n- run (-> scene_path, project_path): launch game\n- stop: stop running game\n- settings_get (key -> project_path): read project setting\n- settings_set (key, value -> project_path): write project setting\n- export (preset, output_path -> project_path): export game build',
+    description: [
+      'Godot project operations.',
+      '',
+      'Actions (required params -> optional):',
+      '- info (-> project_path): project metadata',
+      '- version: Godot engine version',
+      '- run (-> scene_path, project_path): launch game',
+      '- stop: stop running game',
+      '- settings_get (key -> project_path): read project setting',
+      '- settings_set (key, value -> project_path): write project setting',
+      '- export (preset, output_path -> project_path): export game build',
+    ].join('\n'),
     annotations: createAnnotations('Project'),
     inputSchema: {
       type: 'object' as const,
@@ -80,8 +90,19 @@ const P0_TOOLS = [
   },
   {
     name: 'scenes',
-    description:
-      'Scene file (.tscn) CRUD.\n\nActions (required params -> optional):\n- create (scene_path -> root_type="Node2D", root_name, project_path)\n- list (-> project_path)\n- info (scene_path -> project_path)\n- delete (scene_path -> project_path)\n- duplicate (scene_path, new_path -> project_path)\n- set_main (scene_path -> project_path)\n\nscene_path: relative to project root (e.g., "scenes/main.tscn"), NOT res:// prefix. Use nodes tool to edit nodes within a scene.',
+    description: [
+      'Scene file (.tscn) CRUD.',
+      '',
+      'Actions (required params -> optional):',
+      '- create (scene_path -> root_type="Node2D", root_name, project_path)',
+      '- list (-> project_path)',
+      '- info (scene_path -> project_path)',
+      '- delete (scene_path -> project_path)',
+      '- duplicate (scene_path, new_path -> project_path)',
+      '- set_main (scene_path -> project_path)',
+      '',
+      'scene_path: relative to project root (e.g., "scenes/main.tscn"), NOT res:// prefix. Use nodes tool to edit nodes within a scene.',
+    ].join('\n'),
     annotations: createAnnotations('Scenes', { destructive: true }),
     inputSchema: {
       type: 'object' as const,
@@ -105,8 +126,19 @@ const P0_TOOLS = [
   },
   {
     name: 'nodes',
-    description:
-      'Scene node operations.\n\nActions (required params -> optional):\n- add (scene_path, name -> type="Node", parent=".", project_path)\n- remove (scene_path, name -> project_path)\n- rename (scene_path, name, new_name -> project_path)\n- list (scene_path -> project_path)\n- set_property (scene_path, name, property, value -> project_path)\n- get_property (scene_path, name, property -> project_path)\n\nNode paths: relative to scene root using "/" (e.g., "Player/Sprite2D"). Use "." for root.',
+    description: [
+      'Scene node operations.',
+      '',
+      'Actions (required params -> optional):',
+      '- add (scene_path, name -> type="Node", parent=".", project_path)',
+      '- remove (scene_path, name -> project_path)',
+      '- rename (scene_path, name, new_name -> project_path)',
+      '- list (scene_path -> project_path)',
+      '- set_property (scene_path, name, property, value -> project_path)',
+      '- get_property (scene_path, name, property -> project_path)',
+      '',
+      'Node paths: relative to scene root using "/" (e.g., "Player/Sprite2D"). Use "." for root.',
+    ].join('\n'),
     annotations: createAnnotations('Nodes', { destructive: true }),
     inputSchema: {
       type: 'object' as const,
@@ -134,8 +166,19 @@ const P0_TOOLS = [
   },
   {
     name: 'scripts',
-    description:
-      'GDScript file CRUD.\n\nActions (required params -> optional):\n- create (script_path -> extends="Node", content, project_path): generate template\n- read (script_path -> project_path)\n- write (script_path, content -> project_path): replace entire file\n- attach (script_path, scene_path, node_name -> project_path): link to scene node\n- list (-> project_path)\n- delete (script_path -> project_path)\n\nscript_path: relative to project root (e.g., "scripts/player.gd").',
+    description: [
+      'GDScript file CRUD.',
+      '',
+      'Actions (required params -> optional):',
+      '- create (script_path -> extends="Node", content, project_path): generate template',
+      '- read (script_path -> project_path)',
+      '- write (script_path, content -> project_path): replace entire file',
+      '- attach (script_path, scene_path, node_name -> project_path): link to scene node',
+      '- list (-> project_path)',
+      '- delete (script_path -> project_path)',
+      '',
+      'script_path: relative to project root (e.g., "scripts/player.gd").',
+    ].join('\n'),
     annotations: createAnnotations('Scripts', { destructive: true }),
     inputSchema: {
       type: 'object' as const,
@@ -157,8 +200,15 @@ const P0_TOOLS = [
   },
   {
     name: 'editor',
-    description:
-      'Godot editor control.\n\nActions (required params -> optional):\n- launch (-> project_path): open editor\n- status (-> project_path): check if editor is running\n\nFor running the game, use project(action="run") instead.',
+    description: [
+      'Godot editor control.',
+      '',
+      'Actions (required params -> optional):',
+      '- launch (-> project_path): open editor',
+      '- status (-> project_path): check if editor is running',
+      '',
+      'For running the game, use project(action="run") instead.',
+    ].join('\n'),
     annotations: createAnnotations('Editor', { idempotent: true }),
     inputSchema: {
       type: 'object' as const,
@@ -171,8 +221,15 @@ const P0_TOOLS = [
   },
   {
     name: 'config',
-    description:
-      'Server configuration and environment.\n\nActions (required params -> optional):\n- status: current config\n- set (key, value): update setting\n- detect_godot: find Godot binary path\n- check: verify project and Godot availability',
+    description: [
+      'Server configuration and environment.',
+      '',
+      'Actions (required params -> optional):',
+      '- status: current config',
+      '- set (key, value): update setting',
+      '- detect_godot: find Godot binary path',
+      '- check: verify project and Godot availability',
+    ].join('\n'),
     annotations: createAnnotations('Config', { idempotent: true }),
     inputSchema: {
       type: 'object' as const,
@@ -231,8 +288,15 @@ const P0_TOOLS = [
 const P1_TOOLS = [
   {
     name: 'resources',
-    description:
-      'Resource file management.\n\nActions (required params -> optional):\n- list (-> type, project_path): browse resources (type: image|audio|font|shader|scene|resource)\n- info (resource_path -> project_path): resource metadata\n- delete (resource_path -> project_path)\n- import_config (resource_path -> project_path): view import settings',
+    description: [
+      'Resource file management.',
+      '',
+      'Actions (required params -> optional):',
+      '- list (-> type, project_path): browse resources (type: image|audio|font|shader|scene|resource)',
+      '- info (resource_path -> project_path): resource metadata',
+      '- delete (resource_path -> project_path)',
+      '- import_config (resource_path -> project_path): view import settings',
+    ].join('\n'),
     annotations: createAnnotations('Resources', { destructive: true }),
     inputSchema: {
       type: 'object' as const,
@@ -247,8 +311,17 @@ const P1_TOOLS = [
   },
   {
     name: 'input_map',
-    description:
-      'Input action management.\n\nActions (required params -> optional):\n- list (-> project_path): all input actions\n- add_action (action_name -> deadzone=0.5, project_path)\n- remove_action (action_name -> project_path)\n- add_event (action_name, event_type, event_value -> project_path)\n\nevent_type: key | mouse | joypad. event_value: e.g., KEY_SPACE.',
+    description: [
+      'Input action management.',
+      '',
+      'Actions (required params -> optional):',
+      '- list (-> project_path): all input actions',
+      '- add_action (action_name -> deadzone=0.5, project_path)',
+      '- remove_action (action_name -> project_path)',
+      '- add_event (action_name, event_type, event_value -> project_path)',
+      '',
+      'event_type: key | mouse | joypad. event_value: e.g., KEY_SPACE.',
+    ].join('\n'),
     annotations: createAnnotations('Input Map', { destructive: true }),
     inputSchema: {
       type: 'object' as const,
@@ -269,8 +342,14 @@ const P1_TOOLS = [
   },
   {
     name: 'signals',
-    description:
-      'Signal connection management.\n\nActions (required params -> optional):\n- list (scene_path -> project_path): all signal connections\n- connect (scene_path, signal, from, to, method -> flags, project_path)\n- disconnect (scene_path, signal, from, to, method -> project_path)',
+    description: [
+      'Signal connection management.',
+      '',
+      'Actions (required params -> optional):',
+      '- list (scene_path -> project_path): all signal connections',
+      '- connect (scene_path, signal, from, to, method -> flags, project_path)',
+      '- disconnect (scene_path, signal, from, to, method -> project_path)',
+    ].join('\n'),
     annotations: createAnnotations('Signals', { destructive: true }),
     inputSchema: {
       type: 'object' as const,


### PR DESCRIPTION
Refactored multi-line tool descriptions in src/tools/registry.ts to use arrays of strings joined by newlines instead of literal \n characters. This improves source code readability for developers maintaining the registry while maintaining the same tool output for MCP clients.

Key changes:
- Converted single-line strings with `\n` to arrays of strings.
- Used `.join('\n')` to combine the arrays back into a single string.
- Applied this refactoring to core tools including `project`, `scenes`, `nodes`, `scripts`, `editor`, `config`, `resources`, `input_map`, and `signals`.
- Verified changes with `bun run check` and `bun run test`.

---
*PR created automatically by Jules for task [11590868079995639388](https://jules.google.com/task/11590868079995639388) started by @n24q02m*