### PR TITLE
[CLEANUP] Unnecessary RegExp Array Allocation in `match`

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -10,7 +10,7 @@ import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '..
 import { toGodotValue } from '../helpers/godot-types.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
 import { parseProjectSettingsAsync, setSettingInContent } from '../helpers/project-settings.js'
-import { escapeRegExp } from '../helpers/scene-parser.js'
+import { updateNodeInScene } from '../helpers/scene-parser.js'
 import { validateNoNewlines } from '../helpers/security.js'
 
 export async function handlePhysics(action: string, args: Record<string, unknown>, config: GodotConfig) {
@@ -54,28 +54,23 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       if (!(await pathExists(fullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 
-      let content = await readFile(fullPath, 'utf-8')
-      const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-      const match = content.match(nodeRegex)
-      if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-
-      if (match.index === undefined)
-        throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-      const insertPoint = match.index + match[0].length
-      let props = ''
+      const content = await readFile(fullPath, 'utf-8')
+      const updates: Record<string, string> = {}
       if (collisionLayer !== undefined) {
         const val = toGodotValue(collisionLayer)
         validateNoNewlines('Invalid collision_layer: newlines not allowed', val)
-        props += `\ncollision_layer = ${val}`
+        updates.collision_layer = val
       }
       if (collisionMask !== undefined) {
         const val = toGodotValue(collisionMask)
         validateNoNewlines('Invalid collision_mask: newlines not allowed', val)
-        props += `\ncollision_mask = ${val}`
+        updates.collision_mask = val
       }
 
-      content = `${content.slice(0, insertPoint)}${props}${content.slice(insertPoint)}`
-      await writeFile(fullPath, content, 'utf-8')
+      const { content: newContent, updated } = updateNodeInScene(content, nodeName, updates)
+      if (!updated) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+
+      await writeFile(fullPath, newContent, 'utf-8')
 
       return formatSuccess(
         `Set collision on ${nodeName}: layer=${collisionLayer ?? 'unchanged'}, mask=${collisionMask ?? 'unchanged'}`,
@@ -94,26 +89,21 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       if (!(await pathExists(fullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 
-      let content = await readFile(fullPath, 'utf-8')
-      const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-      const match = content.match(nodeRegex)
-      if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-
-      let props = ''
+      const content = await readFile(fullPath, 'utf-8')
+      const updates: Record<string, string> = {}
       const physicsProps = ['gravity_scale', 'mass', 'linear_damp', 'angular_damp', 'freeze']
       for (const prop of physicsProps) {
         if (args[prop] !== undefined) {
           const val = toGodotValue(args[prop])
           validateNoNewlines(`Invalid ${prop}: newlines not allowed`, val)
-          props += `\n${prop} = ${val}`
+          updates[prop] = val
         }
       }
 
-      if (match.index === undefined)
-        throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-      const insertPoint = match.index + match[0].length
-      content = `${content.slice(0, insertPoint)}${props}${content.slice(insertPoint)}`
-      await writeFile(fullPath, content, 'utf-8')
+      const { content: newContent, updated } = updateNodeInScene(content, nodeName, updates)
+      if (!updated) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+
+      await writeFile(fullPath, newContent, 'utf-8')
 
       return formatSuccess(`Configured physics body: ${nodeName}`)
     }

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -8,9 +8,7 @@ import { dirname, join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
-import { escapeRegExp } from '../helpers/scene-parser.js'
-
-const NODE_SECTION_RE = /(\[node [^\]]+\])/
+import { updateNodeInScene } from '../helpers/scene-parser.js'
 
 const SCRIPT_TEMPLATES: Record<string, string> = {
   Node: `extends Node
@@ -210,17 +208,23 @@ async function attachScript(args: Record<string, unknown>, resolvePath: (path: s
   const resPath = `res://${scriptPath.replaceAll('\\', '/')}`
 
   if (nodeName) {
-    const nodePattern = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-    const match = content.match(nodePattern)
-    if (!match)
+    const { content: newContent, updated } = updateNodeInScene(content, nodeName, {
+      script: `ExtResource("${resPath}")`,
+    })
+    if (!updated)
       throw new GodotMCPError(
         `Node "${nodeName}" not found in scene`,
         'NODE_ERROR',
         'Check node name with nodes.list action.',
       )
-    content = content.replace(nodePattern, (_match, p1) => `${p1}\nscript = ExtResource("${resPath}")`)
+    content = newContent
   } else {
-    content = content.replace(NODE_SECTION_RE, (_match, p1) => `${p1}\nscript = ExtResource("${resPath}")`)
+    const nodeIdx = content.indexOf('[node ')
+    if (nodeIdx === -1)
+      throw new GodotMCPError('No nodes found in scene', 'NODE_ERROR', 'Scene must have at least one node.')
+    const endOfLine = content.indexOf('\n', nodeIdx)
+    const insertPoint = endOfLine === -1 ? content.length : endOfLine + 1
+    content = `${content.slice(0, insertPoint)}script = ExtResource("${resPath}")\n${content.slice(insertPoint)}`
   }
 
   await writeFile(sceneFullPath, content, 'utf-8')

--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -8,7 +8,7 @@ import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
-import { escapeRegExp, parseScene } from '../helpers/scene-parser.js'
+import { parseScene, updateNodeInScene } from '../helpers/scene-parser.js'
 
 const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
   Button: { text: '"Click"' },
@@ -185,35 +185,51 @@ async function handleLayout(projectPath: string | null | undefined, args: Record
   }
 
   const fullPath = await resolveScene(projectPath, scenePath)
-  let content = await readFile(fullPath, 'utf-8')
+  const content = await readFile(fullPath, 'utf-8')
 
-  const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-  const match = content.match(nodeRegex)
-  if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-
-  let layoutProps = ''
+  const updates: Record<string, string> = {}
   switch (preset) {
     case 'full_rect':
-      layoutProps =
-        '\nanchors_preset = 15\nanchor_right = 1.0\nanchor_bottom = 1.0\ngrow_horizontal = 2\ngrow_vertical = 2'
+      updates.anchors_preset = '15'
+      updates.anchor_right = '1.0'
+      updates.anchor_bottom = '1.0'
+      updates.grow_horizontal = '2'
+      updates.grow_vertical = '2'
       break
     case 'center':
-      layoutProps =
-        '\nanchors_preset = 8\nanchor_left = 0.5\nanchor_top = 0.5\nanchor_right = 0.5\nanchor_bottom = 0.5\ngrow_horizontal = 2\ngrow_vertical = 2'
+      updates.anchors_preset = '8'
+      updates.anchor_left = '0.5'
+      updates.anchor_top = '0.5'
+      updates.anchor_right = '0.5'
+      updates.anchor_bottom = '0.5'
+      updates.grow_horizontal = '2'
+      updates.grow_vertical = '2'
       break
     case 'top_wide':
-      layoutProps = '\nanchors_preset = 10\nanchor_right = 1.0\ngrow_horizontal = 2'
+      updates.anchors_preset = '10'
+      updates.anchor_right = '1.0'
+      updates.grow_horizontal = '2'
       break
     case 'bottom_wide':
-      layoutProps =
-        '\nanchors_preset = 12\nanchor_top = 1.0\nanchor_right = 1.0\nanchor_bottom = 1.0\ngrow_horizontal = 2\ngrow_vertical = 0'
+      updates.anchors_preset = '12'
+      updates.anchor_top = '1.0'
+      updates.anchor_right = '1.0'
+      updates.anchor_bottom = '1.0'
+      updates.grow_horizontal = '2'
+      updates.grow_vertical = '0'
       break
     case 'left_wide':
-      layoutProps = '\nanchors_preset = 9\nanchor_bottom = 1.0\ngrow_vertical = 2'
+      updates.anchors_preset = '9'
+      updates.anchor_bottom = '1.0'
+      updates.grow_vertical = '2'
       break
     case 'right_wide':
-      layoutProps =
-        '\nanchors_preset = 11\nanchor_left = 1.0\nanchor_right = 1.0\nanchor_bottom = 1.0\ngrow_horizontal = 0\ngrow_vertical = 2'
+      updates.anchors_preset = '11'
+      updates.anchor_left = '1.0'
+      updates.anchor_right = '1.0'
+      updates.anchor_bottom = '1.0'
+      updates.grow_horizontal = '0'
+      updates.grow_vertical = '2'
       break
     default:
       throw new GodotMCPError(
@@ -223,11 +239,10 @@ async function handleLayout(projectPath: string | null | undefined, args: Record
       )
   }
 
-  if (match.index === undefined)
-    throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-  const insertPoint = match.index + match[0].length
-  content = `${content.slice(0, insertPoint)}${layoutProps}${content.slice(insertPoint)}`
-  await writeFile(fullPath, content, 'utf-8')
+  const { content: newContent, updated } = updateNodeInScene(content, nodeName, updates)
+  if (!updated) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+
+  await writeFile(fullPath, newContent, 'utf-8')
 
   return formatSuccess(`Set layout preset "${preset}" on ${nodeName}`)
 }

--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -346,7 +346,7 @@ function transformSceneContent(
 
       // Check if this new section is our target node
       const isNodeHeader = content.charCodeAt(start + 1) === 110 // "n"
-      inTargetNode = isNodeHeader && extractAttribute(line, "name=\"", "\"") === nodeName
+      inTargetNode = isNodeHeader && extractAttribute(line, 'name="', '"') === nodeName
     }
 
     const processed = callbacks.processLine(line, inTargetNode, isSectionHeader)

--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -346,7 +346,7 @@ function transformSceneContent(
 
       // Check if this new section is our target node
       const isNodeHeader = content.charCodeAt(start + 1) === 110 // "n"
-      inTargetNode = isNodeHeader && line.includes(`name="${nodeName}"`)
+      inTargetNode = isNodeHeader && extractAttribute(line, "name=\"", "\"") === nodeName
     }
 
     const processed = callbacks.processLine(line, inTargetNode, isSectionHeader)


### PR DESCRIPTION
This PR addresses unnecessary RegExp array allocations in several composite tools (`physics.ts`, `ui.ts`, and `scripts.ts`) by refactoring them to use the `updateNodeInScene` helper or manual string scanning.

Key changes:
- Refactored `handlePhysics` (`collision_setup`, `body_config`) and `handleUI` (`layout`) to use `updateNodeInScene`, which avoids RegExp capturing groups and provides more robust property updates.
- Refactored `handleScripts` (`attach`) to use `updateNodeInScene` for specific nodes and manual string scanning for the root node, removing the `NODE_SECTION_RE` and associated overhead.
- Improved node matching precision in `src/tools/helpers/scene-parser.ts` by using `extractAttribute` instead of a simple `.includes()` check.
- Ensured all integration tests for affected tools pass.
- Verified no regressions with the full project test suite (813 passes) and TypeScript type checking.

---
*PR created automatically by Jules for task [315696983613730016](https://jules.google.com/task/315696983613730016) started by @n24q02m*