### PR TITLE
fix: confine caller project_path to trusted root (path traversal)

### DIFF
--- a/src/tools/composite/animation.ts
+++ b/src/tools/composite/animation.ts
@@ -6,17 +6,17 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { pathExists, safeResolve } from '../helpers/paths.js'
+import { pathExists, resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 
-async function resolveScene(projectPath: string | null | undefined, scenePath: string): Promise<string> {
-  const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
+async function resolveScene(projectRoot: string, scenePath: string): Promise<string> {
+  const fullPath = safeResolve(projectRoot, scenePath)
   if (!(await pathExists(fullPath)))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
   return fullPath
 }
 
 export async function handleAnimation(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath
+  const projectPath = resolveProjectRoot(args.project_path, config.projectPath)
 
   switch (action) {
     case 'create_player': {

--- a/src/tools/composite/audio.ts
+++ b/src/tools/composite/audio.ts
@@ -7,7 +7,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { pathExists, safeResolve } from '../helpers/paths.js'
+import { pathExists, resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 
 /**
  * Helper to resolve the default bus layout path.
@@ -217,7 +217,8 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
         )
       }
 
-      const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
+      // Confine caller project_path to the trusted base before resolving the scene.
+      const fullPath = safeResolve(resolveProjectRoot(args.project_path, config.projectPath), scenePath)
       if (!(await pathExists(fullPath)))
         throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check file path.')
 

--- a/src/tools/composite/navigation.ts
+++ b/src/tools/composite/navigation.ts
@@ -6,10 +6,10 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { pathExists, safeResolve } from '../helpers/paths.js'
+import { pathExists, resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 
-async function resolveScene(projectPath: string | null | undefined, scenePath: string): Promise<string> {
-  const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
+async function resolveScene(projectRoot: string, scenePath: string): Promise<string> {
+  const fullPath = safeResolve(projectRoot, scenePath)
   if (!(await pathExists(fullPath)))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
   return fullPath
@@ -23,7 +23,7 @@ function appendNode(content: string, name: string, type: string, parent: string,
 }
 
 export async function handleNavigation(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath
+  const projectPath = resolveProjectRoot(args.project_path, config.projectPath)
 
   switch (action) {
     case 'create_region': {

--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -7,7 +7,7 @@ import { readdir, readFile, stat, unlink } from 'node:fs/promises'
 import { extname, join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { pathExists, safeResolve } from '../helpers/paths.js'
+import { pathExists, resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 
 const RESOURCE_EXTENSIONS = new Set([
   '.tres',
@@ -79,6 +79,9 @@ async function findResourceFiles(
 export async function handleResources(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const projectPath = (args.project_path as string) || config.projectPath
   const baseDir = config.projectPath || process.cwd()
+  // Confined trusted project root for per-file actions (info/delete/import_config):
+  // the caller-supplied project_path must stay within baseDir (path-traversal guard).
+  const projectRoot = resolveProjectRoot(args.project_path, config.projectPath)
 
   switch (action) {
     case 'list': {
@@ -120,7 +123,7 @@ export async function handleResources(action: string, args: Record<string, unkno
     case 'info': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-      const fullPath = safeResolve(projectPath || process.cwd(), resPath)
+      const fullPath = safeResolve(projectRoot, resPath)
       if (!(await pathExists(fullPath)))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
@@ -148,7 +151,7 @@ export async function handleResources(action: string, args: Record<string, unkno
     case 'delete': {
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-      const fullPath = safeResolve(projectPath || process.cwd(), resPath)
+      const fullPath = safeResolve(projectRoot, resPath)
       if (!(await pathExists(fullPath)))
         throw new GodotMCPError(`Resource not found: ${resPath}`, 'RESOURCE_ERROR', 'Check the file path.')
 
@@ -164,7 +167,7 @@ export async function handleResources(action: string, args: Record<string, unkno
       const resPath = args.resource_path as string
       if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
 
-      const importPath = safeResolve(projectPath || process.cwd(), `${resPath}.import`)
+      const importPath = safeResolve(projectRoot, `${resPath}.import`)
 
       if (!(await pathExists(importPath))) {
         return formatJSON({ path: resPath, imported: false, message: 'No .import file found.' })

--- a/src/tools/composite/shader.ts
+++ b/src/tools/composite/shader.ts
@@ -7,7 +7,7 @@ import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { safeResolve } from '../helpers/paths.js'
+import { resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 
 const SHADER_TEMPLATES: Record<string, string> = {
   canvas_item: `shader_type canvas_item;
@@ -80,6 +80,9 @@ async function findShaderFiles(dir: string, results: string[] = []): Promise<str
 export async function handleShader(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const projectPath = (args.project_path as string) || config.projectPath
   const baseDir = config.projectPath || process.cwd()
+  // Confined trusted project root for per-file actions (create/read/write/get_params):
+  // the caller-supplied project_path must stay within baseDir (path-traversal guard).
+  const projectRoot = resolveProjectRoot(args.project_path, config.projectPath)
 
   switch (action) {
     case 'create': {
@@ -93,7 +96,7 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderType = (args.shader_type as string) || 'canvas_item'
       const content = (args.content as string) || SHADER_TEMPLATES[shaderType] || SHADER_TEMPLATES.canvas_item
 
-      const fullPath = safeResolve(projectPath || process.cwd(), shaderPath)
+      const fullPath = safeResolve(projectRoot, shaderPath)
 
       // Ensure directory exists
       await mkdir(dirname(fullPath), { recursive: true })
@@ -115,7 +118,7 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderPath = args.shader_path as string
       if (!shaderPath) throw new GodotMCPError('No shader_path specified', 'INVALID_ARGS', 'Provide shader_path.')
 
-      const fullPath = safeResolve(projectPath || process.cwd(), shaderPath)
+      const fullPath = safeResolve(projectRoot, shaderPath)
 
       try {
         const content = await readFile(fullPath, 'utf-8')
@@ -134,7 +137,7 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const content = args.content as string
       if (!content) throw new GodotMCPError('No content specified', 'INVALID_ARGS', 'Provide shader content.')
 
-      const fullPath = safeResolve(projectPath || process.cwd(), shaderPath)
+      const fullPath = safeResolve(projectRoot, shaderPath)
       await mkdir(dirname(fullPath), { recursive: true })
       await writeFile(fullPath, content, 'utf-8')
       return formatSuccess(`Written: ${shaderPath} (${content.length} chars)`)
@@ -144,7 +147,7 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderPath = args.shader_path as string
       if (!shaderPath) throw new GodotMCPError('No shader_path specified', 'INVALID_ARGS', 'Provide shader_path.')
 
-      const fullPath = safeResolve(projectPath || process.cwd(), shaderPath)
+      const fullPath = safeResolve(projectRoot, shaderPath)
 
       try {
         const content = await readFile(fullPath, 'utf-8')

--- a/src/tools/composite/signals.ts
+++ b/src/tools/composite/signals.ts
@@ -6,7 +6,7 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { safeResolve } from '../helpers/paths.js'
+import { resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 import { parseSceneContent } from '../helpers/scene-parser.js'
 
 function validateParameters(...params: unknown[]) {
@@ -26,11 +26,11 @@ function validateParameters(...params: unknown[]) {
 }
 
 export async function handleSignals(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath
+  const projectPath = resolveProjectRoot(args.project_path, config.projectPath)
   const scenePath = args.scene_path as string
 
   if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
-  const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
+  const fullPath = safeResolve(projectPath, scenePath)
 
   async function readScene() {
     try {

--- a/src/tools/composite/tilemap.ts
+++ b/src/tools/composite/tilemap.ts
@@ -8,7 +8,7 @@ import { access, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { safeResolve } from '../helpers/paths.js'
+import { resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 
 /**
  * Async helper to check file existence without blocking the event loop
@@ -23,7 +23,7 @@ async function pathExists(path: string): Promise<boolean> {
 }
 
 export async function handleTilemap(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath
+  const projectPath = resolveProjectRoot(args.project_path, config.projectPath)
 
   switch (action) {
     case 'create_tileset': {
@@ -36,7 +36,7 @@ export async function handleTilemap(action: string, args: Record<string, unknown
         )
       const tileSize = (args.tile_size as number) || 16
 
-      const fullPath = safeResolve(projectPath || process.cwd(), tilesetPath)
+      const fullPath = safeResolve(projectPath, tilesetPath)
 
       // Performance optimization: using async pathExists instead of existsSync
       // to avoid blocking the Node.js event loop during I/O operations
@@ -75,7 +75,7 @@ export async function handleTilemap(action: string, args: Record<string, unknown
         )
       }
 
-      const fullPath = safeResolve(projectPath || process.cwd(), tilesetPath)
+      const fullPath = safeResolve(projectPath, tilesetPath)
 
       // Performance optimization: using async pathExists instead of existsSync
       if (!(await pathExists(fullPath)))
@@ -123,7 +123,7 @@ export async function handleTilemap(action: string, args: Record<string, unknown
       const scenePath = args.scene_path as string
       if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
 
-      const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
+      const fullPath = safeResolve(projectPath, scenePath)
 
       // Performance optimization: using async pathExists instead of existsSync
       if (!(await pathExists(fullPath)))

--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -7,7 +7,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { pathExists, safeResolve } from '../helpers/paths.js'
+import { pathExists, resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 import { escapeRegExp, parseScene } from '../helpers/scene-parser.js'
 
 const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
@@ -66,14 +66,14 @@ const CONTROL_TYPES = new Set([
   'NinePatchRect',
 ])
 
-async function resolveScene(projectPath: string | null | undefined, scenePath: string): Promise<string> {
-  const fullPath = safeResolve(projectPath || process.cwd(), scenePath)
+async function resolveScene(projectRoot: string, scenePath: string): Promise<string> {
+  const fullPath = safeResolve(projectRoot, scenePath)
   if (!(await pathExists(fullPath)))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
   return fullPath
 }
 
-async function handleCreateControl(projectPath: string | null | undefined, args: Record<string, unknown>) {
+async function handleCreateControl(projectPath: string, args: Record<string, unknown>) {
   const scenePath = args.scene_path as string
   if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
   const controlName = args.name as string
@@ -143,7 +143,7 @@ async function handleCreateControl(projectPath: string | null | undefined, args:
   return formatSuccess(`Created UI control: ${controlName} (${controlType}) under ${parent}`)
 }
 
-async function handleSetTheme(projectPath: string | null | undefined, args: Record<string, unknown>) {
+async function handleSetTheme(projectPath: string, args: Record<string, unknown>) {
   const themePath = args.theme_path as string
   if (!themePath)
     throw new GodotMCPError('No theme_path specified', 'INVALID_ARGS', 'Provide theme_path (e.g., "themes/main.tres").')
@@ -162,7 +162,7 @@ async function handleSetTheme(projectPath: string | null | undefined, args: Reco
   return formatSuccess(`Created theme: ${themePath} (font size: ${fontSize})`)
 }
 
-async function handleLayout(projectPath: string | null | undefined, args: Record<string, unknown>) {
+async function handleLayout(projectPath: string, args: Record<string, unknown>) {
   const scenePath = args.scene_path as string
   if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
   const nodeName = args.name as string
@@ -232,7 +232,7 @@ async function handleLayout(projectPath: string | null | undefined, args: Record
   return formatSuccess(`Set layout preset "${preset}" on ${nodeName}`)
 }
 
-async function handleListControls(projectPath: string | null | undefined, args: Record<string, unknown>) {
+async function handleListControls(projectPath: string, args: Record<string, unknown>) {
   const scenePath = args.scene_path as string
   if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
 
@@ -251,7 +251,9 @@ async function handleListControls(projectPath: string | null | undefined, args: 
 }
 
 export async function handleUI(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = (args.project_path as string) || config.projectPath
+  // project_path is caller-controlled and untrusted; confine it to the trusted
+  // project root before any handler uses it as a file-resolution base.
+  const projectPath = resolveProjectRoot(args.project_path, config.projectPath)
 
   switch (action) {
     case 'create_control':

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -75,6 +75,30 @@ export function safeResolve(baseDir: string, targetPath: string): string {
   return resolvedTarget
 }
 
+/**
+ * Resolves the trusted project root for a tool invocation.
+ *
+ * The caller-supplied `project_path` is UNTRUSTED. It must be confined within
+ * the operator-configured trusted base (`config.projectPath`, falling back to
+ * the server's working directory) before it can be used as a `safeResolve`
+ * base for any file operation. Without this confinement an MCP caller could
+ * point `project_path` at an arbitrary directory and read / write / delete
+ * files outside the intended project (path traversal, CWE-22/23).
+ *
+ * @param projectPathArg The untrusted `project_path` argument from the caller
+ * @param trustedBase The operator-configured project root (e.g. config.projectPath)
+ * @returns The absolute, confined project root to use as the base for all
+ *          subsequent per-file `safeResolve` calls
+ * @throws GodotMCPError if `projectPathArg` escapes the trusted base
+ */
+export function resolveProjectRoot(projectPathArg: unknown, trustedBase: string | null | undefined): string {
+  const base = trustedBase || process.cwd()
+  if (typeof projectPathArg === 'string' && projectPathArg.length > 0) {
+    return safeResolve(base, projectPathArg)
+  }
+  return resolve(base)
+}
+
 import { access } from 'node:fs/promises'
 
 /**

--- a/tests/composite/project-path-traversal.test.ts
+++ b/tests/composite/project-path-traversal.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Security: Out-of-project access/delete via unvalidated `project_path`.
+ *
+ * Reproduces the responsibly-disclosed report (Zhihao Zhang, WPI): several tool
+ * handlers used the caller-supplied `project_path` directly as the `safeResolve`
+ * base without first confining it to the operator-configured trusted root. A
+ * caller could point `project_path` at an arbitrary directory and
+ * read / write / delete files outside the intended Godot project (CWE-22/23).
+ *
+ * The trusted boundary is `config.projectPath` (falling back to the server's
+ * working directory). An attacker-controlled `project_path` that escapes that
+ * boundary MUST be rejected before any filesystem operation runs.
+ */
+
+import { existsSync } from 'node:fs'
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleAnimation } from '../../src/tools/composite/animation.js'
+import { handleAudio } from '../../src/tools/composite/audio.js'
+import { handleNavigation } from '../../src/tools/composite/navigation.js'
+import { handleResources } from '../../src/tools/composite/resources.js'
+import { handleShader } from '../../src/tools/composite/shader.js'
+import { handleSignals } from '../../src/tools/composite/signals.js'
+import { handleTilemap } from '../../src/tools/composite/tilemap.js'
+import { handleUI } from '../../src/tools/composite/ui.js'
+
+const MINIMAL_SCENE = '[gd_scene format=3]\n\n[node name="Root" type="Node2D"]\n'
+
+describe('Security: out-of-project access via unvalidated project_path', () => {
+  let root: string
+  let trustedProject: string
+  let outsideDir: string
+  let secretFile: string
+  let outsideScene: string
+  let config: GodotConfig
+
+  beforeEach(async () => {
+    // realpath up front so the macOS firmlink layout (/var -> /private/var) of
+    // the OS temp dir does not confuse the containment assertions.
+    root = await realpath(await mkdtemp(join(tmpdir(), 'godot-mcp-pptrav-')))
+    trustedProject = join(root, 'project')
+    outsideDir = join(root, 'outside')
+    await mkdir(trustedProject)
+    await mkdir(outsideDir)
+    await writeFile(join(trustedProject, 'project.godot'), '[application]\nconfig/name="Trusted"\n')
+    secretFile = join(outsideDir, 'secret.tres')
+    await writeFile(secretFile, '[gd_resource type="Resource" format=3]\n')
+    outsideScene = join(outsideDir, 'victim.tscn')
+    await writeFile(outsideScene, MINIMAL_SCENE)
+    // Server is configured with the trusted project as its boundary.
+    config = { godotPath: null, godotVersion: null, projectPath: trustedProject, activePids: [] }
+  })
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  const escapeRe = /Access denied|outside the project root/
+
+  it('resources.delete refuses to delete a file outside the project', async () => {
+    await expect(
+      handleResources('delete', { project_path: outsideDir, resource_path: 'secret.tres' }, config),
+    ).rejects.toThrow(escapeRe)
+    expect(existsSync(secretFile)).toBe(true)
+  })
+
+  it('resources.info refuses to read a file outside the project', async () => {
+    await expect(
+      handleResources('info', { project_path: outsideDir, resource_path: 'secret.tres' }, config),
+    ).rejects.toThrow(escapeRe)
+  })
+
+  it('resources.import_config refuses to read outside the project', async () => {
+    await expect(
+      handleResources('import_config', { project_path: outsideDir, resource_path: 'secret.tres' }, config),
+    ).rejects.toThrow(escapeRe)
+  })
+
+  it('shader.write refuses to create a file outside the project', async () => {
+    await expect(
+      handleShader('write', { project_path: outsideDir, shader_path: 'pwned.gdshader', content: 'x' }, config),
+    ).rejects.toThrow(escapeRe)
+    expect(existsSync(join(outsideDir, 'pwned.gdshader'))).toBe(false)
+  })
+
+  it('shader.create refuses to create a file outside the project', async () => {
+    await expect(
+      handleShader('create', { project_path: outsideDir, shader_path: 'pwned.gdshader' }, config),
+    ).rejects.toThrow(escapeRe)
+    expect(existsSync(join(outsideDir, 'pwned.gdshader'))).toBe(false)
+  })
+
+  it('shader.read refuses to read a file outside the project', async () => {
+    await expect(
+      handleShader('read', { project_path: outsideDir, shader_path: 'secret.tres' }, config),
+    ).rejects.toThrow(escapeRe)
+  })
+
+  it('ui.set_theme refuses to write a file outside the project', async () => {
+    await expect(handleUI('set_theme', { project_path: outsideDir, theme_path: 'pwned.tres' }, config)).rejects.toThrow(
+      escapeRe,
+    )
+    expect(existsSync(join(outsideDir, 'pwned.tres'))).toBe(false)
+  })
+
+  it('tilemap.create_tileset refuses to write a file outside the project', async () => {
+    await expect(
+      handleTilemap('create_tileset', { project_path: outsideDir, tileset_path: 'pwned.tres' }, config),
+    ).rejects.toThrow(escapeRe)
+    expect(existsSync(join(outsideDir, 'pwned.tres'))).toBe(false)
+  })
+
+  it('animation.create_player refuses to modify a scene outside the project', async () => {
+    await expect(
+      handleAnimation('create_player', { project_path: outsideDir, scene_path: 'victim.tscn' }, config),
+    ).rejects.toThrow(escapeRe)
+  })
+
+  it('navigation.create_region refuses to modify a scene outside the project', async () => {
+    await expect(
+      handleNavigation('create_region', { project_path: outsideDir, scene_path: 'victim.tscn' }, config),
+    ).rejects.toThrow(escapeRe)
+  })
+
+  it('audio.create_stream refuses to modify a scene outside the project', async () => {
+    await expect(
+      handleAudio('create_stream', { project_path: outsideDir, scene_path: 'victim.tscn' }, config),
+    ).rejects.toThrow(escapeRe)
+  })
+
+  it('signals.list refuses to read a scene outside the project', async () => {
+    await expect(
+      handleSignals('list', { project_path: outsideDir, scene_path: 'victim.tscn' }, config),
+    ).rejects.toThrow(escapeRe)
+  })
+
+  it('still allows operations inside the trusted project (no false positives)', async () => {
+    // Sanity: a legitimate in-project shader write succeeds.
+    await expect(
+      handleShader(
+        'write',
+        { project_path: trustedProject, shader_path: 'fx.gdshader', content: 'shader_type canvas_item;' },
+        config,
+      ),
+    ).resolves.toBeDefined()
+    expect(existsSync(join(trustedProject, 'fx.gdshader'))).toBe(true)
+  })
+})

--- a/tests/helpers/paths.test.ts
+++ b/tests/helpers/paths.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join, relative, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { GodotMCPError } from '../../src/tools/helpers/errors.js'
-import { pathExists, safeResolve } from '../../src/tools/helpers/paths.js'
+import { pathExists, resolveProjectRoot, safeResolve } from '../../src/tools/helpers/paths.js'
 
 describe('safeResolve', () => {
   const baseDir = resolve('/mock/base/dir')
@@ -127,6 +127,44 @@ describe('safeResolve canonicalization (symlink / firmlink hardening)', () => {
       expect(rel.startsWith('..')).toBe(false)
     },
   )
+})
+
+describe('resolveProjectRoot', () => {
+  const trustedBase = resolve('/mock/trusted/project')
+
+  it('returns the resolved trusted base when no project_path is given', () => {
+    expect(resolveProjectRoot(undefined, trustedBase)).toBe(trustedBase)
+    expect(resolveProjectRoot('', trustedBase)).toBe(trustedBase)
+    expect(resolveProjectRoot(null, trustedBase)).toBe(trustedBase)
+  })
+
+  it('falls back to process.cwd() when trusted base is unset', () => {
+    expect(resolveProjectRoot(undefined, null)).toBe(resolve(process.cwd()))
+    expect(resolveProjectRoot(undefined, undefined)).toBe(resolve(process.cwd()))
+  })
+
+  it('confines a relative project_path within the trusted base', () => {
+    expect(resolveProjectRoot('sub/project', trustedBase)).toBe(resolve(trustedBase, 'sub/project'))
+  })
+
+  it('accepts an absolute project_path that is inside the trusted base', () => {
+    const inside = resolve(trustedBase, 'inner')
+    expect(resolveProjectRoot(inside, trustedBase)).toBe(inside)
+  })
+
+  it('rejects an absolute project_path outside the trusted base', () => {
+    expect(() => resolveProjectRoot(resolve('/etc'), trustedBase)).toThrowError(GodotMCPError)
+    expect(() => resolveProjectRoot(resolve('/etc'), trustedBase)).toThrow(/Access denied/)
+  })
+
+  it('rejects a relative project_path that traverses outside the trusted base', () => {
+    expect(() => resolveProjectRoot('../../etc', trustedBase)).toThrowError(GodotMCPError)
+  })
+
+  it('ignores non-string project_path values', () => {
+    expect(resolveProjectRoot(123, trustedBase)).toBe(trustedBase)
+    expect(resolveProjectRoot({ evil: '../../etc' }, trustedBase)).toBe(trustedBase)
+  })
 })
 
 describe('pathExists', () => {


### PR DESCRIPTION
## Summary

Fixes a responsibly-disclosed path-traversal vulnerability (reported by **Zhihao Zhang**, WPI).

Several composite tool handlers used the caller-supplied `project_path` **directly** as the `safeResolve` base without first confining it to the operator-configured trusted root (`config.projectPath`, falling back to the server working directory). `safeResolve` only stops the *target* from escaping its base — it trusts the base. So an MCP caller could set `project_path` to an arbitrary directory and **read / write / delete files outside the intended Godot project** (CWE-22 / CWE-23).

### Affected handlers (before fix)
- `resources`: `info`, `delete`, `import_config`
- `shader`: `create`, `read`, `write`, `get_params`
- `ui`: `set_theme` + scene actions (`create_control`, `layout`, `list_controls`)
- `animation`, `navigation`, `signals`, `tilemap`: scene actions
- `audio`: `create_stream`

The already-hardened handlers (`nodes`, `scenes`, `scripts`, `physics`, `project`, `editor`, `input-map`, and the `list` actions) used the correct pattern.

## Fix

Centralize the confinement in a single helper `resolveProjectRoot(project_path, trustedBase)` in `src/tools/helpers/paths.ts`, and route every previously-vulnerable handler through it. The caller `project_path` is now confined within the trusted base via `safeResolve` **before** it is used as a base for any per-file resolution. One enforcement point → future handlers cannot diverge.

This complements #708 (which hardened `safeResolve` against symlink/firmlink traversal of the *target*); this PR closes the gap on the *base*.

## Tests
- `tests/composite/project-path-traversal.test.ts` — PoC regression suite reproducing the report across all affected handlers (out-of-project read/write/delete now rejected; secret files untouched).
- `tests/helpers/paths.test.ts` — unit tests for `resolveProjectRoot`.
- Full suite: 832 passed / 2 skipped; biome + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)