### PR TITLE
[PERF] Object.entries allocation inside loops

### DIFF
--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -85,17 +85,29 @@ async function handleAddNode(projectPath: string, args: Record<string, unknown>)
         'properties must be an object with string keys and values.',
       )
     }
-    for (const [key, value] of Object.entries(args.properties)) {
-      if (typeof key !== 'string' || typeof value !== 'string') {
-        throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property keys and values must be strings.')
+    const props = args.properties as Record<string, unknown>
+    for (const key in props) {
+      if (Object.hasOwn(props, key)) {
+        const value = props[key]
+        if (typeof key !== 'string' || typeof value !== 'string') {
+          throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property keys and values must be strings.')
+        }
+        if (key.includes('=') || key.includes('\n') || key.includes('\r')) {
+          throw new GodotMCPError(
+            'Invalid property key',
+            'INVALID_ARGS',
+            'Property keys must not contain "=", newlines.',
+          )
+        }
+        if (value.includes('\n') || value.includes('\r')) {
+          throw new GodotMCPError(
+            'Invalid property value',
+            'INVALID_ARGS',
+            'Property values must not contain newlines.',
+          )
+        }
+        nodeDecl += `${key} = ${value}\n`
       }
-      if (key.includes('=') || key.includes('\n') || key.includes('\r')) {
-        throw new GodotMCPError('Invalid property key', 'INVALID_ARGS', 'Property keys must not contain "=", newlines.')
-      }
-      if (value.includes('\n') || value.includes('\r')) {
-        throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property values must not contain newlines.')
-      }
-      nodeDecl += `${key} = ${value}\n`
     }
   }
 

--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -109,8 +109,11 @@ async function handleCreateControl(projectPath: string, args: Record<string, unk
   // Add default properties for known control types
   const defaults = CONTROL_TEMPLATES[controlType]
   if (defaults) {
-    for (const [key, value] of Object.entries(defaults)) {
-      nodeDecl += `${key} = ${value}\n`
+    for (const key in defaults) {
+      if (Object.hasOwn(defaults, key)) {
+        const value = defaults[key]
+        nodeDecl += `${key} = ${value}\n`
+      }
     }
   }
 
@@ -123,17 +126,29 @@ async function handleCreateControl(projectPath: string, args: Record<string, unk
         'properties must be an object with string keys and values.',
       )
     }
-    for (const [key, value] of Object.entries(args.properties)) {
-      if (typeof key !== 'string' || typeof value !== 'string') {
-        throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property keys and values must be strings.')
+    const props = args.properties as Record<string, unknown>
+    for (const key in props) {
+      if (Object.hasOwn(props, key)) {
+        const value = props[key]
+        if (typeof key !== 'string' || typeof value !== 'string') {
+          throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property keys and values must be strings.')
+        }
+        if (key.includes('=') || key.includes('\n') || key.includes('\r')) {
+          throw new GodotMCPError(
+            'Invalid property key',
+            'INVALID_ARGS',
+            'Property keys must not contain "=", newlines.',
+          )
+        }
+        if (value.includes('\n') || value.includes('\r')) {
+          throw new GodotMCPError(
+            'Invalid property value',
+            'INVALID_ARGS',
+            'Property values must not contain newlines.',
+          )
+        }
+        nodeDecl += `${key} = ${value}\n`
       }
-      if (key.includes('=') || key.includes('\n') || key.includes('\r')) {
-        throw new GodotMCPError('Invalid property key', 'INVALID_ARGS', 'Property keys must not contain "=", newlines.')
-      }
-      if (value.includes('\n') || value.includes('\r')) {
-        throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property values must not contain newlines.')
-      }
-      nodeDecl += `${key} = ${value}\n`
     }
   }
 

--- a/src/tools/helpers/godot-types.ts
+++ b/src/tools/helpers/godot-types.ts
@@ -229,8 +229,10 @@ export function toGodotValue(value: unknown): string {
  */
 export function serializeGodotObject(className: string, properties: Record<string, unknown>): string {
   let result = `Object(${className}`
-  for (const [key, value] of Object.entries(properties)) {
-    result += `,"${key}":${toGodotValue(value)}`
+  for (const key in properties) {
+    if (Object.hasOwn(properties, key)) {
+      result += `,"${key}":${toGodotValue(properties[key])}`
+    }
   }
   return `${result})`
 }


### PR DESCRIPTION
This PR optimizes the codebase by replacing `Object.entries()` with `for...in` loops and `Object.hasOwn()` checks in performance-sensitive areas where property iteration occurs inside loops. This change avoids unnecessary array and iterator allocations.

Areas optimized:
- `serializeGodotObject` in `src/tools/helpers/godot-types.ts`
- `handleAddNode` in `src/tools/composite/nodes.ts`
- `handleCreateControl` in `src/tools/composite/ui.ts`

Verification:
- Full test suite passed (844 tests).
- Lint and type checks completed (with Biome format fixes).

---
*PR created automatically by Jules for task [7914519913555846208](https://jules.google.com/task/7914519913555846208) started by @n24q02m*