### PR TITLE
[FIX] Large throwUnknownAction string array

### DIFF
--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -223,24 +223,25 @@ async function handleGetNodeProperty(projectPath: string, args: Record<string, u
   return formatJSON({ node: nodeName, property, value: val ?? null })
 }
 
+const NODE_ACTIONS: Record<
+  string,
+  (projectPath: string, args: Record<string, unknown>) => Promise<{ content: Array<{ type: 'text'; text: string }> }>
+> = {
+  add: handleAddNode,
+  remove: handleRemoveNode,
+  rename: handleRenameNode,
+  list: handleListNodes,
+  set_property: handleSetNodeProperty,
+  get_property: handleGetNodeProperty,
+}
+
 export async function handleNodes(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const baseProjectPath = config.projectPath || process.cwd()
   const projectPath = args.project_path ? safeResolve(baseProjectPath, args.project_path as string) : baseProjectPath
 
-  switch (action) {
-    case 'add':
-      return handleAddNode(projectPath, args)
-    case 'remove':
-      return handleRemoveNode(projectPath, args)
-    case 'rename':
-      return handleRenameNode(projectPath, args)
-    case 'list':
-      return handleListNodes(projectPath, args)
-    case 'set_property':
-      return handleSetNodeProperty(projectPath, args)
-    case 'get_property':
-      return handleGetNodeProperty(projectPath, args)
-    default:
-      throwUnknownAction(action, ['add', 'remove', 'rename', 'list', 'set_property', 'get_property'])
+  const handler = NODE_ACTIONS[action]
+  if (handler) {
+    return handler(projectPath, args)
   }
+  throwUnknownAction(action, Object.keys(NODE_ACTIONS))
 }


### PR DESCRIPTION
Refactor the handleNodes dispatcher in src/tools/composite/nodes.ts to use a NODE_ACTIONS object mapping instead of a switch statement. This ensures consistency between the implemented actions and the error reporting by deriving valid actions from Object.keys(NODE_ACTIONS) in the throwUnknownAction call.

Key changes:
- Defined `NODE_ACTIONS` mapping for node actions.
- Updated `handleNodes` to use the mapping.
- Verified changes with tests and linting.

---
*PR created automatically by Jules for task [13397838991042455948](https://jules.google.com/task/13397838991042455948) started by @n24q02m*