### PR TITLE
[CLEANUP] ReDoS via Unsafe Dynamic RegExp in UI layout configuration

### DIFF
--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -8,7 +8,7 @@ import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, resolveProjectRoot, safeResolve } from '../helpers/paths.js'
-import { escapeRegExp, parseScene } from '../helpers/scene-parser.js'
+import { parseScene, updateNodeInScene } from '../helpers/scene-parser.js'
 
 const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
   Button: { text: '"Click"' },
@@ -185,35 +185,63 @@ async function handleLayout(projectPath: string, args: Record<string, unknown>) 
   }
 
   const fullPath = await resolveScene(projectPath, scenePath)
-  let content = await readFile(fullPath, 'utf-8')
+  const content = await readFile(fullPath, 'utf-8')
 
-  const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-  const match = content.match(nodeRegex)
-  if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-
-  let layoutProps = ''
+  let layoutUpdates: Record<string, string> = {}
   switch (preset) {
     case 'full_rect':
-      layoutProps =
-        '\nanchors_preset = 15\nanchor_right = 1.0\nanchor_bottom = 1.0\ngrow_horizontal = 2\ngrow_vertical = 2'
+      layoutUpdates = {
+        anchors_preset: '15',
+        anchor_right: '1.0',
+        anchor_bottom: '1.0',
+        grow_horizontal: '2',
+        grow_vertical: '2',
+      }
       break
     case 'center':
-      layoutProps =
-        '\nanchors_preset = 8\nanchor_left = 0.5\nanchor_top = 0.5\nanchor_right = 0.5\nanchor_bottom = 0.5\ngrow_horizontal = 2\ngrow_vertical = 2'
+      layoutUpdates = {
+        anchors_preset: '8',
+        anchor_left: '0.5',
+        anchor_top: '0.5',
+        anchor_right: '0.5',
+        anchor_bottom: '0.5',
+        grow_horizontal: '2',
+        grow_vertical: '2',
+      }
       break
     case 'top_wide':
-      layoutProps = '\nanchors_preset = 10\nanchor_right = 1.0\ngrow_horizontal = 2'
+      layoutUpdates = {
+        anchors_preset: '10',
+        anchor_right: '1.0',
+        grow_horizontal: '2',
+      }
       break
     case 'bottom_wide':
-      layoutProps =
-        '\nanchors_preset = 12\nanchor_top = 1.0\nanchor_right = 1.0\nanchor_bottom = 1.0\ngrow_horizontal = 2\ngrow_vertical = 0'
+      layoutUpdates = {
+        anchors_preset: '12',
+        anchor_top: '1.0',
+        anchor_right: '1.0',
+        anchor_bottom: '1.0',
+        grow_horizontal: '2',
+        grow_vertical: '0',
+      }
       break
     case 'left_wide':
-      layoutProps = '\nanchors_preset = 9\nanchor_bottom = 1.0\ngrow_vertical = 2'
+      layoutUpdates = {
+        anchors_preset: '9',
+        anchor_bottom: '1.0',
+        grow_vertical: '2',
+      }
       break
     case 'right_wide':
-      layoutProps =
-        '\nanchors_preset = 11\nanchor_left = 1.0\nanchor_right = 1.0\nanchor_bottom = 1.0\ngrow_horizontal = 0\ngrow_vertical = 2'
+      layoutUpdates = {
+        anchors_preset: '11',
+        anchor_left: '1.0',
+        anchor_right: '1.0',
+        anchor_bottom: '1.0',
+        grow_horizontal: '0',
+        grow_vertical: '2',
+      }
       break
     default:
       throw new GodotMCPError(
@@ -223,11 +251,10 @@ async function handleLayout(projectPath: string, args: Record<string, unknown>) 
       )
   }
 
-  if (match.index === undefined)
-    throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-  const insertPoint = match.index + match[0].length
-  content = `${content.slice(0, insertPoint)}${layoutProps}${content.slice(insertPoint)}`
-  await writeFile(fullPath, content, 'utf-8')
+  const { content: updatedContent, updated } = updateNodeInScene(content, nodeName, layoutUpdates)
+  if (!updated) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+
+  await writeFile(fullPath, updatedContent, 'utf-8')
 
   return formatSuccess(`Set layout preset "${preset}" on ${nodeName}`)
 }

--- a/tests/composite/ui.test.ts
+++ b/tests/composite/ui.test.ts
@@ -269,6 +269,22 @@ describe('ui', () => {
         handleUI('layout', { scene_path: 'ghost.tscn', name: 'Root', preset: 'full_rect' }, config),
       ).rejects.toThrow('Scene not found')
     })
+
+    it('should update existing layout properties', async () => {
+      const PRE_LAYOUT_SCENE = `[gd_scene format=3]\n\n[node name="Root" type="Control"]\nanchors_preset = 0\ngrow_horizontal = 1\n`
+      createTmpScene(projectPath, 'pre_layout.tscn', PRE_LAYOUT_SCENE)
+
+      await handleUI('layout', { scene_path: 'pre_layout.tscn', name: 'Root', preset: 'full_rect' }, config)
+
+      const content = readFileSync(join(projectPath, 'pre_layout.tscn'), 'utf-8')
+      expect(content).toContain('anchors_preset = 15')
+      expect(content).toContain('grow_horizontal = 2')
+      expect(content).toContain('anchor_right = 1.0')
+      // Ensure we didn't duplicate keys
+      const lines = content.split('\n')
+      const anchorPresetLines = lines.filter((l) => l.startsWith('anchors_preset'))
+      expect(anchorPresetLines).toHaveLength(1)
+    })
   })
 
   // ==========================================


### PR DESCRIPTION
This PR addresses a ReDoS vulnerability in the UI tool's layout handler.

The previous implementation used a dynamic Regular Expression with a potentially unsafe `[^\]]*` pattern to find the target node header in Godot `.tscn` files. This has been replaced by the established `updateNodeInScene` helper, which uses a line-by-line manual string scanner.

Additionally, the layout presets are now mapped to property objects, which allows `updateNodeInScene` to update existing properties instead of just appending them, preventing property duplication.

Verified with existing tests and a new test case for property updates. All 845 tests passed.

---
*PR created automatically by Jules for task [6666346010231430433](https://jules.google.com/task/6666346010231430433) started by @n24q02m*