### PR TITLE
[PERF] String allocation inside loops via split or matches

### DIFF
--- a/src/tools/composite/audio.ts
+++ b/src/tools/composite/audio.ts
@@ -8,6 +8,55 @@ import { join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, resolveProjectRoot, safeResolve } from '../helpers/paths.js'
+import { countMatches } from '../helpers/strings.js'
+
+/**
+ * Manual scanner for bus names in .tres files to avoid regex allocations.
+ */
+function* scanBuses(content: string): Generator<{ index: number; name: string }> {
+  let pos = 0
+  const len = content.length
+
+  while (pos < len) {
+    pos = content.indexOf('bus/', pos)
+    if (pos === -1) break
+
+    const indexStart = pos + 4
+    let indexEnd = indexStart
+    while (indexEnd < len && content.charCodeAt(indexEnd) >= 48 && content.charCodeAt(indexEnd) <= 57) {
+      indexEnd++
+    }
+
+    if (indexEnd === indexStart) {
+      pos++
+      continue
+    }
+
+    if (content.startsWith('/name', indexEnd)) {
+      const eqIdx = content.indexOf('=', indexEnd + 5)
+      if (eqIdx !== -1) {
+        // Simple check for " after = (potentially with spaces)
+        let quoteStart = eqIdx + 1
+        while (quoteStart < len && content.charCodeAt(quoteStart) <= 32) quoteStart++
+
+        if (content[quoteStart] === '"') {
+          const quoteEnd = content.indexOf('"', quoteStart + 1)
+          if (quoteEnd !== -1) {
+            let index = 0
+            for (let i = indexStart; i < indexEnd; i++) {
+              index = index * 10 + (content.charCodeAt(i) - 48)
+            }
+            const name = content.slice(quoteStart + 1, quoteEnd)
+            yield { index, name }
+            pos = quoteEnd + 1
+            continue
+          }
+        }
+      }
+    }
+    pos = indexEnd
+  }
+}
 
 /**
  * Helper to resolve the default bus layout path.
@@ -36,9 +85,8 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       const buses: { name: string; volume?: string; solo?: boolean; mute?: boolean }[] = []
 
       // Parse bus entries
-      const busRegex = /bus\/(\d+)\/name\s*=\s*"([^"]*)"/g
-      for (const match of content.matchAll(busRegex)) {
-        buses.push({ name: match[2] })
+      for (const match of scanBuses(content)) {
+        buses.push({ name: match.name })
       }
 
       if (buses.length === 0) buses.push({ name: 'Master' })
@@ -85,7 +133,7 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       }
 
       // Count existing buses
-      const busCount = (content.match(/bus\/\d+\/name/g) || []).length
+      const busCount = countMatches(content, /bus\/\d+\/name/g)
 
       const newBus = [
         `bus/${busCount}/name = "${busName}"`,
@@ -151,11 +199,10 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       }
 
       // Find the target bus index
-      const busRegex = /bus\/(\d+)\/name\s*=\s*"([^"]*)"/g
       let busIndex = -1
-      for (const match of content.matchAll(busRegex)) {
-        if (match[2] === busName) {
-          busIndex = Number.parseInt(match[1], 10)
+      for (const match of scanBuses(content)) {
+        if (match.name === busName) {
+          busIndex = match.index
           break
         }
       }
@@ -165,8 +212,7 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
 
       // Count existing effects on this bus
       const effectCountRegex = new RegExp(`bus/${busIndex}/effect/\\d+/effect`, 'g')
-      const existingEffects = content.match(effectCountRegex) || []
-      const effectIndex = existingEffects.length
+      const effectIndex = countMatches(content, effectCountRegex)
 
       // Generate unique sub_resource id
       const subResId = `${fullEffectType}_${Date.now()}`

--- a/src/tools/helpers/strings.ts
+++ b/src/tools/helpers/strings.ts
@@ -33,3 +33,33 @@ export function parseCommaSeparatedList(str: string): string[] {
 
   return result
 }
+
+/**
+ * Count occurrences of a substring within a string without allocations.
+ * Guarded against infinite loops with empty search strings.
+ */
+export function countString(str: string, search: string): number {
+  if (!search || !str) return 0
+  let count = 0
+  let pos = 0
+  while (true) {
+    pos = str.indexOf(search, pos)
+    if (pos === -1) break
+    count++
+    pos += search.length
+  }
+  return count
+}
+
+/**
+ * Count occurrences of a regex pattern within a string using a non-allocating loop.
+ * Requires the 'g' flag on the regex to avoid infinite loops.
+ */
+export function countMatches(str: string, regex: RegExp): number {
+  if (!str) return 0
+  let count = 0
+  while (regex.exec(str) !== null) {
+    count++
+  }
+  return count
+}

--- a/tests/helpers/strings.test.ts
+++ b/tests/helpers/strings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseCommaSeparatedList } from '../../src/tools/helpers/strings.js'
+import { countMatches, countString, parseCommaSeparatedList } from '../../src/tools/helpers/strings.js'
 
 describe('strings helpers', () => {
   describe('parseCommaSeparatedList', () => {
@@ -33,6 +33,35 @@ describe('strings helpers', () => {
 
     it('should handle items with inner spaces', () => {
       expect(parseCommaSeparatedList('word1 word2, word3 word4')).toEqual(['word1 word2', 'word3 word4'])
+    })
+  })
+
+  describe('countString', () => {
+    it('should count occurrences of a substring', () => {
+      expect(countString('apple, banana, apple, cherry', 'apple')).toBe(2)
+    })
+
+    it('should return 0 if substring is not found', () => {
+      expect(countString('apple, banana, cherry', 'date')).toBe(0)
+    })
+
+    it('should handle empty strings', () => {
+      expect(countString('', 'apple')).toBe(0)
+      expect(countString('apple', '')).toBe(0)
+    })
+  })
+
+  describe('countMatches', () => {
+    it('should count occurrences of a regex pattern', () => {
+      expect(countMatches('bus/0/name, bus/1/name, bus/2/name', /bus\/\d+\/name/g)).toBe(3)
+    })
+
+    it('should return 0 if pattern is not found', () => {
+      expect(countMatches('apple, banana, cherry', /date/g)).toBe(0)
+    })
+
+    it('should handle empty strings', () => {
+      expect(countMatches('', /apple/g)).toBe(0)
     })
   })
 })


### PR DESCRIPTION
This PR optimizes the performance of audio bus layout parsing in `src/tools/composite/audio.ts` by reducing unnecessary string allocations.

Key changes:
1.  **New String Utilities**: Added `countString` and `countMatches` to `src/tools/helpers/strings.ts`. These functions allow counting occurrences of substrings or regex patterns without creating intermediate arrays (avoiding `(match() || []).length`).
2.  **Manual Bus Scanning**: Implemented a generator-based manual scanner `scanBuses` in `audio.ts` that uses `indexOf` to parse bus indices and names from `.tres` files. This replaces `content.matchAll(busRegex)`, which allocates multiple match objects.
3.  **Efficient Counting**: Updated the `add_bus` and `add_effect` actions to use `countMatches` for determining existing bus or effect counts.
4.  **Verification**: Added unit tests for the new string utilities and verified all existing audio tests pass. Ran `bun run check` to ensure linting and types are correct.

---
*PR created automatically by Jules for task [2939780709578744911](https://jules.google.com/task/2939780709578744911) started by @n24q02m*