### PR TITLE
[TEST] Missing error path test for pathExists

### DIFF
--- a/src/tools/composite/tilemap.ts
+++ b/src/tools/composite/tilemap.ts
@@ -3,24 +3,11 @@
  * Actions: create_tileset | add_source | set_tile | paint | list
  */
 
-import { constants } from 'node:fs'
-import { access, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { resolveProjectRoot, safeResolve } from '../helpers/paths.js'
-
-/**
- * Async helper to check file existence without blocking the event loop
- */
-async function pathExists(path: string): Promise<boolean> {
-  try {
-    await access(path, constants.F_OK)
-    return true
-  } catch {
-    return false
-  }
-}
+import { pathExists, resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 
 export async function handleTilemap(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const projectPath = resolveProjectRoot(args.project_path, config.projectPath)

--- a/tests/helpers/paths.test.ts
+++ b/tests/helpers/paths.test.ts
@@ -239,4 +239,29 @@ describe('pathExists', () => {
       mockedAccess.mockRestore()
     }
   })
+
+  it('returns false when access throws EACCES (Permission Denied)', async () => {
+    const mockedAccess = vi.mocked(access)
+    // biome-ignore lint/suspicious/noExplicitAny: needed for mocking error code
+    const error = new Error('Permission denied') as any
+    error.code = 'EACCES'
+    mockedAccess.mockRejectedValue(error)
+
+    try {
+      expect(await pathExists('/restricted/path')).toBe(false)
+    } finally {
+      mockedAccess.mockRestore()
+    }
+  })
+
+  it('returns false when access throws a non-Error value', async () => {
+    const mockedAccess = vi.mocked(access)
+    mockedAccess.mockRejectedValue('not an error object')
+
+    try {
+      expect(await pathExists('/any/path')).toBe(false)
+    } finally {
+      mockedAccess.mockRestore()
+    }
+  })
 })


### PR DESCRIPTION
This PR adds missing error path tests for the `pathExists` utility in `src/tools/helpers/paths.ts`. 

Key changes:
- Added test cases in `tests/helpers/paths.test.ts` to simulate `access()` failing with permission errors (`EACCES`) and throwing non-Error values.
- Refactored `src/tools/composite/tilemap.ts` to remove its local duplicate `pathExists` implementation and use the shared, now fully-tested helper from `src/tools/helpers/paths.ts`.
- Verified 100% coverage for the affected logic and ensured all existing tests pass.

---
*PR created automatically by Jules for task [340662148608698425](https://jules.google.com/task/340662148608698425) started by @n24q02m*