### PR TITLE
[PERF] Unnecessary Object.keys allocation

### DIFF
--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -422,17 +422,18 @@ export function updateNodeInScene(
   }
 
   const updatedProperties = new Set<string>()
-  const keys = Object.keys(updates)
 
   const newContent = transformSceneContent(content, nodeName, {
     processLine: (line, inTargetNode, isSectionHeader) => {
       if (inTargetNode && !isSectionHeader) {
         // Find if this line is one of our target properties
         const trimmed = line.trimStart()
-        for (const key of keys) {
-          if (trimmed.startsWith(`${key} `) || trimmed.startsWith(`${key}=`)) {
-            updatedProperties.add(key)
-            return `${key} = ${updates[key]}`
+        for (const key in updates) {
+          if (Object.hasOwn(updates, key)) {
+            if (trimmed.startsWith(`${key} `) || trimmed.startsWith(`${key}=`)) {
+              updatedProperties.add(key)
+              return `${key} = ${updates[key]}`
+            }
           }
         }
       }
@@ -440,9 +441,11 @@ export function updateNodeInScene(
     },
     onTargetNodeEnd: () => {
       const added: string[] = []
-      for (const key of keys) {
-        if (!updatedProperties.has(key)) {
-          added.push(`${key} = ${updates[key]}`)
+      for (const key in updates) {
+        if (Object.hasOwn(updates, key)) {
+          if (!updatedProperties.has(key)) {
+            added.push(`${key} = ${updates[key]}`)
+          }
         }
       }
       return added


### PR DESCRIPTION
This PR replaces `Object.keys(updates)` with `for...in` loops in the `updateNodeInScene` function within `src/tools/helpers/scene-parser.ts`. This change avoids unnecessary array allocations in memory during scene property updates, which is a common operation when processing Godot scene files line-by-line. `Object.hasOwn()` checks have been added to the loops for robustness and to comply with linting rules.

---
*PR created automatically by Jules for task [1334438753243769322](https://jules.google.com/task/1334438753243769322) started by @n24q02m*