### PR TITLE
[CLEANUP] Unnecessary RegExp Array Allocation in `match`

### DIFF
--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -10,7 +10,7 @@ import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '..
 import { toGodotValue } from '../helpers/godot-types.js'
 import { safeResolve } from '../helpers/paths.js'
 import { type ProjectSettings, parseProjectSettingsAsync, setSettingInContent } from '../helpers/project-settings.js'
-import { escapeRegExp } from '../helpers/scene-parser.js'
+import { updateNodeInScene } from '../helpers/scene-parser.js'
 import { validateNoNewlines } from '../helpers/security.js'
 
 export async function handlePhysics(action: string, args: Record<string, unknown>, config: GodotConfig) {
@@ -53,9 +53,6 @@ export async function handlePhysics(action: string, args: Record<string, unknown
 
       validateNoNewlines(undefined, scenePath, nodeName)
 
-      const collisionLayer = args.collision_layer
-      const collisionMask = args.collision_mask
-
       const fullPath = safeResolve(safeResolve(config.projectPath || process.cwd(), projectPath), scenePath)
 
       let content: string
@@ -67,30 +64,26 @@ export async function handlePhysics(action: string, args: Record<string, unknown
         }
         throw err
       }
-      const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-      const match = content.match(nodeRegex)
-      if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
 
-      if (match.index === undefined)
-        throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-      const insertPoint = match.index + match[0].length
-      let props = ''
-      if (collisionLayer !== undefined) {
-        const val = toGodotValue(collisionLayer)
+      const updates: Record<string, string> = {}
+      if (args.collision_layer !== undefined) {
+        const val = toGodotValue(args.collision_layer)
         validateNoNewlines('Invalid collision_layer: newlines not allowed', val)
-        props += `\ncollision_layer = ${val}`
+        updates.collision_layer = val
       }
-      if (collisionMask !== undefined) {
-        const val = toGodotValue(collisionMask)
+      if (args.collision_mask !== undefined) {
+        const val = toGodotValue(args.collision_mask)
         validateNoNewlines('Invalid collision_mask: newlines not allowed', val)
-        props += `\ncollision_mask = ${val}`
+        updates.collision_mask = val
       }
 
-      content = `${content.slice(0, insertPoint)}${props}${content.slice(insertPoint)}`
-      await writeFile(fullPath, content, 'utf-8')
+      const { content: updatedContent, updated } = updateNodeInScene(content, nodeName, updates)
+      if (!updated) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+
+      await writeFile(fullPath, updatedContent, 'utf-8')
 
       return formatSuccess(
-        `Set collision on ${nodeName}: layer=${collisionLayer ?? 'unchanged'}, mask=${collisionMask ?? 'unchanged'}`,
+        `Set collision on ${nodeName}: layer=${args.collision_layer ?? 'unchanged'}, mask=${args.collision_mask ?? 'unchanged'}`,
       )
     }
 
@@ -113,25 +106,21 @@ export async function handlePhysics(action: string, args: Record<string, unknown
         }
         throw err
       }
-      const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-      const match = content.match(nodeRegex)
-      if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
 
-      let props = ''
+      const updates: Record<string, string> = {}
       const physicsProps = ['gravity_scale', 'mass', 'linear_damp', 'angular_damp', 'freeze']
       for (const prop of physicsProps) {
         if (args[prop] !== undefined) {
           const val = toGodotValue(args[prop])
           validateNoNewlines(`Invalid ${prop}: newlines not allowed`, val)
-          props += `\n${prop} = ${val}`
+          updates[prop] = val
         }
       }
 
-      if (match.index === undefined)
-        throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-      const insertPoint = match.index + match[0].length
-      content = `${content.slice(0, insertPoint)}${props}${content.slice(insertPoint)}`
-      await writeFile(fullPath, content, 'utf-8')
+      const { content: updatedContent, updated } = updateNodeInScene(content, nodeName, updates)
+      if (!updated) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+
+      await writeFile(fullPath, updatedContent, 'utf-8')
 
       return formatSuccess(`Configured physics body: ${nodeName}`)
     }


### PR DESCRIPTION
This PR refactors the `collision_setup` and `body_config` actions in `src/tools/composite/physics.ts` to use the `updateNodeInScene` helper from `src/tools/helpers/scene-parser.ts`. 

The original implementation used `String.prototype.match` with a dynamic `RegExp` containing capturing groups, which allocated an array object on every call. By switching to `updateNodeInScene`, we not only reduce these allocations but also leverage a more robust, line-by-line transformation logic that handles property updates and additions correctly without risk of duplication.

Changes:
- Imported `updateNodeInScene` in `src/tools/composite/physics.ts`.
- Removed the now-unused `escapeRegExp` import.
- Refactored `collision_setup` to collect updates into a record and apply them via `updateNodeInScene`.
- Refactored `body_config` to collect physics properties into a record and apply them via `updateNodeInScene`.
- Removed manual string slicing and index calculations.

Verification:
- Ran `bun run test tests/composite/physics.test.ts` (All 11 passed).
- Ran full test suite `bun run test` (All 844 passed).
- Verified `bun run check` and `tsc --noEmit` pass.

---
*PR created automatically by Jules for task [11557748275214650163](https://jules.google.com/task/11557748275214650163) started by @n24q02m*