### PR TITLE
[CLEANUP] ReDoS via Unsafe Dynamic RegExp in Scripts node pattern

### DIFF
--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -8,9 +8,7 @@ import { dirname, join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
-import { escapeRegExp } from '../helpers/scene-parser.js'
-
-const NODE_SECTION_RE = /(\[node [^\]]+\])/
+import { updateNodeInScene } from '../helpers/scene-parser.js'
 
 const SCRIPT_TEMPLATES: Record<string, string> = {
   Node: `extends Node
@@ -209,19 +207,40 @@ async function attachScript(args: Record<string, unknown>, resolvePath: (path: s
   // ⚡ Bolt: Using replaceAll('\\', '/') avoids RegExp allocation overhead
   const resPath = `res://${scriptPath.replaceAll('\\', '/')}`
 
-  if (nodeName) {
-    const nodePattern = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-    const match = content.match(nodePattern)
-    if (!match)
-      throw new GodotMCPError(
-        `Node "${nodeName}" not found in scene`,
-        'NODE_ERROR',
-        'Check node name with nodes.list action.',
-      )
-    content = content.replace(nodePattern, (_match, p1) => `${p1}\nscript = ExtResource("${resPath}")`)
-  } else {
-    content = content.replace(NODE_SECTION_RE, (_match, p1) => `${p1}\nscript = ExtResource("${resPath}")`)
+  let targetNode = nodeName
+  if (!targetNode) {
+    // If no node name provided, find the first [node ...] section and extract its name
+    const nodeStart = content.indexOf('[node ')
+    if (nodeStart !== -1) {
+      const nameAttr = 'name="'
+      const nameIdx = content.indexOf(nameAttr, nodeStart)
+      const sectionEnd = content.indexOf(']', nodeStart)
+      if (nameIdx !== -1 && nameIdx < sectionEnd) {
+        const nameStart = nameIdx + nameAttr.length
+        const nameEnd = content.indexOf('"', nameStart)
+        if (nameEnd !== -1) {
+          targetNode = content.slice(nameStart, nameEnd)
+        }
+      }
+    }
   }
+
+  if (!targetNode) {
+    throw new GodotMCPError('No nodes found in scene', 'NODE_ERROR', 'Create a node first.')
+  }
+
+  const { content: updatedContent, updated } = updateNodeInScene(content, targetNode, {
+    script: `ExtResource("${resPath}")`,
+  })
+
+  if (!updated) {
+    throw new GodotMCPError(
+      `Node "${targetNode}" not found in scene`,
+      'NODE_ERROR',
+      'Check node name with nodes.list action.',
+    )
+  }
+  content = updatedContent
 
   await writeFile(sceneFullPath, content, 'utf-8')
   return formatSuccess(`Attached script ${scriptPath} to ${nodeName || 'root node'} in ${scenePath}`)

--- a/tests/composite/scripts.test.ts
+++ b/tests/composite/scripts.test.ts
@@ -288,6 +288,31 @@ describe('scripts', () => {
       const content = readFileSync(join(projectPath, 'level.tscn'), 'utf-8')
       expect(content).toContain('res://player.gd')
     })
+    it('should attach script to the first node if node_name is not provided', async () => {
+      const scene = `[gd_scene format=3]\n\n[node name="FirstNode" type="Node2D"]\n\n[node name="SecondNode" type="Node2D" parent="."]\n`
+      createTmpScene(projectPath, 'no_node.tscn', scene)
+      createTmpScript(projectPath, 'test.gd')
+
+      await handleScripts(
+        'attach',
+        {
+          project_path: projectPath,
+          scene_path: 'no_node.tscn',
+          script_path: 'test.gd',
+        },
+        config,
+      )
+
+      const updated = readFileSync(join(projectPath, 'no_node.tscn'), 'utf-8')
+      expect(updated).toContain('[node name="FirstNode"')
+      // Check that script is attached to FirstNode, not just present in file
+      const sections = updated.split('[node ')
+      const firstNodeSection = sections.find((s) => s.startsWith('name="FirstNode"'))
+      expect(firstNodeSection).toContain('script = ExtResource("res://test.gd")')
+
+      const secondNodeSection = sections.find((s) => s.startsWith('name="SecondNode"'))
+      expect(secondNodeSection).not.toContain('script = ExtResource("res://test.gd")')
+    })
 
     it('should throw if node_name not found in scene', async () => {
       createTmpScene(projectPath, 'test.tscn', MINIMAL_TSCN)


### PR DESCRIPTION
This PR addresses a ReDoS vulnerability in the script attachment tool by replacing a dynamic Regular Expression with a safer manual string scanning approach and utilizing the `updateNodeInScene` utility.

Key changes:
- Replaced the vulnerable dynamic RegExp in `src/tools/composite/scripts.ts`.
- Removed the unanchored `NODE_SECTION_RE`.
- Implemented a robust manual scanner to identify the target node (defaulting to the first node if `node_name` is not provided).
- Utilized `updateNodeInScene` for safe property modification, preventing property duplication.
- Added an integration test to ensure correct behavior when attaching a script without a specified node name.
- Verified that all existing security and integration tests pass.

---
*PR created automatically by Jules for task [961115895892655297](https://jules.google.com/task/961115895892655297) started by @n24q02m*