### PR TITLE
[TEST] Missing error path test for execGodotAsync

### DIFF
--- a/src/godot/headless.ts
+++ b/src/godot/headless.ts
@@ -68,11 +68,12 @@ export async function execGodotAsync(
       exitCode: 0,
     }
   } catch (err: unknown) {
+    const error = err && typeof err === 'object' ? (err as Record<string, unknown>) : null
     return {
       success: false,
-      stdout: (err as { stdout?: string }).stdout?.trim() || '',
-      stderr: (err as { stderr?: string }).stderr?.trim() || (err as Error).message || 'Unknown error',
-      exitCode: (err as { code?: number }).code ?? 1,
+      stdout: (error?.stdout as string | undefined)?.trim() || '',
+      stderr: (error?.stderr as string | undefined)?.trim() || (err as Error)?.message || 'Unknown error',
+      exitCode: (error?.code as number | undefined) ?? 1,
     }
   }
 }

--- a/tests/godot/headless.test.ts
+++ b/tests/godot/headless.test.ts
@@ -447,5 +447,21 @@ describe('headless', () => {
       expect(result.success).toBe(false)
       expect(result.exitCode).toBe(1)
     })
+    it('should handle null catch value', async () => {
+      execFileAsyncMock.mockRejectedValue(null)
+
+      const result = await execGodotAsync('/usr/bin/godot', ['--version'])
+      expect(result.success).toBe(false)
+      expect(result.stderr).toBe('Unknown error')
+      expect(result.exitCode).toBe(1)
+    })
+    it('should handle undefined catch value', async () => {
+      execFileAsyncMock.mockRejectedValue(undefined)
+
+      const result = await execGodotAsync('/usr/bin/godot', ['--version'])
+      expect(result.success).toBe(false)
+      expect(result.stderr).toBe('Unknown error')
+      expect(result.exitCode).toBe(1)
+    })
   })
 })


### PR DESCRIPTION
This PR adds missing error path tests for execGodotAsync in src/godot/headless.ts. It also improves the robustness of the error handling logic to prevent crashes when a non-object or null value is caught, ensuring 100% test coverage and better reliability.

---
*PR created automatically by Jules for task [5778242962066562342](https://jules.google.com/task/5778242962066562342) started by @n24q02m*