### PR TITLE
[FIX] Refactor prefix match

### DIFF
--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -87,34 +87,49 @@ export function findClosestMatch(input: string, validOptions: string[]): string 
   const safeInput = input.length > 100 ? input.slice(0, 100) : input
   const lower = safeInput.toLowerCase()
 
-  // 1. Priority: Exact match (case-insensitive)
-  for (const option of validOptions) {
-    if (option.toLowerCase() === lower) {
-      return option
-    }
-  }
-
-  // 2. Priority: Prefix/containment match
-  // We want the one with the smallest absolute length difference
+  // Pass 1: Exact, Prefix, and Containment matches
+  // Priority hierarchy:
+  // 1. Exact match (case-insensitive)
+  // 2. Best prefix match (one starts with the other, closest in length)
+  // 3. Best containment match (one contains the other, closest in length)
   let bestPrefixMatch: string | null = null
-  let minLenDiff = Number.POSITIVE_INFINITY
+  let minPrefixLenDiff = Number.POSITIVE_INFINITY
+
+  let bestContainmentMatch: string | null = null
+  let minContainmentLenDiff = Number.POSITIVE_INFINITY
 
   for (const option of validOptions) {
     const optionLower = option.toLowerCase()
+
+    // 1. Exact match (returns immediately)
+    if (optionLower === lower) {
+      return option
+    }
+
+    const lenDiff = Math.abs(optionLower.length - lower.length)
+
+    // 2. Prefix match
     if (optionLower.startsWith(lower) || lower.startsWith(optionLower)) {
-      const lenDiff = Math.abs(optionLower.length - lower.length)
-      if (lenDiff < minLenDiff) {
-        minLenDiff = lenDiff
+      if (lenDiff < minPrefixLenDiff) {
+        minPrefixLenDiff = lenDiff
         bestPrefixMatch = option
+      }
+      continue
+    }
+
+    // 3. Containment match (substring)
+    if (optionLower.includes(lower) || lower.includes(optionLower)) {
+      if (lenDiff < minContainmentLenDiff) {
+        minContainmentLenDiff = lenDiff
+        bestContainmentMatch = option
       }
     }
   }
 
-  if (bestPrefixMatch !== null) {
-    return bestPrefixMatch
-  }
+  if (bestPrefixMatch !== null) return bestPrefixMatch
+  if (bestContainmentMatch !== null) return bestContainmentMatch
 
-  // 3. Fallback: Fuzzy matching using bigram similarity
+  // Fallback: Fuzzy matching using bigram similarity (Dice coefficient)
   let bestFuzzyMatch: string | null = null
   let bestScore = 0
 

--- a/tests/helpers/errors.test.ts
+++ b/tests/helpers/errors.test.ts
@@ -190,6 +190,20 @@ describe('errors', () => {
     it('should return the closest prefix match by length', () => {
       expect(findClosestMatch('cre', ['create_node', 'create'])).toBe('create')
     })
+
+    it('should prefer prefix match over containment match', () => {
+      // 'create' is a prefix of 'create_node'
+      // 'create' is contained in 'recreate_node' (but not a prefix)
+      expect(findClosestMatch('create', ['recreate_node', 'create_node'])).toBe('create_node')
+    })
+
+    it('should return containment match if no prefix match exists', () => {
+      expect(findClosestMatch('node', ['create_node', 'delete_node'])).toBe('create_node')
+    })
+
+    it('should return the closest containment match by length', () => {
+      expect(findClosestMatch('node', ['create_new_node', 'create_node'])).toBe('create_node')
+    })
   })
 
   // ==========================================


### PR DESCRIPTION
Refactored the findClosestMatch utility in src/tools/helpers/errors.ts to be more efficient and accurate. The new implementation uses a single-pass loop for high-priority matches (Exact, Prefix, Containment) and fallbacks to fuzzy bigram matching only when necessary. It also implements proper substring containment matching which was previously only described in comments but not fully implemented.

Key improvements:
- Consolidated loops to reduce iterations and redundant toLowerCase() calls.
- Added explicit containment matching via .includes().
- Established clear priority: Exact > Prefix > Containment > Fuzzy.
- Added new test cases to verify priorities and substring matches.

---
*PR created automatically by Jules for task [7880994837826764440](https://jules.google.com/task/7880994837826764440) started by @n24q02m*