### PR TITLE
fix: correct documentation drift (security email, dead links, commit-type list, tool count)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ tests/
 
 ### Commits
 
-Conventional Commits: `type(scope): message` (e.g., `feat:`, `fix:`, `docs:`, `chore:`)
+Conventional Commits: `type(scope): message`. Only `feat:` and `fix:` are accepted (enforced by the commit-message hook).
 
 ### Pre-commit Hooks
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -43,7 +43,7 @@ an individual is officially representing the community in public spaces.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-**n24q02m@gmail.com**.
+**quangminh2402.dev@gmail.com**.
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,23 +72,16 @@ We use [Conventional Commits](https://www.conventionalcommits.org/):
 
 ### Types
 
+Only `feat` and `fix` are accepted (enforced by the commit-message hook):
+
 - `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation changes
-- `style`: Code style changes
-- `refactor`: Code refactoring
-- `perf`: Performance improvements
-- `test`: Adding or updating tests
-- `chore`: Maintenance tasks
-- `ci`: CI/CD changes
-- `build`: Build system changes
+- `fix`: Bug fix (also used for docs, tests, chores, and other maintenance changes)
 
 ### Examples
 
 ```text
 feat: add new tool action for shader compilation
 fix: correct scene parser regex for nested resources
-docs: update README examples
 ```
 
 ## Release Process

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ mcp-name: io.github.n24q02m/better-godot-mcp
 
 ## Documentation
 
-Full docs at **[mcp.n24q02m.com/servers/better-godot-mcp/](https://mcp.n24q02m.com/servers/better-godot-mcp/)**:
+Full docs at **[mcp.n24q02m.com/servers/better-godot-mcp/setup/](https://mcp.n24q02m.com/servers/better-godot-mcp/setup/)**:
 
 - [Setup](https://mcp.n24q02m.com/servers/better-godot-mcp/setup/) -- install methods for Claude Code, Codex, Gemini CLI, Cursor, Windsurf, mcp.json
 - [Modes overview](https://mcp.n24q02m.com/get-started/modes-overview/) -- stdio / local-relay / remote-relay / remote-oauth
@@ -155,7 +155,7 @@ bun run dev
 
 ## Trust Model
 
-This plugin implements **TC-Local** (no auth required -- no credentials stored). See [mcp-core/docs/TRUST-MODEL.md](https://github.com/n24q02m/mcp-core/blob/main/docs/TRUST-MODEL.md) for full classification.
+This plugin implements **TC-Local** (no auth required -- no credentials stored). See [the trust model reference](https://mcp.n24q02m.com/servers/mcp-core/trust-model/) for full classification.
 
 | Mode | Storage | Encryption | Who can read your data? |
 |---|---|---|---|

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@
 If you discover a security vulnerability, please report it responsibly:
 
 1. **Do NOT** open a public issue
-2. Email **n24q02m@gmail.com** with details
+2. Email **quangminh2402.dev@gmail.com** with details
 3. Include steps to reproduce if possible
 4. Allow reasonable time for a fix before disclosure
 

--- a/src/init-server.ts
+++ b/src/init-server.ts
@@ -2,7 +2,7 @@
  * Better Godot MCP Server - Initialization
  *
  * Enhanced MCP server for Godot Engine with:
- * - Composite mega-tools (8 tools, ~20 actions)
+ * - Composite mega-tools (17 tools, ~70 actions)
  * - Cross-platform Godot binary detection
  * - CLI headless operations
  * - EditorPlugin TCP support (Phase 2)


### PR DESCRIPTION
## Documentation drift audit fixes

Part of the multi-repo docs audit. All findings verified against actual code/live URLs before editing.

### Findings

1. **Security-contact email inconsistency** -- `SECURITY.md` and `CODE_OF_CONDUCT.md` used `n24q02m@gmail.com`; aligned to the canonical `quangminh2402.dev@gmail.com` already used by sibling repos (mcp-core, better-notion, wet, telegram, etc.). No new personal email introduced.
2. **Dead links** (curl-verified):
   - `https://github.com/n24q02m/mcp-core/blob/main/docs/TRUST-MODEL.md` -> 404. Repointed to `https://mcp.n24q02m.com/servers/mcp-core/trust-model/` (200), matching the canonical form in better-notion-mcp.
   - `https://mcp.n24q02m.com/servers/better-godot-mcp/` bare server-root -> 404 (404s for all servers). Repointed the "Full docs at" link to the working `/setup/` leaf (200). Other `/setup/`, `/get-started/modes-overview/`, `/get-started/multi-user/` leaves confirmed 200 and left as-is.
3. **Tool count** -- registry registers exactly **17 tools** (P0:7 + P1:3 + P2:4 + P3:3). README, CLAUDE.md, AGENTS.md, and the Tools table already correct (17). Fixed a stale `init-server.ts` doc-comment that still said "8 tools, ~20 actions" -> "17 tools, ~70 actions". No `config__open_relay` exists or is claimed (godot is stdio-local, no relay) -- correct as-is.
4. **Commit-type list** -- `CONTRIBUTING.md` and `AGENTS.md` listed 9 conventional types (docs/chore/refactor/etc.), contradicting the repo's enforced `feat`/`fix`-only policy (`scripts/enforce-commit.sh` commit-msg hook). Aligned both to feat/fix-only.
5. **Transport/Docker docs** -- verified accurate, no fix needed: Dockerfile ships `stdio` + `http` multi-targets; code supports `--http` / `MCP_TRANSPORT=http` / `TRANSPORT_MODE=http`. No doc claims stdio-only or no-Docker.

### Verification
- `bun run check` (biome) clean; `tsc --noEmit` clean.
- All replacement URLs curl-verified 200.
- Surgical diff, no drive-by refactors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)