### PR TITLE
fix: add Comparison section to README capability matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ mcp-name: io.github.n24q02m/better-godot-mcp
 - [Status](#status)
 - [Documentation](#documentation)
 - [Tools](#tools)
+- [Comparison](#comparison)
 - [Configuration](#configuration)
 - [Security](#security)
 - [Build from Source](#build-from-source)
@@ -121,6 +122,31 @@ Full docs at **[mcp.n24q02m.com/servers/better-godot-mcp/setup/](https://mcp.n24
 | `navigation` | `create_region`, `add_agent`, `add_obstacle` | Navigation regions, agents, and obstacles |
 | `ui` | `create_control`, `set_theme`, `layout`, `list_controls` | UI control creation and theming |
 | `help` | - | Get full documentation for any tool |
+
+## Comparison
+
+How better-godot-mcp stacks up against direct competitors in each pillar:
+
+| Capability | better-godot-mcp | Coding-Solo/godot-mcp | bradypp/godot-mcp | tugcantopaloglu/godot-mcp |
+|---|---|---|---|---|
+| Scene file management | Yes (`scenes`: create/list/info/delete/duplicate/set_main) | Yes (create/save) | Yes (create/save) | Yes (create/read/modify) |
+| Node tree manipulation | Yes (`nodes`: add/remove/rename/list/get+set_property) | Partial (add only) | Yes (add/edit/remove) | Yes (add/remove/reparent) |
+| GDScript file CRUD | Yes (`scripts`: create/read/write/attach/list/delete) | No | No | Partial (create from template + runtime eval) |
+| Shader file CRUD | Yes (`shader`: create/read/write/get_params/list) | No | No | Partial (create/read .gdshader) |
+| Animation authoring | Yes (`animation`: player/track/keyframe) | No | No | Yes (player/tween/state machine) |
+| TileMap / TileSet | Yes (`tilemap`: tileset/source/set_tile/paint) | No | No | Yes (TileMapLayer cells) |
+| Physics layers / bodies | Yes (`physics`: layers/collision/body_config) | No | No | Yes (collision/joints/raycast) |
+| Audio bus management | Yes (`audio`: buses/effects/streams) | No | No | Yes (buses/routing/effects) |
+| Navigation setup | Yes (`navigation`: region/agent/obstacle) | No | No | Yes (navigation) |
+| UI control authoring | Yes (`ui`: control/theme/layout) | No | Partial (via add node) | Yes (controls/themes/menus) |
+| Input map editing | Yes (`input_map`: action/event) | No | No | Yes (actions/key bindings) |
+| Signal connections | Yes (`signals`: connect/disconnect/list) | No | No | Yes (connect/emit/await) |
+| Launch editor / run project | Yes (`editor`, `project` run/stop) | Yes | Yes | Yes |
+| Works without running editor | Yes (text-based `.tscn` parsing) | Yes (headless GDScript bridge) | Yes (headless GDScript bridge) | Partial (CLI headless or live TCP socket) |
+| No credentials stored (TC-Local) | Yes | Yes | Yes | Yes |
+| stdio + HTTP transports | Yes (stdio default + `--http`) | No (stdio only) | No (stdio only) | No (stdio only) |
+| Docker image (amd64 + arm64) | Yes | No | No | No |
+| Token-tiered tool descriptions | Yes (compact + on-demand `help`) | No | No | No |
 
 ## Configuration
 


### PR DESCRIPTION
## What

Adds a `## Comparison` section to the README, matching the Tier-1 house style already used in [wet-mcp](https://github.com/n24q02m/wet-mcp) and [mnemo-mcp](https://github.com/n24q02m/mnemo-mcp): a capability matrix versus **named, real** competitor Godot MCP servers.

- Placed immediately after `## Tools` (mirrors wet-mcp adjacency: Tools -> Comparison -> ...), before `## Configuration`.
- Added to the table of contents.

## How cells were derived

- **Our column** (`better-godot-mcp`): derived strictly from `src/tools/registry.ts` (17 mega-tools) and the README — accurate, not aspirational.
- **Competitor columns**: only marked when verifiable from each repo's public docs. Where a repo offers a partial/template-only version of a pillar, the cell says `Partial` with the qualifier.

## Competitors verified (all real GitHub repos)

| Competitor | Repo | Notes |
|---|---|---|
| Coding-Solo/godot-mcp | https://github.com/Coding-Solo/godot-mcp | Most popular original; ~13 tools (TS + GDScript bridge). Scenes/nodes/sprites/run/launch only; no GDScript-CRUD, shader, anim, tilemap, physics, audio, nav, UI-author, input, signals. |
| bradypp/godot-mcp | https://github.com/bradypp/godot-mcp | 17 tools (TS); fork-family of Coding-Solo. Scenes + node edit + sprites; explicitly does NOT manage GDScript/shaders/anim/tilemap/physics/audio/nav/UI/input/signals. |
| tugcantopaloglu/godot-mcp | https://github.com/tugcantopaloglu/godot-mcp | 149 tools (TS); extends Coding-Solo. Broadest coverage: scenes/nodes/scripts(template+eval)/shader/anim/tilemap/physics/audio/UI/input/signals. Uses CLI headless + live TCP socket (autoload port 9090). |

Other real repos found but not included (kept to 3 to avoid a sprawling matrix; available if reviewer prefers a swap): hi-godot/godot-ai, DaRealDaHoodie/Claude-GoDot-MCP, LeeSinLiang/godot-mcp, ee0pdt/Godot-MCP, Dokujaa/Godot-MCP.

## Source URLs (competitor evidence)

- https://github.com/Coding-Solo/godot-mcp
- https://github.com/bradypp/godot-mcp
- https://github.com/tugcantopaloglu/godot-mcp

## Verification

- `bun run check` -> pass (biome + tsc; only pre-existing schema-version INFO note, unrelated).
- README-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)