### PR TITLE
[CLEANUP] ReDoS via Unsafe Dynamic RegExp in Physics collision setup

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -10,7 +10,7 @@ import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '..
 import { toGodotValue } from '../helpers/godot-types.js'
 import { safeResolve } from '../helpers/paths.js'
 import { type ProjectSettings, parseProjectSettingsAsync, setSettingInContent } from '../helpers/project-settings.js'
-import { escapeRegExp } from '../helpers/scene-parser.js'
+import { updateNodeInScene } from '../helpers/scene-parser.js'
 import { validateNoNewlines } from '../helpers/security.js'
 
 export async function handlePhysics(action: string, args: Record<string, unknown>, config: GodotConfig) {
@@ -67,27 +67,25 @@ export async function handlePhysics(action: string, args: Record<string, unknown
         }
         throw err
       }
-      const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-      const match = content.match(nodeRegex)
-      if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
 
-      if (match.index === undefined)
-        throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-      const insertPoint = match.index + match[0].length
-      let props = ''
+      const updates: Record<string, string> = {}
       if (collisionLayer !== undefined) {
         const val = toGodotValue(collisionLayer)
         validateNoNewlines('Invalid collision_layer: newlines not allowed', val)
-        props += `\ncollision_layer = ${val}`
+        updates.collision_layer = val
       }
       if (collisionMask !== undefined) {
         const val = toGodotValue(collisionMask)
         validateNoNewlines('Invalid collision_mask: newlines not allowed', val)
-        props += `\ncollision_mask = ${val}`
+        updates.collision_mask = val
       }
 
-      content = `${content.slice(0, insertPoint)}${props}${content.slice(insertPoint)}`
-      await writeFile(fullPath, content, 'utf-8')
+      const { content: updatedContent, updated } = updateNodeInScene(content, nodeName, updates)
+      if (!updated) {
+        throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+      }
+
+      await writeFile(fullPath, updatedContent, 'utf-8')
 
       return formatSuccess(
         `Set collision on ${nodeName}: layer=${collisionLayer ?? 'unchanged'}, mask=${collisionMask ?? 'unchanged'}`,
@@ -113,25 +111,23 @@ export async function handlePhysics(action: string, args: Record<string, unknown
         }
         throw err
       }
-      const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-      const match = content.match(nodeRegex)
-      if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
 
-      let props = ''
+      const updates: Record<string, string> = {}
       const physicsProps = ['gravity_scale', 'mass', 'linear_damp', 'angular_damp', 'freeze']
       for (const prop of physicsProps) {
         if (args[prop] !== undefined) {
           const val = toGodotValue(args[prop])
           validateNoNewlines(`Invalid ${prop}: newlines not allowed`, val)
-          props += `\n${prop} = ${val}`
+          updates[prop] = val
         }
       }
 
-      if (match.index === undefined)
+      const { content: updatedContent, updated } = updateNodeInScene(content, nodeName, updates)
+      if (!updated) {
         throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-      const insertPoint = match.index + match[0].length
-      content = `${content.slice(0, insertPoint)}${props}${content.slice(insertPoint)}`
-      await writeFile(fullPath, content, 'utf-8')
+      }
+
+      await writeFile(fullPath, updatedContent, 'utf-8')
 
       return formatSuccess(`Configured physics body: ${nodeName}`)
     }

--- a/tests/security/redos_physics.test.ts
+++ b/tests/security/redos_physics.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { handlePhysics } from '../../src/tools/composite/physics.js'
+import { createTmpProject, createTmpScene, makeConfig } from '../fixtures.js'
+import type { GodotConfig } from '../../src/godot/types.js'
+
+describe('Physics ReDoS Security', () => {
+  let projectPath: string
+  let cleanup: () => void
+  let config: GodotConfig
+
+  beforeEach(() => {
+    const tmp = createTmpProject()
+    projectPath = tmp.projectPath
+    cleanup = tmp.cleanup
+    config = makeConfig({ projectPath })
+  })
+
+  afterEach(() => cleanup())
+
+  it('should not be vulnerable to ReDoS in collision_setup via node name', async () => {
+    // This node name is crafted to be slow on vulnerable regex: [node name="..."][^]*]
+    // Although the specific vulnerability was name specific, we test long input.
+    const longNodeName = 'A' + 'B'.repeat(50000) + 'C'
+    const sceneContent = '[gd_scene format=3]\n\n[node name="Root" type="Node"]\n'
+    createTmpScene(projectPath, 'test.tscn', sceneContent)
+
+    const startTime = Date.now()
+    await expect(
+      handlePhysics(
+        'collision_setup',
+        {
+          project_path: projectPath,
+          scene_path: 'test.tscn',
+          name: longNodeName,
+          collision_layer: 1
+        },
+        config,
+      )
+    ).rejects.toThrow(/Node ".*" not found/)
+    const duration = Date.now() - startTime
+
+    // If it's slow, it's a sign of ReDoS. Usually ReDoS takes seconds or minutes.
+    // 1 second is very generous for a simple string search.
+    expect(duration).toBeLessThan(1000)
+  })
+
+  it('should not be vulnerable to ReDoS in body_config via node name', async () => {
+    const longNodeName = 'A' + 'B'.repeat(50000) + 'C'
+    const sceneContent = '[gd_scene format=3]\n\n[node name="Root" type="Node"]\n'
+    createTmpScene(projectPath, 'test.tscn', sceneContent)
+
+    const startTime = Date.now()
+    await expect(
+      handlePhysics(
+        'body_config',
+        {
+          project_path: projectPath,
+          scene_path: 'test.tscn',
+          name: longNodeName,
+          gravity_scale: 1.0
+        },
+        config,
+      )
+    ).rejects.toThrow(/Node ".*" not found/)
+    const duration = Date.now() - startTime
+
+    expect(duration).toBeLessThan(1000)
+  })
+})

--- a/tests/security/redos_physics.test.ts
+++ b/tests/security/redos_physics.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { GodotConfig } from '../../src/godot/types.js'
 import { handlePhysics } from '../../src/tools/composite/physics.js'
 import { createTmpProject, createTmpScene, makeConfig } from '../fixtures.js'
-import type { GodotConfig } from '../../src/godot/types.js'
 
 describe('Physics ReDoS Security', () => {
   let projectPath: string
@@ -20,7 +20,7 @@ describe('Physics ReDoS Security', () => {
   it('should not be vulnerable to ReDoS in collision_setup via node name', async () => {
     // This node name is crafted to be slow on vulnerable regex: [node name="..."][^]*]
     // Although the specific vulnerability was name specific, we test long input.
-    const longNodeName = 'A' + 'B'.repeat(50000) + 'C'
+    const longNodeName = `A${'B'.repeat(50000)}C`
     const sceneContent = '[gd_scene format=3]\n\n[node name="Root" type="Node"]\n'
     createTmpScene(projectPath, 'test.tscn', sceneContent)
 
@@ -32,10 +32,10 @@ describe('Physics ReDoS Security', () => {
           project_path: projectPath,
           scene_path: 'test.tscn',
           name: longNodeName,
-          collision_layer: 1
+          collision_layer: 1,
         },
         config,
-      )
+      ),
     ).rejects.toThrow(/Node ".*" not found/)
     const duration = Date.now() - startTime
 
@@ -45,7 +45,7 @@ describe('Physics ReDoS Security', () => {
   })
 
   it('should not be vulnerable to ReDoS in body_config via node name', async () => {
-    const longNodeName = 'A' + 'B'.repeat(50000) + 'C'
+    const longNodeName = `A${'B'.repeat(50000)}C`
     const sceneContent = '[gd_scene format=3]\n\n[node name="Root" type="Node"]\n'
     createTmpScene(projectPath, 'test.tscn', sceneContent)
 
@@ -57,10 +57,10 @@ describe('Physics ReDoS Security', () => {
           project_path: projectPath,
           scene_path: 'test.tscn',
           name: longNodeName,
-          gravity_scale: 1.0
+          gravity_scale: 1.0,
         },
         config,
-      )
+      ),
     ).rejects.toThrow(/Node ".*" not found/)
     const duration = Date.now() - startTime
 


### PR DESCRIPTION
This PR fixes a ReDoS vulnerability in `src/tools/composite/physics.ts` by replacing dynamic Regular Expressions with the `updateNodeInScene` helper. This also improves the robustness of property updates by preventing duplication.

Summary of changes:
- Refactored `collision_setup` and `body_config` to use `updateNodeInScene`.
- Added `tests/security/redos_physics.test.ts` to test for ReDoS resilience.
- Verified that all existing physics and security tests pass.

---
*PR created automatically by Jules for task [10496423477983324340](https://jules.google.com/task/10496423477983324340) started by @n24q02m*