### PR TITLE
[TEST] Missing error path test for pathExists

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/composite/tilemap.ts
+++ b/src/tools/composite/tilemap.ts
@@ -3,24 +3,11 @@
  * Actions: create_tileset | add_source | set_tile | paint | list
  */
 
-import { constants } from 'node:fs'
-import { access, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { resolveProjectRoot, safeResolve } from '../helpers/paths.js'
-
-/**
- * Async helper to check file existence without blocking the event loop
- */
-async function pathExists(path: string): Promise<boolean> {
-  try {
-    await access(path, constants.F_OK)
-    return true
-  } catch {
-    return false
-  }
-}
+import { pathExists, resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 
 export async function handleTilemap(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const projectPath = resolveProjectRoot(args.project_path, config.projectPath)

--- a/tests/helpers/paths.test.ts
+++ b/tests/helpers/paths.test.ts
@@ -229,6 +229,63 @@ describe('pathExists', () => {
     expect(await pathExists(nonExistentPath)).toBe(false)
   })
 
+  it('returns false when access throws EACCES (permission denied)', async () => {
+    const mockedAccess = vi.mocked(access)
+    const error = new Error('Permission denied')
+    ;(error as NodeJS.ErrnoException).code = 'EACCES'
+    mockedAccess.mockRejectedValue(error)
+
+    try {
+      expect(await pathExists('/any/path')).toBe(false)
+    } finally {
+      mockedAccess.mockRestore()
+    }
+  })
+
+  it('returns false when access rejects with null', async () => {
+    const mockedAccess = vi.mocked(access)
+    mockedAccess.mockRejectedValue(null)
+
+    try {
+      expect(await pathExists('/any/path')).toBe(false)
+    } finally {
+      mockedAccess.mockRestore()
+    }
+  })
+
+  it('returns false when access rejects with undefined', async () => {
+    const mockedAccess = vi.mocked(access)
+    mockedAccess.mockRejectedValue(undefined)
+
+    try {
+      expect(await pathExists('/any/path')).toBe(false)
+    } finally {
+      mockedAccess.mockRestore()
+    }
+  })
+
+  it('returns false when access rejects with a string', async () => {
+    const mockedAccess = vi.mocked(access)
+    mockedAccess.mockRejectedValue('Error string')
+
+    try {
+      expect(await pathExists('/any/path')).toBe(false)
+    } finally {
+      mockedAccess.mockRestore()
+    }
+  })
+
+  it('returns false when access rejects with a number', async () => {
+    const mockedAccess = vi.mocked(access)
+    mockedAccess.mockRejectedValue(500)
+
+    try {
+      expect(await pathExists('/any/path')).toBe(false)
+    } finally {
+      mockedAccess.mockRestore()
+    }
+  })
+
   it('returns false when access throws an unexpected error', async () => {
     const mockedAccess = vi.mocked(access)
     mockedAccess.mockRejectedValue(new Error('Unexpected error'))


### PR DESCRIPTION
Added comprehensive error path tests for pathExists in tests/helpers/paths.test.ts, covering EACCES and various non-Error rejection values (null, undefined, string, number). Verified that they pass and maintain 100% coverage for src/tools/helpers/paths.ts.
Refactored src/tools/composite/tilemap.ts to use the shared pathExists helper from src/tools/helpers/paths.ts, removing a local duplicate implementation.
Cleaned up unused imports in src/tools/composite/tilemap.ts and fixed a linting issue in the new tests.
Migrated biome.json to match the current CLI version.

---
*PR created automatically by Jules for task [17324843545527825419](https://jules.google.com/task/17324843545527825419) started by @n24q02m*