### PR TITLE
[PERF] Use pre-allocated counting instead of match().length

### DIFF
--- a/src/tools/composite/audio.ts
+++ b/src/tools/composite/audio.ts
@@ -6,6 +6,7 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
+import { countMatches } from '../helpers/strings.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 
@@ -85,7 +86,7 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       }
 
       // Count existing buses
-      const busCount = (content.match(/bus\/\d+\/name/g) || []).length
+      const busCount = countMatches(content, /bus\/\d+\/name/g)
 
       const newBus = [
         `bus/${busCount}/name = "${busName}"`,

--- a/src/tools/composite/tilemap.ts
+++ b/src/tools/composite/tilemap.ts
@@ -6,6 +6,7 @@
 import { constants } from 'node:fs'
 import { access, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
+import { countMatches } from '../helpers/strings.js'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { resolveProjectRoot, safeResolve } from '../helpers/paths.js'
@@ -87,7 +88,7 @@ export async function handleTilemap(action: string, args: Record<string, unknown
       const resPath = `res://${texturePath.replaceAll('\\', '/')}`
 
       // Count existing sources to get next ID
-      const sourceCount = (content.match(/\[ext_resource/g) || []).length
+      const sourceCount = countMatches(content, /\[ext_resource/g)
       const sourceId = `source_${sourceCount}`
 
       // Add ext_resource reference

--- a/src/tools/helpers/strings.ts
+++ b/src/tools/helpers/strings.ts
@@ -33,3 +33,38 @@ export function parseCommaSeparatedList(str: string): string[] {
 
   return result
 }
+
+/**
+ * Efficiently counts occurrences of a substring or global RegExp in a string.
+ * Uses matchAll for RegExp to avoid intermediate array allocations,
+ * and a simple indexOf loop for strings.
+ */
+export function countMatches(str: string, search: string | RegExp): number {
+  if (!str) return 0
+  if (typeof search === 'string') {
+    if (search.length === 0) return 0
+    let count = 0
+    let pos = str.indexOf(search)
+    while (pos !== -1) {
+      count++
+      pos = str.indexOf(search, pos + search.length)
+    }
+    return count
+  }
+
+  if (!search.global) {
+    // Re-create the RegExp with global flag if missing
+    const globalSearch = new RegExp(search.source, search.flags + 'g')
+    let count = 0
+    for (const _ of str.matchAll(globalSearch)) {
+      count++
+    }
+    return count
+  }
+
+  let count = 0
+  for (const _ of str.matchAll(search)) {
+    count++
+  }
+  return count
+}

--- a/tests/helpers/strings.test.ts
+++ b/tests/helpers/strings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseCommaSeparatedList } from '../../src/tools/helpers/strings.js'
+import { parseCommaSeparatedList, countMatches } from '../../src/tools/helpers/strings.js'
 
 describe('strings helpers', () => {
   describe('parseCommaSeparatedList', () => {
@@ -33,6 +33,40 @@ describe('strings helpers', () => {
 
     it('should handle items with inner spaces', () => {
       expect(parseCommaSeparatedList('word1 word2, word3 word4')).toEqual(['word1 word2', 'word3 word4'])
+    })
+  })
+
+  describe('countMatches', () => {
+    it('should count occurrences of a simple string', () => {
+      expect(countMatches('apple apple orange', 'apple')).toBe(2)
+      expect(countMatches('apple apple orange', 'orange')).toBe(1)
+      expect(countMatches('apple apple orange', 'banana')).toBe(0)
+    })
+
+    it('should count occurrences of a global RegExp', () => {
+      expect(countMatches('apple apple orange', /apple/g)).toBe(2)
+      expect(countMatches('apple apple orange', /orange/g)).toBe(1)
+      expect(countMatches('apple apple orange', /banana/g)).toBe(0)
+    })
+
+    it('should count occurrences of a non-global RegExp', () => {
+      expect(countMatches('apple apple orange', /apple/)).toBe(2)
+      expect(countMatches('apple apple orange', /orange/)).toBe(1)
+    })
+
+    it('should handle empty strings', () => {
+      expect(countMatches('', 'apple')).toBe(0)
+      expect(countMatches('apple', '')).toBe(0)
+    })
+
+    it('should handle complex regex patterns', () => {
+      const content = 'bus/0/name = "Master"\nbus/1/name = "Music"\nbus/2/name = "SFX"'
+      expect(countMatches(content, /bus\/\d+\/name/g)).toBe(3)
+    })
+
+    it('should handle overlapping matches if implemented as such (current is non-overlapping)', () => {
+      // "aaaa" with "aa" should be 2 matches (index 0 and 2)
+      expect(countMatches('aaaa', 'aa')).toBe(2)
     })
   })
 })


### PR DESCRIPTION
This PR introduces a performance optimization by replacing the inefficient `(match() || []).length` pattern with a dedicated `countMatches` utility.

### Changes:
- **`src/tools/helpers/strings.ts`**: Implemented `countMatches(str, search)` which uses an efficient `indexOf` loop for string searches and `matchAll` iterators for `RegExp` searches. This avoids the `O(N)` allocation of match arrays.
- **`src/tools/composite/tilemap.ts`**: Updated to use `countMatches` for counting `[ext_resource]` entries.
- **`src/tools/composite/audio.ts`**: Updated to use `countMatches` for counting `bus/N/name` entries.
- **`tests/helpers/strings.test.ts`**: Added unit tests covering string, `RegExp` (global and non-global), empty cases, and overlapping patterns.

### Rationale:
Using `match().length` creates an intermediate array containing all matches, which is then immediately discarded. For large Godot resource files (like complex TileMaps or Audio Layouts), this can lead to significant memory pressure and unnecessary GC cycles. `countMatches` provides a constant-memory alternative for counting.

---
*PR created automatically by Jules for task [6923786918202325771](https://jules.google.com/task/6923786918202325771) started by @n24q02m*