### PR TITLE
[CLEANUP] Unnecessary RegExp Array Allocation in \`match\`

### DIFF
--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -10,7 +10,7 @@ import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '..
 import { toGodotValue } from '../helpers/godot-types.js'
 import { safeResolve } from '../helpers/paths.js'
 import { type ProjectSettings, parseProjectSettingsAsync, setSettingInContent } from '../helpers/project-settings.js'
-import { escapeRegExp } from '../helpers/scene-parser.js'
+import { updateNodeInScene } from '../helpers/scene-parser.js'
 import { validateNoNewlines } from '../helpers/security.js'
 
 export async function handlePhysics(action: string, args: Record<string, unknown>, config: GodotConfig) {
@@ -67,26 +67,23 @@ export async function handlePhysics(action: string, args: Record<string, unknown
         }
         throw err
       }
-      const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-      const match = content.match(nodeRegex)
-      if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
 
-      if (match.index === undefined)
-        throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-      const insertPoint = match.index + match[0].length
-      let props = ''
+      const updates: Record<string, string> = {}
       if (collisionLayer !== undefined) {
         const val = toGodotValue(collisionLayer)
         validateNoNewlines('Invalid collision_layer: newlines not allowed', val)
-        props += `\ncollision_layer = ${val}`
+        updates.collision_layer = val
       }
       if (collisionMask !== undefined) {
         const val = toGodotValue(collisionMask)
         validateNoNewlines('Invalid collision_mask: newlines not allowed', val)
-        props += `\ncollision_mask = ${val}`
+        updates.collision_mask = val
       }
 
-      content = `${content.slice(0, insertPoint)}${props}${content.slice(insertPoint)}`
+      const { content: updatedContent, updated } = updateNodeInScene(content, nodeName, updates)
+      if (!updated) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+      content = updatedContent
+
       await writeFile(fullPath, content, 'utf-8')
 
       return formatSuccess(
@@ -113,24 +110,21 @@ export async function handlePhysics(action: string, args: Record<string, unknown
         }
         throw err
       }
-      const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-      const match = content.match(nodeRegex)
-      if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
 
-      let props = ''
+      const updates: Record<string, string> = {}
       const physicsProps = ['gravity_scale', 'mass', 'linear_damp', 'angular_damp', 'freeze']
       for (const prop of physicsProps) {
         if (args[prop] !== undefined) {
           const val = toGodotValue(args[prop])
           validateNoNewlines(`Invalid ${prop}: newlines not allowed`, val)
-          props += `\n${prop} = ${val}`
+          updates[prop] = val
         }
       }
 
-      if (match.index === undefined)
-        throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-      const insertPoint = match.index + match[0].length
-      content = `${content.slice(0, insertPoint)}${props}${content.slice(insertPoint)}`
+      const { content: updatedContent, updated } = updateNodeInScene(content, nodeName, updates)
+      if (!updated) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+      content = updatedContent
+
       await writeFile(fullPath, content, 'utf-8')
 
       return formatSuccess(`Configured physics body: ${nodeName}`)

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -1,5 +1,5 @@
 /**
- * Scripts tool - GDScript file management
+ * Scripts tool - Godot script management and attachment
  * Actions: create | read | write | attach | list | delete
  */
 
@@ -8,7 +8,7 @@ import { dirname, join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
-import { escapeRegExp } from '../helpers/scene-parser.js'
+import { updateNodeInScene } from '../helpers/scene-parser.js'
 
 const NODE_SECTION_RE = /(\[node [^\]]+\])/
 
@@ -210,17 +210,18 @@ async function attachScript(args: Record<string, unknown>, resolvePath: (path: s
   const resPath = `res://${scriptPath.replaceAll('\\', '/')}`
 
   if (nodeName) {
-    const nodePattern = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-    const match = content.match(nodePattern)
-    if (!match)
+    const { content: updatedContent, updated } = updateNodeInScene(content, nodeName, {
+      script: `ExtResource("${resPath}")`,
+    })
+    if (!updated)
       throw new GodotMCPError(
         `Node "${nodeName}" not found in scene`,
         'NODE_ERROR',
         'Check node name with nodes.list action.',
       )
-    content = content.replace(nodePattern, (_match, p1) => `${p1}\nscript = ExtResource("${resPath}")`)
+    content = updatedContent
   } else {
-    content = content.replace(NODE_SECTION_RE, (_match, p1) => `${p1}\nscript = ExtResource("${resPath}")`)
+    content = content.replace(NODE_SECTION_RE, ($0) => `${$0}\nscript = ExtResource("${resPath}")`)
   }
 
   await writeFile(sceneFullPath, content, 'utf-8')

--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -8,7 +8,7 @@ import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, resolveProjectRoot, safeResolve } from '../helpers/paths.js'
-import { escapeRegExp, parseScene } from '../helpers/scene-parser.js'
+import { parseScene, updateNodeInScene } from '../helpers/scene-parser.js'
 
 const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
   Button: { text: '"Click"' },
@@ -185,35 +185,63 @@ async function handleLayout(projectPath: string, args: Record<string, unknown>) 
   }
 
   const fullPath = await resolveScene(projectPath, scenePath)
-  let content = await readFile(fullPath, 'utf-8')
+  const content = await readFile(fullPath, 'utf-8')
 
-  const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-  const match = content.match(nodeRegex)
-  if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-
-  let layoutProps = ''
+  let updates: Record<string, string> = {}
   switch (preset) {
     case 'full_rect':
-      layoutProps =
-        '\nanchors_preset = 15\nanchor_right = 1.0\nanchor_bottom = 1.0\ngrow_horizontal = 2\ngrow_vertical = 2'
+      updates = {
+        anchors_preset: '15',
+        anchor_right: '1.0',
+        anchor_bottom: '1.0',
+        grow_horizontal: '2',
+        grow_vertical: '2',
+      }
       break
     case 'center':
-      layoutProps =
-        '\nanchors_preset = 8\nanchor_left = 0.5\nanchor_top = 0.5\nanchor_right = 0.5\nanchor_bottom = 0.5\ngrow_horizontal = 2\ngrow_vertical = 2'
+      updates = {
+        anchors_preset: '8',
+        anchor_left: '0.5',
+        anchor_top: '0.5',
+        anchor_right: '0.5',
+        anchor_bottom: '0.5',
+        grow_horizontal: '2',
+        grow_vertical: '2',
+      }
       break
     case 'top_wide':
-      layoutProps = '\nanchors_preset = 10\nanchor_right = 1.0\ngrow_horizontal = 2'
+      updates = {
+        anchors_preset: '10',
+        anchor_right: '1.0',
+        grow_horizontal: '2',
+      }
       break
     case 'bottom_wide':
-      layoutProps =
-        '\nanchors_preset = 12\nanchor_top = 1.0\nanchor_right = 1.0\nanchor_bottom = 1.0\ngrow_horizontal = 2\ngrow_vertical = 0'
+      updates = {
+        anchors_preset: '12',
+        anchor_top: '1.0',
+        anchor_right: '1.0',
+        anchor_bottom: '1.0',
+        grow_horizontal: '2',
+        grow_vertical: '0',
+      }
       break
     case 'left_wide':
-      layoutProps = '\nanchors_preset = 9\nanchor_bottom = 1.0\ngrow_vertical = 2'
+      updates = {
+        anchors_preset: '9',
+        anchor_bottom: '1.0',
+        grow_vertical: '2',
+      }
       break
     case 'right_wide':
-      layoutProps =
-        '\nanchors_preset = 11\nanchor_left = 1.0\nanchor_right = 1.0\nanchor_bottom = 1.0\ngrow_horizontal = 0\ngrow_vertical = 2'
+      updates = {
+        anchors_preset: '11',
+        anchor_left: '1.0',
+        anchor_right: '1.0',
+        anchor_bottom: '1.0',
+        grow_horizontal: '0',
+        grow_vertical: '2',
+      }
       break
     default:
       throw new GodotMCPError(
@@ -223,11 +251,10 @@ async function handleLayout(projectPath: string, args: Record<string, unknown>) 
       )
   }
 
-  if (match.index === undefined)
-    throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-  const insertPoint = match.index + match[0].length
-  content = `${content.slice(0, insertPoint)}${layoutProps}${content.slice(insertPoint)}`
-  await writeFile(fullPath, content, 'utf-8')
+  const { content: updatedContent, updated } = updateNodeInScene(content, nodeName, updates)
+  if (!updated) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+
+  await writeFile(fullPath, updatedContent, 'utf-8')
 
   return formatSuccess(`Set layout preset "${preset}" on ${nodeName}`)
 }


### PR DESCRIPTION
This PR refactors multiple composite tools to eliminate inefficient \`String.prototype.match\` calls that were creating unnecessary array allocations. By adopting the centralized \`updateNodeInScene\` utility, we not only improve performance but also ensure that Godot scene properties are updated or appended correctly without duplication.

Affected files:
- \`src/tools/composite/physics.ts\`: \`collision_setup\` and \`body_config\` actions.
- \`src/tools/composite/ui.ts\`: \`layout\` action.
- \`src/tools/composite/scripts.ts\`: \`attach\` action when a specific node name is provided.

Verification:
- Relevant integration tests for Physics, UI, and Scripts all pass.
- Full project linting and type checking are clean.

---
*PR created automatically by Jules for task [6636544380507000783](https://jules.google.com/task/6636544380507000783) started by @n24q02m*