### PR TITLE
[CLEANUP] ReDoS via Unsafe Dynamic RegExp in UI layout configuration

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -8,7 +8,7 @@ import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, resolveProjectRoot, safeResolve } from '../helpers/paths.js'
-import { escapeRegExp, parseScene } from '../helpers/scene-parser.js'
+import { parseScene, updateNodeInScene } from '../helpers/scene-parser.js'
 
 const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
   Button: { text: '"Click"' },
@@ -29,6 +29,51 @@ const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
   HBoxContainer: {},
   VBoxContainer: {},
   GridContainer: { columns: '2' },
+}
+
+const LAYOUT_PRESETS: Record<string, Record<string, string>> = {
+  full_rect: {
+    anchors_preset: '15',
+    anchor_right: '1.0',
+    anchor_bottom: '1.0',
+    grow_horizontal: '2',
+    grow_vertical: '2',
+  },
+  center: {
+    anchors_preset: '8',
+    anchor_left: '0.5',
+    anchor_top: '0.5',
+    anchor_right: '0.5',
+    anchor_bottom: '0.5',
+    grow_horizontal: '2',
+    grow_vertical: '2',
+  },
+  top_wide: {
+    anchors_preset: '10',
+    anchor_right: '1.0',
+    grow_horizontal: '2',
+  },
+  bottom_wide: {
+    anchors_preset: '12',
+    anchor_top: '1.0',
+    anchor_right: '1.0',
+    anchor_bottom: '1.0',
+    grow_horizontal: '2',
+    grow_vertical: '0',
+  },
+  left_wide: {
+    anchors_preset: '9',
+    anchor_bottom: '1.0',
+    grow_vertical: '2',
+  },
+  right_wide: {
+    anchors_preset: '11',
+    anchor_left: '1.0',
+    anchor_right: '1.0',
+    anchor_bottom: '1.0',
+    grow_horizontal: '0',
+    grow_vertical: '2',
+  },
 }
 
 const CONTROL_TYPES = new Set([
@@ -184,50 +229,22 @@ async function handleLayout(projectPath: string, args: Record<string, unknown>) 
     )
   }
 
-  const fullPath = await resolveScene(projectPath, scenePath)
-  let content = await readFile(fullPath, 'utf-8')
-
-  const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-  const match = content.match(nodeRegex)
-  if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-
-  let layoutProps = ''
-  switch (preset) {
-    case 'full_rect':
-      layoutProps =
-        '\nanchors_preset = 15\nanchor_right = 1.0\nanchor_bottom = 1.0\ngrow_horizontal = 2\ngrow_vertical = 2'
-      break
-    case 'center':
-      layoutProps =
-        '\nanchors_preset = 8\nanchor_left = 0.5\nanchor_top = 0.5\nanchor_right = 0.5\nanchor_bottom = 0.5\ngrow_horizontal = 2\ngrow_vertical = 2'
-      break
-    case 'top_wide':
-      layoutProps = '\nanchors_preset = 10\nanchor_right = 1.0\ngrow_horizontal = 2'
-      break
-    case 'bottom_wide':
-      layoutProps =
-        '\nanchors_preset = 12\nanchor_top = 1.0\nanchor_right = 1.0\nanchor_bottom = 1.0\ngrow_horizontal = 2\ngrow_vertical = 0'
-      break
-    case 'left_wide':
-      layoutProps = '\nanchors_preset = 9\nanchor_bottom = 1.0\ngrow_vertical = 2'
-      break
-    case 'right_wide':
-      layoutProps =
-        '\nanchors_preset = 11\nanchor_left = 1.0\nanchor_right = 1.0\nanchor_bottom = 1.0\ngrow_horizontal = 0\ngrow_vertical = 2'
-      break
-    default:
-      throw new GodotMCPError(
-        `Unknown layout preset: ${preset}`,
-        'INVALID_ARGS',
-        'Valid presets: full_rect, center, top_wide, bottom_wide, left_wide, right_wide.',
-      )
+  const layoutProps = LAYOUT_PRESETS[preset]
+  if (!layoutProps) {
+    throw new GodotMCPError(
+      `Unknown layout preset: ${preset}`,
+      'INVALID_ARGS',
+      'Valid presets: full_rect, center, top_wide, bottom_wide, left_wide, right_wide.',
+    )
   }
 
-  if (match.index === undefined)
-    throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-  const insertPoint = match.index + match[0].length
-  content = `${content.slice(0, insertPoint)}${layoutProps}${content.slice(insertPoint)}`
-  await writeFile(fullPath, content, 'utf-8')
+  const fullPath = await resolveScene(projectPath, scenePath)
+  const content = await readFile(fullPath, 'utf-8')
+
+  const { content: newContent, updated } = updateNodeInScene(content, nodeName, layoutProps)
+  if (!updated) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+
+  await writeFile(fullPath, newContent, 'utf-8')
 
   return formatSuccess(`Set layout preset "${preset}" on ${nodeName}`)
 }

--- a/tests/composite/ui.test.ts
+++ b/tests/composite/ui.test.ts
@@ -194,6 +194,27 @@ describe('ui', () => {
     })
   })
 
+  it('should update existing properties instead of duplicating them', async () => {
+    createTmpScene(projectPath, 'ctrl.tscn', CONTROL_SCENE)
+
+    // First apply full_rect
+    await handleUI('layout', { scene_path: 'ctrl.tscn', name: 'Root', preset: 'full_rect' }, config)
+
+    // Then apply center
+    await handleUI('layout', { scene_path: 'ctrl.tscn', name: 'Root', preset: 'center' }, config)
+
+    const content = readFileSync(join(projectPath, 'ctrl.tscn'), 'utf-8')
+
+    // Check for 'anchors_preset = 8' (from center)
+    expect(content).toContain('anchors_preset = 8')
+    // Ensure 'anchors_preset = 15' (from full_rect) is no longer there
+    expect(content).not.toContain('anchors_preset = 15')
+
+    // Count occurrences of 'anchors_preset ='
+    const matches = content.match(/anchors_preset =/g)
+    expect(matches).toHaveLength(1)
+  })
+
   // ==========================================
   // set_theme
   // ==========================================


### PR DESCRIPTION
Refactored `handleLayout` in `src/tools/composite/ui.ts` to use the centralized `updateNodeInScene` utility instead of a dynamic Regular Expression with `[^\]]*`. This change mitigates potential ReDoS vulnerabilities and ensures that layout properties are updated correctly without duplication.

Key changes:
- Defined a `LAYOUT_PRESETS` constant mapping preset names to property objects.
- Replaced the vulnerable `RegExp` and manual string manipulation in `handleLayout` with a call to `updateNodeInScene`.
- Removed the unused `escapeRegExp` import from `src/tools/composite/ui.ts`.
- Added a new test case to `tests/composite/ui.test.ts` to verify that repeated calls to `layout` update existing properties instead of duplicating them.
- Updated `biome.json` to match the installed CLI version.

---
*PR created automatically by Jules for task [1454993616770726615](https://jules.google.com/task/1454993616770726615) started by @n24q02m*