### PR TITLE
[FIX] Large throwUnknownAction string array

### DIFF
--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -223,24 +223,23 @@ async function handleGetNodeProperty(projectPath: string, args: Record<string, u
   return formatJSON({ node: nodeName, property, value: val ?? null })
 }
 
+const NODE_ACTIONS: Record<string, (projectPath: string, args: Record<string, unknown>) => Promise<unknown>> = {
+  add: handleAddNode,
+  remove: handleRemoveNode,
+  rename: handleRenameNode,
+  list: handleListNodes,
+  set_property: handleSetNodeProperty,
+  get_property: handleGetNodeProperty,
+}
+
 export async function handleNodes(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const baseProjectPath = config.projectPath || process.cwd()
   const projectPath = args.project_path ? safeResolve(baseProjectPath, args.project_path as string) : baseProjectPath
 
-  switch (action) {
-    case 'add':
-      return handleAddNode(projectPath, args)
-    case 'remove':
-      return handleRemoveNode(projectPath, args)
-    case 'rename':
-      return handleRenameNode(projectPath, args)
-    case 'list':
-      return handleListNodes(projectPath, args)
-    case 'set_property':
-      return handleSetNodeProperty(projectPath, args)
-    case 'get_property':
-      return handleGetNodeProperty(projectPath, args)
-    default:
-      throwUnknownAction(action, ['add', 'remove', 'rename', 'list', 'set_property', 'get_property'])
+  const handler = NODE_ACTIONS[action]
+  if (handler) {
+    return handler(projectPath, args)
   }
+
+  throwUnknownAction(action, Object.keys(NODE_ACTIONS))
 }

--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -223,7 +223,13 @@ async function handleGetNodeProperty(projectPath: string, args: Record<string, u
   return formatJSON({ node: nodeName, property, value: val ?? null })
 }
 
-const NODE_ACTIONS: Record<string, (projectPath: string, args: Record<string, unknown>) => Promise<unknown>> = {
+const NODE_ACTIONS: Record<
+  string,
+  (
+    projectPath: string,
+    args: Record<string, unknown>,
+  ) => Promise<{ content: { type: string; text: string }[]; isError?: boolean }>
+> = {
   add: handleAddNode,
   remove: handleRemoveNode,
   rename: handleRenameNode,


### PR DESCRIPTION
Refactored the `handleNodes` function in `src/tools/composite/nodes.ts` to use a `NODE_ACTIONS` object mapping instead of a switch statement. This ensures that the valid actions listed in `throwUnknownAction` are automatically derived from the keys of `NODE_ACTIONS`, preventing inconsistencies between the dispatcher and the error message.

- Replaced switch statement with `NODE_ACTIONS` map.
- Updated `throwUnknownAction` to use `Object.keys(NODE_ACTIONS)`.
- Fixed Biome linting issues (noExplicitAny).
- Verified functionality with existing tests and extra verification for suggestions.

---
*PR created automatically by Jules for task [9438917060544121602](https://jules.google.com/task/9438917060544121602) started by @n24q02m*