### PR TITLE
[FIX] Strip specific prefixes and improve node path normalization

### DIFF
--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -21,20 +21,44 @@ function resolveScenePath(projectPath: string, scenePath: string): string {
 
 /**
  * Normalize node path: strip common LLM mistakes like "/root/SceneName/" prefix.
+ * Handles backslashes, case-insensitivity, and absolute vs relative paths.
  * Returns the corrected path and whether it was auto-corrected.
  */
 function normalizeNodePath(path: string): { path: string; corrected: boolean } {
   if (!path || path === '.') return { path, corrected: false }
-  // Strip /root/ or /root/SceneName/ prefix that LLMs commonly generate
-  const rootMatch = path.match(/^\/root\/(?:[^/]+\/)?(.+)$/)
+
+  // Normalize backslashes to forward slashes
+  const normalized = path.replace(/\\/g, '/')
+  const corrected = path.includes('\\')
+
+  // Case-insensitive check for /root/ or root/ prefix
+  // These are common LLM mistakes when they try to use absolute paths.
+  const rootMatch = normalized.match(/^\/?root\/(.+)$/i)
   if (rootMatch) {
-    return { path: rootMatch[1], corrected: true }
+    const afterRoot = rootMatch[1]
+    const segments = afterRoot.split('/').filter(Boolean)
+    if (segments.length <= 1) {
+      return { path: '.', corrected: true }
+    }
+    const remaining = segments.slice(1).join('/')
+    return { path: remaining, corrected: true }
   }
+
+  // Handle /root or root (exact match)
+  // We only treat it as the scene root if it's explicitly "/root" or "root" (case-insensitive)
+  // But wait, if someone has a node named "Root" that is NOT the scene root?
+  // In Godot, the root of the scene being edited is often named after the scene or "Root".
+  // LLMs often use "/root/SceneName/..."
+  if (normalized.toLowerCase() === '/root') {
+    return { path: '.', corrected: true }
+  }
+
   // Strip leading slash
-  if (path.startsWith('/')) {
-    return { path: path.slice(1), corrected: false }
+  if (normalized.startsWith('/')) {
+    return { path: normalized.slice(1), corrected: true }
   }
-  return { path, corrected: false }
+
+  return { path: normalized, corrected }
 }
 
 async function handleAddNode(projectPath: string, args: Record<string, unknown>) {

--- a/tests/composite/nodes_normalization.test.ts
+++ b/tests/composite/nodes_normalization.test.ts
@@ -1,0 +1,97 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { handleNodes } from '../../src/tools/composite/nodes.js'
+
+describe('nodes path normalization integration', () => {
+  const projectPath = join(tmpdir(), `godot-mcp-norm-test-${Date.now()}`)
+  const config = { projectPath }
+
+  const MINIMAL_TSCN = `[gd_scene format=3]
+
+[node name="Root" type="Node"]
+`
+
+  beforeAll(() => {
+    mkdirSync(projectPath, { recursive: true })
+    writeFileSync(join(projectPath, 'test.tscn'), MINIMAL_TSCN)
+  })
+
+  afterAll(() => {
+    rmSync(projectPath, { recursive: true, force: true })
+  })
+
+  it('should handle /root/SceneName/ prefix in add action', async () => {
+    // This should add "Child" under "Root" (which is '.')
+    const result = await handleNodes(
+      'add',
+      {
+        project_path: projectPath,
+        scene_path: 'test.tscn',
+        name: 'Child',
+        parent: '/root/Root/',
+      },
+      config as unknown as GodotConfig,
+    )
+
+    expect(result.content[0].text).toContain('under .')
+  })
+
+  it('should handle backslashes and case-insensitivity', async () => {
+    const result = await handleNodes(
+      'add',
+      {
+        project_path: projectPath,
+        scene_path: 'test.tscn',
+        name: 'Child2',
+        parent: 'ROOT\\Root',
+      },
+      config as unknown as GodotConfig,
+    )
+
+    expect(result.content[0].text).toContain('under .')
+  })
+
+  it('should handle deep paths under root', async () => {
+    // First add a parent
+    await handleNodes(
+      'add',
+      {
+        project_path: projectPath,
+        scene_path: 'test.tscn',
+        name: 'MyParent',
+        parent: '.',
+      },
+      config as unknown as GodotConfig,
+    )
+
+    const result = await handleNodes(
+      'add',
+      {
+        project_path: projectPath,
+        scene_path: 'test.tscn',
+        name: 'DeepChild',
+        parent: '/root/Root/MyParent',
+      },
+      config as unknown as GodotConfig,
+    )
+
+    expect(result.content[0].text).toContain('under MyParent')
+  })
+
+  it('should handle leading slash without root', async () => {
+    const result = await handleNodes(
+      'add',
+      {
+        project_path: projectPath,
+        scene_path: 'test.tscn',
+        name: 'AnotherChild',
+        parent: '/MyParent',
+      },
+      config as unknown as GodotConfig,
+    )
+
+    expect(result.content[0].text).toContain('under MyParent')
+  })
+})


### PR DESCRIPTION
This PR improves the \`normalizeNodePath\` function in \`src/tools/composite/nodes.ts\` to more robustly handle common LLM mistakes when providing node paths.

Key improvements:
- **Backslash Normalization**: Automatically converts \`\\\` to \`/\`.
- **Case-Insensitivity**: Prefixes like \`/root/\` or \`ROOT/\` are now handled correctly.
- **Absolute to Relative Conversion**: LLMs often provide runtime absolute paths like \`/root/SceneRoot/Path/To/Node\`. These are now correctly converted to scene-relative paths (\`Path/To/Node\`).
- **Minimal Root Handling**: Paths referring just to the root (\`/root\`) are correctly normalized to \`.\`.
- **Regression Fix**: Ensured that simple node names that happen to be "Root" but are not part of an absolute path prefix are preserved.

New integration tests were added in \`tests/composite/nodes_normalization.test.ts\` to verify these cases. All existing tests passed.

---
*PR created automatically by Jules for task [6304119968769215978](https://jules.google.com/task/6304119968769215978) started by @n24q02m*