### PR TITLE
[CLEANUP] ReDoS via Unsafe Dynamic RegExp in Scripts node pattern

### DIFF
--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -10,7 +10,7 @@ import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '..
 import { toGodotValue } from '../helpers/godot-types.js'
 import { safeResolve } from '../helpers/paths.js'
 import { type ProjectSettings, parseProjectSettingsAsync, setSettingInContent } from '../helpers/project-settings.js'
-import { escapeRegExp } from '../helpers/scene-parser.js'
+import { updateNodeInScene } from '../helpers/scene-parser.js'
 import { validateNoNewlines } from '../helpers/security.js'
 
 export async function handlePhysics(action: string, args: Record<string, unknown>, config: GodotConfig) {
@@ -67,27 +67,22 @@ export async function handlePhysics(action: string, args: Record<string, unknown
         }
         throw err
       }
-      const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-      const match = content.match(nodeRegex)
-      if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-
-      if (match.index === undefined)
-        throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-      const insertPoint = match.index + match[0].length
-      let props = ''
+      const updates: Record<string, string> = {}
       if (collisionLayer !== undefined) {
         const val = toGodotValue(collisionLayer)
         validateNoNewlines('Invalid collision_layer: newlines not allowed', val)
-        props += `\ncollision_layer = ${val}`
+        updates.collision_layer = val
       }
       if (collisionMask !== undefined) {
         const val = toGodotValue(collisionMask)
         validateNoNewlines('Invalid collision_mask: newlines not allowed', val)
-        props += `\ncollision_mask = ${val}`
+        updates.collision_mask = val
       }
 
-      content = `${content.slice(0, insertPoint)}${props}${content.slice(insertPoint)}`
-      await writeFile(fullPath, content, 'utf-8')
+      const { content: updated, updated: success } = updateNodeInScene(content, nodeName, updates)
+      if (!success) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+
+      await writeFile(fullPath, updated, 'utf-8')
 
       return formatSuccess(
         `Set collision on ${nodeName}: layer=${collisionLayer ?? 'unchanged'}, mask=${collisionMask ?? 'unchanged'}`,
@@ -113,25 +108,20 @@ export async function handlePhysics(action: string, args: Record<string, unknown
         }
         throw err
       }
-      const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-      const match = content.match(nodeRegex)
-      if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-
-      let props = ''
+      const updates: Record<string, string> = {}
       const physicsProps = ['gravity_scale', 'mass', 'linear_damp', 'angular_damp', 'freeze']
       for (const prop of physicsProps) {
         if (args[prop] !== undefined) {
           const val = toGodotValue(args[prop])
           validateNoNewlines(`Invalid ${prop}: newlines not allowed`, val)
-          props += `\n${prop} = ${val}`
+          updates[prop] = val
         }
       }
 
-      if (match.index === undefined)
-        throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-      const insertPoint = match.index + match[0].length
-      content = `${content.slice(0, insertPoint)}${props}${content.slice(insertPoint)}`
-      await writeFile(fullPath, content, 'utf-8')
+      const { content: updated, updated: success } = updateNodeInScene(content, nodeName, updates)
+      if (!success) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+
+      await writeFile(fullPath, updated, 'utf-8')
 
       return formatSuccess(`Configured physics body: ${nodeName}`)
     }

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -8,9 +8,7 @@ import { dirname, join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
-import { escapeRegExp } from '../helpers/scene-parser.js'
-
-const NODE_SECTION_RE = /(\[node [^\]]+\])/
+import { parseSceneContent, updateNodeInScene } from '../helpers/scene-parser.js'
 
 const SCRIPT_TEMPLATES: Record<string, string> = {
   Node: `extends Node
@@ -177,7 +175,7 @@ async function writeScript(args: Record<string, unknown>, resolvePath: (path: st
 async function attachScript(args: Record<string, unknown>, resolvePath: (path: string) => string) {
   const scenePath = args.scene_path as string
   const scriptPath = args.script_path as string
-  const nodeName = args.node_name as string
+  let nodeName = args.node_name as string
   if (!scenePath || !scriptPath) {
     throw new GodotMCPError(
       'Both scene_path and script_path required',
@@ -205,26 +203,32 @@ async function attachScript(args: Record<string, unknown>, resolvePath: (path: s
   if (!(await pathExists(sceneFullPath)))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
 
-  let content = await readFile(sceneFullPath, 'utf-8')
+  const content = await readFile(sceneFullPath, 'utf-8')
   // ⚡ Bolt: Using replaceAll('\\', '/') avoids RegExp allocation overhead
   const resPath = `res://${scriptPath.replaceAll('\\', '/')}`
 
-  if (nodeName) {
-    const nodePattern = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-    const match = content.match(nodePattern)
-    if (!match)
-      throw new GodotMCPError(
-        `Node "${nodeName}" not found in scene`,
-        'NODE_ERROR',
-        'Check node name with nodes.list action.',
-      )
-    content = content.replace(nodePattern, (_match, p1) => `${p1}\nscript = ExtResource("${resPath}")`)
-  } else {
-    content = content.replace(NODE_SECTION_RE, (_match, p1) => `${p1}\nscript = ExtResource("${resPath}")`)
+  if (!nodeName) {
+    const scene = parseSceneContent(content)
+    if (scene.nodes.length === 0) {
+      throw new GodotMCPError('Scene has no nodes', 'SCENE_ERROR', 'Create a node first.')
+    }
+    nodeName = scene.nodes[0].name
   }
 
-  await writeFile(sceneFullPath, content, 'utf-8')
-  return formatSuccess(`Attached script ${scriptPath} to ${nodeName || 'root node'} in ${scenePath}`)
+  const { content: updated, updated: success } = updateNodeInScene(content, nodeName, {
+    script: `ExtResource("${resPath}")`,
+  })
+
+  if (!success) {
+    throw new GodotMCPError(
+      `Node "${nodeName}" not found in scene`,
+      'NODE_ERROR',
+      'Check node name with nodes.list action.',
+    )
+  }
+
+  await writeFile(sceneFullPath, updated, 'utf-8')
+  return formatSuccess(`Attached script ${scriptPath} to ${nodeName} in ${scenePath}`)
 }
 
 async function listScripts(baseDir: string, projectPath: string | undefined) {

--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -8,7 +8,7 @@ import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, resolveProjectRoot, safeResolve } from '../helpers/paths.js'
-import { escapeRegExp, parseScene } from '../helpers/scene-parser.js'
+import { parseScene, updateNodeInScene } from '../helpers/scene-parser.js'
 
 const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
   Button: { text: '"Click"' },
@@ -185,35 +185,51 @@ async function handleLayout(projectPath: string, args: Record<string, unknown>) 
   }
 
   const fullPath = await resolveScene(projectPath, scenePath)
-  let content = await readFile(fullPath, 'utf-8')
+  const content = await readFile(fullPath, 'utf-8')
 
-  const nodeRegex = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-  const match = content.match(nodeRegex)
-  if (!match) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-
-  let layoutProps = ''
+  const updates: Record<string, string> = {}
   switch (preset) {
     case 'full_rect':
-      layoutProps =
-        '\nanchors_preset = 15\nanchor_right = 1.0\nanchor_bottom = 1.0\ngrow_horizontal = 2\ngrow_vertical = 2'
+      updates.anchors_preset = '15'
+      updates.anchor_right = '1.0'
+      updates.anchor_bottom = '1.0'
+      updates.grow_horizontal = '2'
+      updates.grow_vertical = '2'
       break
     case 'center':
-      layoutProps =
-        '\nanchors_preset = 8\nanchor_left = 0.5\nanchor_top = 0.5\nanchor_right = 0.5\nanchor_bottom = 0.5\ngrow_horizontal = 2\ngrow_vertical = 2'
+      updates.anchors_preset = '8'
+      updates.anchor_left = '0.5'
+      updates.anchor_top = '0.5'
+      updates.anchor_right = '0.5'
+      updates.anchor_bottom = '0.5'
+      updates.grow_horizontal = '2'
+      updates.grow_vertical = '2'
       break
     case 'top_wide':
-      layoutProps = '\nanchors_preset = 10\nanchor_right = 1.0\ngrow_horizontal = 2'
+      updates.anchors_preset = '10'
+      updates.anchor_right = '1.0'
+      updates.grow_horizontal = '2'
       break
     case 'bottom_wide':
-      layoutProps =
-        '\nanchors_preset = 12\nanchor_top = 1.0\nanchor_right = 1.0\nanchor_bottom = 1.0\ngrow_horizontal = 2\ngrow_vertical = 0'
+      updates.anchors_preset = '12'
+      updates.anchor_top = '1.0'
+      updates.anchor_right = '1.0'
+      updates.anchor_bottom = '1.0'
+      updates.grow_horizontal = '2'
+      updates.grow_vertical = '0'
       break
     case 'left_wide':
-      layoutProps = '\nanchors_preset = 9\nanchor_bottom = 1.0\ngrow_vertical = 2'
+      updates.anchors_preset = '9'
+      updates.anchor_bottom = '1.0'
+      updates.grow_vertical = '2'
       break
     case 'right_wide':
-      layoutProps =
-        '\nanchors_preset = 11\nanchor_left = 1.0\nanchor_right = 1.0\nanchor_bottom = 1.0\ngrow_horizontal = 0\ngrow_vertical = 2'
+      updates.anchors_preset = '11'
+      updates.anchor_left = '1.0'
+      updates.anchor_right = '1.0'
+      updates.anchor_bottom = '1.0'
+      updates.grow_horizontal = '0'
+      updates.grow_vertical = '2'
       break
     default:
       throw new GodotMCPError(
@@ -223,11 +239,10 @@ async function handleLayout(projectPath: string, args: Record<string, unknown>) 
       )
   }
 
-  if (match.index === undefined)
-    throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
-  const insertPoint = match.index + match[0].length
-  content = `${content.slice(0, insertPoint)}${layoutProps}${content.slice(insertPoint)}`
-  await writeFile(fullPath, content, 'utf-8')
+  const { content: updated, updated: success } = updateNodeInScene(content, nodeName, updates)
+  if (!success) throw new GodotMCPError(`Node "${nodeName}" not found`, 'NODE_ERROR', 'Check node name.')
+
+  await writeFile(fullPath, updated, 'utf-8')
 
   return formatSuccess(`Set layout preset "${preset}" on ${nodeName}`)
 }


### PR DESCRIPTION
Refactored attachScript in scripts.ts to use the centralized updateNodeInScene utility, which uses a safe line-by-line scanner instead of dynamic RegExps with greedy quantifiers. This fixes a ReDoS vulnerability and ensures proper property deduplication.

Also refactored similar patterns in physics.ts (collision_setup, body_config) and ui.ts (layout) for consistency and security.

Key changes:
- Removed NODE_SECTION_RE and unsafe dynamic RegExps in scripts.ts, physics.ts, and ui.ts.
- Integrated updateNodeInScene and parseSceneContent from scene-parser.ts.
- Ensured all tests (integration and security) pass.
- Verified linting and type checking.

---
*PR created automatically by Jules for task [1271889566613062753](https://jules.google.com/task/1271889566613062753) started by @n24q02m*