### PR TITLE
fix: scripts attach via updateNodeInScene + restore pathExists error-path tests

### DIFF
--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -8,9 +8,7 @@ import { dirname, join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
-import { escapeRegExp } from '../helpers/scene-parser.js'
-
-const NODE_SECTION_RE = /(\[node [^\]]+\])/
+import { parseSceneContent, updateNodeInScene } from '../helpers/scene-parser.js'
 
 const SCRIPT_TEMPLATES: Record<string, string> = {
   Node: `extends Node
@@ -177,7 +175,7 @@ async function writeScript(args: Record<string, unknown>, resolvePath: (path: st
 async function attachScript(args: Record<string, unknown>, resolvePath: (path: string) => string) {
   const scenePath = args.scene_path as string
   const scriptPath = args.script_path as string
-  const nodeName = args.node_name as string
+  let nodeName = args.node_name as string
   if (!scenePath || !scriptPath) {
     throw new GodotMCPError(
       'Both scene_path and script_path required',
@@ -205,26 +203,32 @@ async function attachScript(args: Record<string, unknown>, resolvePath: (path: s
   if (!(await pathExists(sceneFullPath)))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
 
-  let content = await readFile(sceneFullPath, 'utf-8')
+  const content = await readFile(sceneFullPath, 'utf-8')
   // ⚡ Bolt: Using replaceAll('\\', '/') avoids RegExp allocation overhead
   const resPath = `res://${scriptPath.replaceAll('\\', '/')}`
 
-  if (nodeName) {
-    const nodePattern = new RegExp(`(\\[node name="${escapeRegExp(nodeName)}"[^\\]]*\\])`)
-    const match = content.match(nodePattern)
-    if (!match)
-      throw new GodotMCPError(
-        `Node "${nodeName}" not found in scene`,
-        'NODE_ERROR',
-        'Check node name with nodes.list action.',
-      )
-    content = content.replace(nodePattern, (_match, p1) => `${p1}\nscript = ExtResource("${resPath}")`)
-  } else {
-    content = content.replace(NODE_SECTION_RE, (_match, p1) => `${p1}\nscript = ExtResource("${resPath}")`)
+  // Default to the scene's first (root) node when no node_name is provided.
+  if (!nodeName) {
+    const scene = parseSceneContent(content)
+    if (scene.nodes.length === 0) {
+      throw new GodotMCPError('Scene has no nodes', 'SCENE_ERROR', 'Create a node first.')
+    }
+    nodeName = scene.nodes[0].name
   }
 
-  await writeFile(sceneFullPath, content, 'utf-8')
-  return formatSuccess(`Attached script ${scriptPath} to ${nodeName || 'root node'} in ${scenePath}`)
+  const { content: updated, updated: success } = updateNodeInScene(content, nodeName, {
+    script: `ExtResource("${resPath}")`,
+  })
+  if (!success) {
+    throw new GodotMCPError(
+      `Node "${nodeName}" not found in scene`,
+      'NODE_ERROR',
+      'Check node name with nodes.list action.',
+    )
+  }
+
+  await writeFile(sceneFullPath, updated, 'utf-8')
+  return formatSuccess(`Attached script ${scriptPath} to ${nodeName} in ${scenePath}`)
 }
 
 async function listScripts(baseDir: string, projectPath: string | undefined) {

--- a/tests/helpers/paths.test.ts
+++ b/tests/helpers/paths.test.ts
@@ -229,6 +229,63 @@ describe('pathExists', () => {
     expect(await pathExists(nonExistentPath)).toBe(false)
   })
 
+  it('returns false when access throws EACCES (permission denied)', async () => {
+    const mockedAccess = vi.mocked(access)
+    const error = new Error('Permission denied')
+    ;(error as NodeJS.ErrnoException).code = 'EACCES'
+    mockedAccess.mockRejectedValue(error)
+
+    try {
+      expect(await pathExists('/any/path')).toBe(false)
+    } finally {
+      mockedAccess.mockRestore()
+    }
+  })
+
+  it('returns false when access rejects with null', async () => {
+    const mockedAccess = vi.mocked(access)
+    mockedAccess.mockRejectedValue(null)
+
+    try {
+      expect(await pathExists('/any/path')).toBe(false)
+    } finally {
+      mockedAccess.mockRestore()
+    }
+  })
+
+  it('returns false when access rejects with undefined', async () => {
+    const mockedAccess = vi.mocked(access)
+    mockedAccess.mockRejectedValue(undefined)
+
+    try {
+      expect(await pathExists('/any/path')).toBe(false)
+    } finally {
+      mockedAccess.mockRestore()
+    }
+  })
+
+  it('returns false when access rejects with a string', async () => {
+    const mockedAccess = vi.mocked(access)
+    mockedAccess.mockRejectedValue('Error string')
+
+    try {
+      expect(await pathExists('/any/path')).toBe(false)
+    } finally {
+      mockedAccess.mockRestore()
+    }
+  })
+
+  it('returns false when access rejects with a number', async () => {
+    const mockedAccess = vi.mocked(access)
+    mockedAccess.mockRejectedValue(500)
+
+    try {
+      expect(await pathExists('/any/path')).toBe(false)
+    } finally {
+      mockedAccess.mockRestore()
+    }
+  })
+
   it('returns false when access throws an unexpected error', async () => {
     const mockedAccess = vi.mocked(access)
     mockedAccess.mockRejectedValue(new Error('Unexpected error'))


### PR DESCRIPTION
Consolidates the two genuine, non-overlapping pieces left over after the PR-triage batch (#842/#837 merged, conflicting/superseded duplicates closed).

## Changes
1. **scripts.ts `attachScript`** -> migrate from `new RegExp(\`...escapeRegExp(nodeName)...\`)` + loose `NODE_SECTION_RE` fallback to the shared `updateNodeInScene` helper (now used consistently by physics.ts and ui.ts via #842). When no `node_name` is given, defaults to the scene's first node via `parseSceneContent`. Removes the last `escapeRegExp` usage in the scripts tool. This is the unique part of the now-closed #841 (its physics/ui changes already shipped in #842).
2. **paths.test.ts** -> restore the `pathExists` error-path coverage (EACCES, null, undefined, string, number rejections) from the now-closed #826. #826's tilemap change shipped via #837, but its test additions did not.

## Verification
- `bun run check` (biome + tsc): clean
- `bun x vitest run tests/helpers/paths.test.ts tests/composite/scripts.test.ts`: 48 passed, 2 skipped
- Full suite: 861 passed (1 unrelated flaky timeout in core.test.ts init-server import under parallel load; passes in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)