### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix process ID validation silently ignoring invalid state

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Weak matching logic in error suggestions can mislead users or automated agents into calling unintended tools if they make a typo that partially matches multiple tool names.
 **Learning:** Prioritizing exact matches and closer prefix matches reduces the risk of incorrect "Did you mean...?" suggestions.
 **Prevention:** Implemented a length-difference based tie-breaker for prefix matches in `findClosestMatch` to ensure the most specific match is suggested.
+## 2025-05-22 - [Process ID Validation Weakness]
+**Vulnerability:** The codebase previously used a pattern of `if (!isValidPid(pid)) continue` to skip invalid PIDs in `project.ts` and `editor.ts`. While this prevented injection by avoiding shell execution, it silently swallowed the failure. This could obscure tampering or hide corrupted internal state, allowing an attacker to insert malicious PIDs into the configuration undetected while legitimate processes were left untouched.
+**Learning:** Silently ignoring validation errors can hide active attacks or state corruption.
+**Prevention:** Replaced silent `continue` with `validatePid(pid)` which explicitly throws a `GodotMCPError` with `INVALID_ARGS`. This ensures failures are surfaced securely without exposing sensitive execution details, adhering to the "fail securely" principle and providing clear visibility into invalid input attempts.

--- a/src/tools/composite/editor.ts
+++ b/src/tools/composite/editor.ts
@@ -7,7 +7,7 @@ import { launchGodotEditor } from '../../godot/headless.js'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
-import { isValidPid, validatePid } from '../helpers/security.js'
+import { validatePid } from '../helpers/security.js'
 
 /**
  * Check if tracked Godot processes are running
@@ -17,9 +17,7 @@ function getGodotProcesses(config: GodotConfig): Array<{ pid: string; name: stri
 
   for (const pid of config.activePids) {
     // Security: strictly validate pid is a positive safe integer before using in process.kill
-    if (!isValidPid(pid)) {
-      continue
-    }
+    validatePid(pid)
 
     try {
       process.kill(pid, 0)

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -16,7 +16,7 @@ import {
   parseProjectSettingsAsync,
   setSettingInContent,
 } from '../helpers/project-settings.js'
-import { isValidPid, validatePid } from '../helpers/security.js'
+import { validatePid } from '../helpers/security.js'
 import { parseCommaSeparatedList } from '../helpers/strings.js'
 
 async function parseProjectGodot(projectPath: string): Promise<ProjectInfo> {
@@ -163,9 +163,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       let stoppedCount = 0
       for (const pid of config.activePids) {
         // Security: strictly validate pid is a positive safe integer before using in shell commands or process.kill
-        if (!isValidPid(pid)) {
-          continue
-        }
+        validatePid(pid)
 
         try {
           if (process.platform === 'win32') {

--- a/tests/security/pid-injection.test.ts
+++ b/tests/security/pid-injection.test.ts
@@ -30,70 +30,48 @@ describe('PID Injection Security', () => {
   })
 
   describe('handleProject stop action', () => {
-    it('should NOT call taskkill or process.kill with non-numeric PIDs', async () => {
+    it('should explicitly REJECT non-numeric PIDs', async () => {
       const maliciousPid = '123; calc.exe'
       // biome-ignore lint/suspicious/noExplicitAny: explicitly testing injection
       config.activePids = [maliciousPid as any]
 
       const processKillSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
-      const originalPlatform = process.platform
 
-      // Test Windows path
-      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+      await expect(handleProject('stop', {}, config)).rejects.toThrow(/Invalid PID/)
 
-      await handleProject('stop', {}, config)
-
-      expect(processKillSpy).not.toHaveBeenCalledWith(maliciousPid, expect.anything())
-      expect(execFileSync).not.toHaveBeenCalledWith(
-        'taskkill',
-        expect.arrayContaining([maliciousPid]),
-        expect.anything(),
-      )
-
-      // Test Unix path
-      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
-      vi.clearAllMocks()
-      // biome-ignore lint/suspicious/noExplicitAny: explicitly testing injection
-      config.activePids = [maliciousPid as any]
-
-      await handleProject('stop', {}, config)
-      expect(processKillSpy).not.toHaveBeenCalledWith(maliciousPid, expect.anything())
+      expect(processKillSpy).not.toHaveBeenCalled()
+      expect(execFileSync).not.toHaveBeenCalled()
 
       processKillSpy.mockRestore()
-      Object.defineProperty(process, 'platform', { value: originalPlatform })
     })
 
-    it('should NOT call taskkill or process.kill with non-integer PIDs', async () => {
+    it('should explicitly REJECT non-integer PIDs', async () => {
       const maliciousPid = 123.456
       // biome-ignore lint/suspicious/noExplicitAny: explicitly testing injection
       config.activePids = [maliciousPid as any]
 
       const processKillSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
 
-      await handleProject('stop', {}, config)
+      await expect(handleProject('stop', {}, config)).rejects.toThrow(/Invalid PID/)
 
-      expect(processKillSpy).not.toHaveBeenCalledWith(maliciousPid, expect.anything())
-      expect(execFileSync).not.toHaveBeenCalledWith(
-        'taskkill',
-        expect.arrayContaining([maliciousPid.toString()]),
-        expect.anything(),
-      )
+      expect(processKillSpy).not.toHaveBeenCalled()
+      expect(execFileSync).not.toHaveBeenCalled()
 
       processKillSpy.mockRestore()
     })
   })
 
   describe('handleEditor status action', () => {
-    it('should NOT call process.kill with non-numeric PIDs', async () => {
+    it('should explicitly REJECT non-numeric PIDs', async () => {
       const maliciousPid = '123; calc.exe'
       // biome-ignore lint/suspicious/noExplicitAny: explicitly testing injection
       config.activePids = [maliciousPid as any]
 
       const processKillSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
 
-      await handleEditor('status', {}, config)
+      await expect(handleEditor('status', {}, config)).rejects.toThrow(/Invalid PID/)
 
-      expect(processKillSpy).not.toHaveBeenCalledWith(maliciousPid, expect.anything())
+      expect(processKillSpy).not.toHaveBeenCalled()
 
       processKillSpy.mockRestore()
     })


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The codebase previously used \`if (!isValidPid(pid)) continue\` to skip invalid PIDs. While this prevented command injection, it silently swallowed the failure. This could obscure tampering or hide corrupted internal state, allowing an attacker to insert malicious PIDs into the configuration undetected.
🎯 **Impact:** State corruption or malicious injection attempts could go unnoticed by system operators, reducing observability and making the system harder to audit.
🔧 **Fix:** Replaced silent \`continue\` with \`validatePid(pid)\` which explicitly throws a \`GodotMCPError\`. This ensures failures are surfaced securely.
✅ **Verification:** Updated tests in \`pid-injection.test.ts\` to verify that a rejection is thrown with an "Invalid PID" message when non-numeric or non-integer PIDs are encountered. All tests pass locally.

---
*PR created automatically by Jules for task [16578046302766700054](https://jules.google.com/task/16578046302766700054) started by @n24q02m*