### PR TITLE
⚡ Bolt: Optimize parseGodotValue structural type matching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -26,3 +26,6 @@
 2. Best prefix/containment match, defined as the one with the smallest absolute length difference relative to the input.
 3. Fuzzy bigram similarity (Dice coefficient) with a threshold > 0.4.
 This ensures that "create" matches "create" even if "create_node" appears earlier in the options list, and "cre" matches "create" over "create_node".
+## 2026-06-11 - [Optimize parseGodotValue structural type matching]
+**Learning:** Checking regular expressions (like `V2_RE`, `V2I_RE`, etc.) directly on input strings can cause unnecessary overhead if the input doesn't match the expected structural type, especially if they share the same starting character.
+**Action:** Used `String.prototype.startsWith()` checks (e.g., `trimmed.startsWith('Vector2(')`) before executing the regular expressions in `parseGodotValue` to short-circuit parsing and prevent RegExp matching overhead entirely.

--- a/src/tools/helpers/godot-types.ts
+++ b/src/tools/helpers/godot-types.ts
@@ -75,28 +75,30 @@ export function parseGodotValue(expr: string, _depth = 0): unknown {
   // ⚡ Bolt: Fast path for checking structural Godot types by checking first character
   // Vector2, Vector2i, Vector3 ('V' = 86)
   if (firstChar === 86) {
-    const v2Match = trimmed.match(V2_RE)
-    if (v2Match) {
-      return { x: Number.parseFloat(v2Match[1]), y: Number.parseFloat(v2Match[2]) } as Vector2
-    }
-
-    const v2iMatch = trimmed.match(V2I_RE)
-    if (v2iMatch) {
-      return { x: Number.parseInt(v2iMatch[1], 10), y: Number.parseInt(v2iMatch[2], 10) } as Vector2
-    }
-
-    const v3Match = trimmed.match(V3_RE)
-    if (v3Match) {
-      return {
-        x: Number.parseFloat(v3Match[1]),
-        y: Number.parseFloat(v3Match[2]),
-        z: Number.parseFloat(v3Match[3]),
-      } as Vector3
+    if (trimmed.startsWith('Vector2(')) {
+      const v2Match = trimmed.match(V2_RE)
+      if (v2Match) {
+        return { x: Number.parseFloat(v2Match[1]), y: Number.parseFloat(v2Match[2]) } as Vector2
+      }
+    } else if (trimmed.startsWith('Vector2i(')) {
+      const v2iMatch = trimmed.match(V2I_RE)
+      if (v2iMatch) {
+        return { x: Number.parseInt(v2iMatch[1], 10), y: Number.parseInt(v2iMatch[2], 10) } as Vector2
+      }
+    } else if (trimmed.startsWith('Vector3(')) {
+      const v3Match = trimmed.match(V3_RE)
+      if (v3Match) {
+        return {
+          x: Number.parseFloat(v3Match[1]),
+          y: Number.parseFloat(v3Match[2]),
+          z: Number.parseFloat(v3Match[3]),
+        } as Vector3
+      }
     }
   }
 
   // Color ('C' = 67)
-  if (firstChar === 67) {
+  if (firstChar === 67 && trimmed.startsWith('Color(')) {
     const colorMatch = trimmed.match(COLOR_RE)
     if (colorMatch) {
       return {
@@ -109,7 +111,7 @@ export function parseGodotValue(expr: string, _depth = 0): unknown {
   }
 
   // Rect2 ('R' = 82)
-  if (firstChar === 82) {
+  if (firstChar === 82 && trimmed.startsWith('Rect2(')) {
     const rectMatch = trimmed.match(RECT2_RE)
     if (rectMatch) {
       return {


### PR DESCRIPTION
💡 **What:** Added `String.prototype.startsWith()` fast-path checks before executing regular expressions in `parseGodotValue` for Godot structural types (`Vector2`, `Vector2i`, `Vector3`, `Color`, `Rect2`).
🎯 **Why:** To avoid unnecessary regular expression matching overhead (and the cost of regex engine failures) when the Godot string does not match the structural type, particularly when multiple types share the same starting character (e.g., 'V' for Vector2/Vector2i/Vector3).
📊 **Impact:** Reduces CPU overhead during parsing of large `.tscn` and `.tres` files by short-circuiting regex evaluations.
🔬 **Measurement:** The `bun run test` suite for `godot-types.ts` passes without regressions, demonstrating that the functional correctness remains intact while the hot path avoids regex when unnecessary.

---
*PR created automatically by Jules for task [18010662022184849695](https://jules.google.com/task/18010662022184849695) started by @n24q02m*