### PR TITLE
fix: sync README tagline to current capability description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 mcp-name: io.github.n24q02m/better-godot-mcp
 
-**Composite MCP server for Godot Engine -- 17 mega-tools for AI-assisted game development**
+**Composite MCP server for Godot Engine -- 17 composite tools for AI-assisted game development.**
 
 <!-- Badge Row 1: Status -->
 [![CI](https://github.com/n24q02m/better-godot-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/n24q02m/better-godot-mcp/actions/workflows/ci.yml)


### PR DESCRIPTION
Sync the README tagline to the cleaned-up, jargon-free repo description (drop dated/internal jargon and brittle tool counts; frame by capability).