### PR TITLE
[SECURITY] Argument Injection in Run Tool via scene_path

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Weak matching logic in error suggestions can mislead users or automated agents into calling unintended tools if they make a typo that partially matches multiple tool names.
 **Learning:** Prioritizing exact matches and closer prefix matches reduces the risk of incorrect "Did you mean...?" suggestions.
 **Prevention:** Implemented a length-difference based tie-breaker for prefix matches in `findClosestMatch` to ensure the most specific match is suggested.
+
+## 2026-06-13 - Argument Injection via Space-Padded Flags
+**Vulnerability:** Argument injection in CLI-invoking tools.
+**Learning:** Checking for leading hyphens using `startsWith('-')` on untrusted input can be bypassed if the attacker pads the flag with leading spaces (e.g., " -s malicious.gd").
+**Prevention:** Always `.trim()` user-provided strings before performing safety checks like hyphen-prefixed flag detection.

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -107,7 +107,7 @@ export async function handleProject(action: string, args: Record<string, unknown
           'Provide project_path argument or set it via config.set action.',
         )
       }
-      if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
+      if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
         throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
       }
       const info = await parseProjectGodot(safeResolve(config.projectPath || process.cwd(), projectPath))
@@ -128,7 +128,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       const projectPath = (args.project_path as string) || config.projectPath
       if (!projectPath)
         throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
-      if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
+      if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
         throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
       }
 
@@ -139,7 +139,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (scenePath && (scenePath.includes('\n') || scenePath.includes('\r'))) {
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain newlines.')
       }
-      if (scenePath?.startsWith('-')) {
+      if (scenePath?.trim().startsWith('-')) {
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not start with a hyphen.')
       }
 
@@ -193,7 +193,7 @@ export async function handleProject(action: string, args: Record<string, unknown
     case 'settings_get': {
       const projectPath = (args.project_path as string) || config.projectPath
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
-      if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
+      if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
         throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
       }
       const key = args.key as string
@@ -219,7 +219,7 @@ export async function handleProject(action: string, args: Record<string, unknown
     case 'settings_set': {
       const projectPath = (args.project_path as string) || config.projectPath
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
-      if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
+      if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
         throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
       }
       const key = args.key as string
@@ -257,7 +257,7 @@ export async function handleProject(action: string, args: Record<string, unknown
         throw new GodotMCPError('Godot not found', 'GODOT_NOT_FOUND', 'Set GODOT_PATH env var or install Godot.')
       const projectPath = (args.project_path as string) || config.projectPath
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
-      if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
+      if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
         throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
       }
       const preset = args.preset as string
@@ -274,7 +274,7 @@ export async function handleProject(action: string, args: Record<string, unknown
         throw new GodotMCPError('Invalid arguments', 'INVALID_ARGS', 'Preset and output path must be strings.')
       }
 
-      if (preset.startsWith('-') || outputPath.startsWith('-')) {
+      if (preset.trim().startsWith('-') || outputPath.trim().startsWith('-')) {
         throw new GodotMCPError(
           'Invalid arguments',
           'INVALID_ARGS',


### PR DESCRIPTION
This PR fixes a security vulnerability where space-padded flags could bypass the hyphen check in the Project tool's run, info, settings, and export actions. By trimming the input before checking for leading hyphens, we ensure that argument injection is properly prevented.

Changes:
- Updated \`src/tools/composite/project.ts\` to trim inputs before checking for leading hyphens.
- Verified fix with reproduction tests and full test suite (867 tests passing).
- Recorded learning in \`.jules/sentinel.md\`.

---
*PR created automatically by Jules for task [13869978366470809234](https://jules.google.com/task/13869978366470809234) started by @n24q02m*