### PR TITLE
[FIX] Function is too long

### DIFF
--- a/src/tools/composite/signals.ts
+++ b/src/tools/composite/signals.ts
@@ -25,135 +25,148 @@ function validateParameters(...params: unknown[]) {
   }
 }
 
-export async function handleSignals(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = resolveProjectRoot(args.project_path, config.projectPath)
-  const scenePath = args.scene_path as string
+async function readSceneContent(fullPath: string, scenePath: string) {
+  try {
+    return await readFile(fullPath, 'utf-8')
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
+    }
+    throw error
+  }
+}
 
+async function handleListSignals(projectPath: string, args: Record<string, unknown>) {
+  const scenePath = args.scene_path as string
   if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
   const fullPath = safeResolve(projectPath, scenePath)
 
-  async function readScene() {
-    try {
-      return await readFile(fullPath, 'utf-8')
-    } catch (error: unknown) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
-      }
-      throw error
-    }
+  const content = await readSceneContent(fullPath, scenePath)
+  const scene = parseSceneContent(content)
+
+  return formatJSON({
+    scene: scenePath,
+    count: scene.connections.length,
+    connections: scene.connections,
+  })
+}
+
+async function handleConnectSignal(projectPath: string, args: Record<string, unknown>) {
+  const scenePath = args.scene_path as string
+  if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+  const fullPath = safeResolve(projectPath, scenePath)
+
+  const signal = args.signal as string
+  const from = args.from as string
+  const to = args.to as string
+  const method = args.method as string
+  if (!signal || !from || !to || !method) {
+    throw new GodotMCPError(
+      'signal, from, to, and method required',
+      'INVALID_ARGS',
+      'Provide signal name, source node, target node, and method name.',
+    )
   }
 
-  switch (action) {
-    case 'list': {
-      const content = await readScene()
-      const scene = parseSceneContent(content)
-
-      return formatJSON({
-        scene: scenePath,
-        count: scene.connections.length,
-        // ⚡ Bolt: Return the pre-parsed connections array directly to avoid O(N) redundant object allocations
-        connections: scene.connections,
-      })
-    }
-
-    case 'connect': {
-      const signal = args.signal as string
-      const from = args.from as string
-      const to = args.to as string
-      const method = args.method as string
-      if (!signal || !from || !to || !method) {
-        throw new GodotMCPError(
-          'signal, from, to, and method required',
-          'INVALID_ARGS',
-          'Provide signal name, source node, target node, and method name.',
-        )
-      }
-
-      const flags = args.flags as number | undefined
-      if (flags !== undefined && typeof flags !== 'number') {
-        throw new GodotMCPError('flags must be a number', 'INVALID_ARGS')
-      }
-
-      validateParameters(signal, from, to, method, flags)
-
-      let content = await readScene()
-
-      // Check for duplicate
-      const scene = parseSceneContent(content)
-      const existing = scene.connectionsKeyed.get(`${signal}:${from}:${to}:${method}`)
-      if (existing) {
-        throw new GodotMCPError(
-          'Connection already exists',
-          'SIGNAL_ERROR',
-          'This signal connection is already defined.',
-        )
-      }
-
-      // Append connection
-      const flagsAttr = flags !== undefined ? ` flags=${flags}` : ''
-      const connectionLine = `\n[connection signal="${signal}" from="${from}" to="${to}" method="${method}"${flagsAttr}]\n`
-      content = `${content.trimEnd()}\n${connectionLine}`
-
-      await writeFile(fullPath, content, 'utf-8')
-      return formatSuccess(`Connected: ${from}.${signal} -> ${to}.${method}()`)
-    }
-
-    case 'disconnect': {
-      const signal = args.signal as string
-      const from = args.from as string
-      const to = args.to as string
-      const method = args.method as string
-      if (!signal || !from || !to || !method) {
-        throw new GodotMCPError(
-          'signal, from, to, and method required',
-          'INVALID_ARGS',
-          'All four parameters are required.',
-        )
-      }
-
-      validateParameters(signal, from, to, method)
-
-      const content = await readScene()
-      const filtered: string[] = []
-      let pos = 0
-      const len = content.length
-      let found = false
-
-      while (pos < len) {
-        let nextNewline = content.indexOf('\n', pos)
-        if (nextNewline === -1) nextNewline = len
-
-        const line = content.substring(pos, nextNewline)
-        const trimmed = line.trim()
-
-        if (
-          trimmed.startsWith('[connection') &&
-          trimmed.includes(`signal="${signal}"`) &&
-          trimmed.includes(`from="${from}"`) &&
-          trimmed.includes(`to="${to}"`) &&
-          trimmed.includes(`method="${method}"`)
-        ) {
-          found = true
-        } else {
-          filtered.push(line)
-        }
-
-        pos = nextNewline + 1
-      }
-
-      if (!found) {
-        throw new GodotMCPError(
-          'Connection not found',
-          'SIGNAL_ERROR',
-          'Check signal, from, to, and method parameters.',
-        )
-      }
-
-      await writeFile(fullPath, filtered.join('\n'), 'utf-8')
-      return formatSuccess(`Disconnected: ${from}.${signal} -> ${to}.${method}()`)
-    }
-
-    default:
-      throwUnknownAction(action, ['list', 'connect', 'disconnect'])
+  const flags = args.flags as number | undefined
+  if (flags !== undefined && typeof flags !== 'number') {
+    throw new GodotMCPError('flags must be a number', 'INVALID_ARGS')
   }
+
+  validateParameters(signal, from, to, method, flags)
+
+  let content = await readSceneContent(fullPath, scenePath)
+
+  // Check for duplicate
+  const scene = parseSceneContent(content)
+  const existing = scene.connectionsKeyed.get(`${signal}:${from}:${to}:${method}`)
+  if (existing) {
+    throw new GodotMCPError('Connection already exists', 'SIGNAL_ERROR', 'This signal connection is already defined.')
+  }
+
+  // Append connection
+  const flagsAttr = flags !== undefined ? ` flags=${flags}` : ''
+  const connectionLine = `\n[connection signal="${signal}" from="${from}" to="${to}" method="${method}"${flagsAttr}]\n`
+  content = `${content.trimEnd()}\n${connectionLine}`
+
+  await writeFile(fullPath, content, 'utf-8')
+  return formatSuccess(`Connected: ${from}.${signal} -> ${to}.${method}()`)
+}
+
+async function handleDisconnectSignal(projectPath: string, args: Record<string, unknown>) {
+  const scenePath = args.scene_path as string
+  if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+  const fullPath = safeResolve(projectPath, scenePath)
+
+  const signal = args.signal as string
+  const from = args.from as string
+  const to = args.to as string
+  const method = args.method as string
+  if (!signal || !from || !to || !method) {
+    throw new GodotMCPError(
+      'signal, from, to, and method required',
+      'INVALID_ARGS',
+      'All four parameters are required.',
+    )
+  }
+
+  validateParameters(signal, from, to, method)
+
+  const content = await readSceneContent(fullPath, scenePath)
+  const filtered: string[] = []
+  let pos = 0
+  const len = content.length
+  let found = false
+
+  while (pos < len) {
+    let nextNewline = content.indexOf('\n', pos)
+    if (nextNewline === -1) nextNewline = len
+
+    const line = content.substring(pos, nextNewline)
+    const trimmed = line.trim()
+
+    if (
+      trimmed.startsWith('[connection') &&
+      trimmed.includes(`signal="${signal}"`) &&
+      trimmed.includes(`from="${from}"`) &&
+      trimmed.includes(`to="${to}"`) &&
+      trimmed.includes(`method="${method}"`)
+    ) {
+      found = true
+    } else {
+      filtered.push(line)
+    }
+
+    pos = nextNewline + 1
+  }
+
+  if (!found) {
+    throw new GodotMCPError('Connection not found', 'SIGNAL_ERROR', 'Check signal, from, to, and method parameters.')
+  }
+
+  await writeFile(fullPath, filtered.join('\n'), 'utf-8')
+  return formatSuccess(`Disconnected: ${from}.${signal} -> ${to}.${method}()`)
+}
+
+const SIGNAL_ACTIONS: Record<
+  string,
+  (
+    projectPath: string,
+    args: Record<string, unknown>,
+  ) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>
+> = {
+  list: handleListSignals,
+  connect: handleConnectSignal,
+  disconnect: handleDisconnectSignal,
+}
+
+export async function handleSignals(action: string, args: Record<string, unknown>, config: GodotConfig) {
+  const projectPath = resolveProjectRoot(args.project_path, config.projectPath)
+
+  const handler = SIGNAL_ACTIONS[action]
+  if (handler) {
+    return handler(projectPath, args)
+  }
+
+  throwUnknownAction(action, Object.keys(SIGNAL_ACTIONS))
 }


### PR DESCRIPTION
The `handleSignals` function in `src/tools/composite/signals.ts` was previously too long and contained nested logic for multiple actions. This PR refactors it to follow the project's standard dispatcher pattern.

Key changes:
- Created standalone handler functions: `handleListSignals`, `handleConnectSignal`, and `handleDisconnectSignal`.
- Implemented a `SIGNAL_ACTIONS` dispatcher mapping.
- Centralized scene reading logic into a `readSceneContent` utility function to reduce code duplication and handle `ENOENT` consistently.
- Improved readability and maintainability by flattening the logic.

All existing signal management tests pass, and the refactor maintains full backward compatibility with existing tool arguments and behaviors.

---
*PR created automatically by Jules for task [5495039014199951039](https://jules.google.com/task/5495039014199951039) started by @n24q02m*