### PR TITLE
[SECURITY] Argument Injection in Export Tool

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Weak matching logic in error suggestions can mislead users or automated agents into calling unintended tools if they make a typo that partially matches multiple tool names.
 **Learning:** Prioritizing exact matches and closer prefix matches reduces the risk of incorrect "Did you mean...?" suggestions.
 **Prevention:** Implemented a length-difference based tie-breaker for prefix matches in `findClosestMatch` to ensure the most specific match is suggested.
+## 2026-06-13 - [Argument Injection Bypass via Leading Spaces]
+**Vulnerability:** Input validation using `.startsWith('-')` was bypassed by adding leading spaces to arguments (e.g., `  --flag`), allowing CLI flag injection in Godot commands.
+**Learning:** Security checks on command-line arguments must account for whitespace padding if the arguments are later passed to external processes.
+**Prevention:** Use `.trim().startsWith('-')` to ensure all hyphen-prefixed arguments are caught regardless of leading whitespace.

--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -44,7 +44,7 @@ export async function handleConfig(action: string, args: Record<string, unknown>
       // and we use spawnSync/spawn (not shell exec), so it's not a security risk
       if (
         (key === 'project_path' || key === 'godot_path') &&
-        (typeof value !== 'string' || /[;&|`$(){}<>'"\0\n\r]/.test(value) || value.startsWith('-'))
+        (typeof value !== 'string' || /[;&|`$(){}<>'"\0\n\r]/.test(value) || value.trim().startsWith('-'))
       ) {
         throw new GodotMCPError(
           `Invalid characters or format in ${key}`,

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -107,7 +107,7 @@ export async function handleProject(action: string, args: Record<string, unknown
           'Provide project_path argument or set it via config.set action.',
         )
       }
-      if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
+      if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
         throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
       }
       const info = await parseProjectGodot(safeResolve(config.projectPath || process.cwd(), projectPath))
@@ -128,7 +128,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       const projectPath = (args.project_path as string) || config.projectPath
       if (!projectPath)
         throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
-      if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
+      if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
         throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
       }
 
@@ -139,7 +139,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (scenePath && (scenePath.includes('\n') || scenePath.includes('\r'))) {
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain newlines.')
       }
-      if (scenePath?.startsWith('-')) {
+      if (scenePath?.trim().startsWith('-')) {
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not start with a hyphen.')
       }
 
@@ -193,7 +193,7 @@ export async function handleProject(action: string, args: Record<string, unknown
     case 'settings_get': {
       const projectPath = (args.project_path as string) || config.projectPath
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
-      if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
+      if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
         throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
       }
       const key = args.key as string
@@ -219,7 +219,7 @@ export async function handleProject(action: string, args: Record<string, unknown
     case 'settings_set': {
       const projectPath = (args.project_path as string) || config.projectPath
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
-      if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
+      if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
         throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
       }
       const key = args.key as string
@@ -257,7 +257,7 @@ export async function handleProject(action: string, args: Record<string, unknown
         throw new GodotMCPError('Godot not found', 'GODOT_NOT_FOUND', 'Set GODOT_PATH env var or install Godot.')
       const projectPath = (args.project_path as string) || config.projectPath
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
-      if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
+      if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
         throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
       }
       const preset = args.preset as string
@@ -274,7 +274,7 @@ export async function handleProject(action: string, args: Record<string, unknown
         throw new GodotMCPError('Invalid arguments', 'INVALID_ARGS', 'Preset and output path must be strings.')
       }
 
-      if (preset.startsWith('-') || outputPath.startsWith('-')) {
+      if (preset.trim().startsWith('-') || outputPath.trim().startsWith('-')) {
         throw new GodotMCPError(
           'Invalid arguments',
           'INVALID_ARGS',

--- a/tests/security/argument-injection.test.ts
+++ b/tests/security/argument-injection.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { handleProject } from '../../src/tools/composite/project.js'
+import { handleConfig } from '../../src/tools/composite/config.js'
+import type { GodotConfig } from '../../src/godot/types.js'
+
+vi.mock('../../src/godot/headless.js', () => ({
+  execGodotAsync: vi.fn().mockResolvedValue({ success: true, stdout: '', stderr: '', exitCode: 0 }),
+  execGodotSync: vi.fn(),
+  runGodotProject: vi.fn().mockReturnValue({ pid: 12345 }),
+}))
+
+describe('argument injection security', () => {
+  let config: GodotConfig
+
+  beforeEach(() => {
+    config = {
+      godotPath: '/path/to/godot',
+      projectPath: '.',
+      activePids: [],
+      godotVersion: { major: 4, minor: 1, patch: 0, raw: '4.1.0' }
+    } as unknown as GodotConfig
+  })
+
+  describe('Project Tool', () => {
+    it('should reject preset with leading spaces and a hyphen', async () => {
+      await expect(
+        handleProject('export', { preset: '  --script=bad.gd', output_path: 'out.exe' }, config),
+      ).rejects.toThrow('Invalid arguments')
+    })
+
+    it('should reject output_path with leading spaces and a hyphen', async () => {
+      await expect(
+        handleProject('export', { preset: 'Win', output_path: '  --script=bad.gd' }, config),
+      ).rejects.toThrow('Invalid arguments')
+    })
+
+    it('should reject project_path with leading spaces and a hyphen', async () => {
+      await expect(
+        handleProject('export', { project_path: '  --arg', preset: 'Win', output_path: 'out.exe' }, config),
+      ).rejects.toThrow('Invalid project path')
+    })
+
+    it('should reject scene_path with leading spaces and a hyphen', async () => {
+      await expect(
+        handleProject('run', { scene_path: '  --script=bad.gd' }, config),
+      ).rejects.toThrow('Invalid scene path')
+    })
+  })
+
+  describe('Config Tool', () => {
+    it('should reject project_path with leading spaces and a hyphen', async () => {
+      await expect(
+        handleConfig('set', { key: 'project_path', value: '  --arg' }, config),
+      ).rejects.toThrow('Invalid characters or format')
+    })
+
+    it('should reject godot_path with leading spaces and a hyphen', async () => {
+      await expect(
+        handleConfig('set', { key: 'godot_path', value: '  --arg' }, config),
+      ).rejects.toThrow('Invalid characters or format')
+    })
+  })
+})


### PR DESCRIPTION
This PR fixes a security vulnerability where argument injection was possible in several MCP tools (Export, Run, Info, etc.) by providing strings with leading spaces and a hyphen (e.g., "  --script=bad.gd").

### Problem
The existing checks used `startsWith('-')` which only looked at the first character of the string. Attackers could bypass this by padding the injected flag with spaces.

### Solution
Modified the validation logic to use `.trim().startsWith('-')` for all sensitive path and argument inputs. This ensures that any input starting with a hyphen, regardless of leading whitespace, is rejected.

### Changes
- Updated `src/tools/composite/project.ts` validation for `project_path`, `scene_path`, `preset`, and `output_path`.
- Updated `src/tools/composite/config.ts` validation for `project_path` and `godot_path`.
- Added a new security test suite: `tests/security/argument-injection.test.ts`.
- Recorded the vulnerability and learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [15045173830742199279](https://jules.google.com/task/15045173830742199279) started by @n24q02m*