### PR TITLE
[TEST] Missing error path test for pathExists

### DIFF
--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,4 +1,5 @@
 import { realpathSync } from 'node:fs'
+import { access } from 'node:fs/promises'
 import { dirname, isAbsolute, relative, resolve, sep } from 'node:path'
 import { GodotMCPError } from './errors.js'
 
@@ -98,8 +99,6 @@ export function resolveProjectRoot(projectPathArg: unknown, trustedBase: string 
   }
   return resolve(base)
 }
-
-import { access } from 'node:fs/promises'
 
 /**
  * Asynchronously checks if a file or directory exists.

--- a/tests/helpers/paths.test.ts
+++ b/tests/helpers/paths.test.ts
@@ -296,4 +296,16 @@ describe('pathExists', () => {
       mockedAccess.mockRestore()
     }
   })
+
+  it('returns false for broken symlinks', async () => {
+    const target = join(testDir, 'non-existent-target')
+    const link = join(testDir, 'broken-link')
+    await symlink(target, link)
+
+    expect(await pathExists(link)).toBe(false)
+  })
+
+  it('returns false for an empty string path', async () => {
+    expect(await pathExists('')).toBe(false)
+  })
 })


### PR DESCRIPTION
This PR improves the test coverage and robustness of the `pathExists` helper function.

Key changes:
- Moved the `access` import from the middle of `src/tools/helpers/paths.ts` to the top to follow the project's coding standards.
- Added new test cases in `tests/helpers/paths.test.ts` to cover broken symlinks and empty string paths.
- Verified that the changes maintain 100% test coverage for the `paths.ts` module.
- Ran linting and type checking to ensure no regressions.

---
*PR created automatically by Jules for task [17137103723855118484](https://jules.google.com/task/17137103723855118484) started by @n24q02m*