### PR TITLE
[CLEANUP] Avoid direct console.error

### DIFF
--- a/src/tools/helpers/logger.ts
+++ b/src/tools/helpers/logger.ts
@@ -8,26 +8,34 @@ const PREFIX = `[${SERVER_NAME}]`
 
 const isDebugEnabled = process.env.DEBUG === 'true' || process.env.NODE_ENV === 'development'
 
+/**
+ * Internal helper to write logs to stderr.
+ */
+function emit(label: string | null, message: string, ...args: unknown[]) {
+  const formattedLabel = label ? `${label}: ` : ''
+  console.error(`${PREFIX} ${formattedLabel}${message}`, ...args)
+}
+
 export const logger = {
   /**
    * Log an info message.
    */
   info: (message: string, ...args: unknown[]) => {
-    console.error(`${PREFIX} ${message}`, ...args)
+    emit(null, message, ...args)
   },
 
   /**
    * Log a warning message.
    */
   warn: (message: string, ...args: unknown[]) => {
-    console.error(`${PREFIX} WARN: ${message}`, ...args)
+    emit('WARN', message, ...args)
   },
 
   /**
    * Log an error message.
    */
   error: (message: string, ...args: unknown[]) => {
-    console.error(`${PREFIX} ERROR: ${message}`, ...args)
+    emit('ERROR', message, ...args)
   },
 
   /**
@@ -35,7 +43,7 @@ export const logger = {
    */
   debug: (message: string, ...args: unknown[]) => {
     if (isDebugEnabled) {
-      console.error(`${PREFIX} DEBUG: ${message}`, ...args)
+      emit('DEBUG', message, ...args)
     }
   },
 }


### PR DESCRIPTION
Refactored the logger utility to use a centralized 'emit' helper function for all stderr output. This ensures consistent formatting and makes the logging logic more maintainable by reducing duplicate console.error calls.

---
*PR created automatically by Jules for task [9634213783766695430](https://jules.google.com/task/9634213783766695430) started by @n24q02m*