### PR TITLE
[CLEANUP] Avoid direct console.error

### DIFF
--- a/src/tools/helpers/logger.ts
+++ b/src/tools/helpers/logger.ts
@@ -1,3 +1,5 @@
+import { format } from 'node:util'
+
 /**
  * Centralized logger utility for Better Godot MCP.
  * All logs are written to stderr to avoid interfering with MCP JSON-RPC on stdout.
@@ -13,21 +15,21 @@ export const logger = {
    * Log an info message.
    */
   info: (message: string, ...args: unknown[]) => {
-    console.error(`${PREFIX} ${message}`, ...args)
+    process.stderr.write(`${format(`${PREFIX} ${message}`, ...args)}\n`)
   },
 
   /**
    * Log a warning message.
    */
   warn: (message: string, ...args: unknown[]) => {
-    console.error(`${PREFIX} WARN: ${message}`, ...args)
+    process.stderr.write(`${format(`${PREFIX} WARN: ${message}`, ...args)}\n`)
   },
 
   /**
    * Log an error message.
    */
   error: (message: string, ...args: unknown[]) => {
-    console.error(`${PREFIX} ERROR: ${message}`, ...args)
+    process.stderr.write(`${format(`${PREFIX} ERROR: ${message}`, ...args)}\n`)
   },
 
   /**
@@ -35,7 +37,7 @@ export const logger = {
    */
   debug: (message: string, ...args: unknown[]) => {
     if (isDebugEnabled) {
-      console.error(`${PREFIX} DEBUG: ${message}`, ...args)
+      process.stderr.write(`${format(`${PREFIX} DEBUG: ${message}`, ...args)}\n`)
     }
   },
 }


### PR DESCRIPTION
This PR refactors the centralized logger utility to avoid direct `console.error` calls, which can sometimes be flagged by linting tools or lead to inconsistent behavior in environments where `console` is restricted.

Changes:
- Imported `format` from `node:util`.
- Replaced `console.error` with `process.stderr.write` in `info`, `warn`, `error`, and `debug` methods.
- Used `util.format` to ensure that multiple arguments and objects are correctly stringified before being written to `stderr`.
- Verified changes with unit tests (manually run and then removed) and by running the full project test suite.

---
*PR created automatically by Jules for task [18357844248364563702](https://jules.google.com/task/18357844248364563702) started by @n24q02m*