### PR TITLE
[PERF] Object.entries allocation inside loops

### DIFF
--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -109,17 +109,29 @@ async function handleAddNode(projectPath: string, args: Record<string, unknown>)
         'properties must be an object with string keys and values.',
       )
     }
-    for (const [key, value] of Object.entries(args.properties)) {
-      if (typeof key !== 'string' || typeof value !== 'string') {
-        throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property keys and values must be strings.')
+    const properties = args.properties as Record<string, unknown>
+    for (const key in properties) {
+      if (Object.hasOwn(properties, key)) {
+        const value = properties[key]
+        if (typeof key !== 'string' || typeof value !== 'string') {
+          throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property keys and values must be strings.')
+        }
+        if (key.includes('=') || key.includes('\n') || key.includes('\r')) {
+          throw new GodotMCPError(
+            'Invalid property key',
+            'INVALID_ARGS',
+            'Property keys must not contain "=", newlines.',
+          )
+        }
+        if (value.includes('\n') || value.includes('\r')) {
+          throw new GodotMCPError(
+            'Invalid property value',
+            'INVALID_ARGS',
+            'Property values must not contain newlines.',
+          )
+        }
+        nodeDecl += `${key} = ${value}\n`
       }
-      if (key.includes('=') || key.includes('\n') || key.includes('\r')) {
-        throw new GodotMCPError('Invalid property key', 'INVALID_ARGS', 'Property keys must not contain "=", newlines.')
-      }
-      if (value.includes('\n') || value.includes('\r')) {
-        throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property values must not contain newlines.')
-      }
-      nodeDecl += `${key} = ${value}\n`
     }
   }
 

--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -109,8 +109,10 @@ async function handleCreateControl(projectPath: string, args: Record<string, unk
   // Add default properties for known control types
   const defaults = CONTROL_TEMPLATES[controlType]
   if (defaults) {
-    for (const [key, value] of Object.entries(defaults)) {
-      nodeDecl += `${key} = ${value}\n`
+    for (const key in defaults) {
+      if (Object.hasOwn(defaults, key)) {
+        nodeDecl += `${key} = ${defaults[key]}\n`
+      }
     }
   }
 
@@ -123,17 +125,29 @@ async function handleCreateControl(projectPath: string, args: Record<string, unk
         'properties must be an object with string keys and values.',
       )
     }
-    for (const [key, value] of Object.entries(args.properties)) {
-      if (typeof key !== 'string' || typeof value !== 'string') {
-        throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property keys and values must be strings.')
+    const properties = args.properties as Record<string, unknown>
+    for (const key in properties) {
+      if (Object.hasOwn(properties, key)) {
+        const value = properties[key]
+        if (typeof key !== 'string' || typeof value !== 'string') {
+          throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property keys and values must be strings.')
+        }
+        if (key.includes('=') || key.includes('\n') || key.includes('\r')) {
+          throw new GodotMCPError(
+            'Invalid property key',
+            'INVALID_ARGS',
+            'Property keys must not contain "=", newlines.',
+          )
+        }
+        if (value.includes('\n') || value.includes('\r')) {
+          throw new GodotMCPError(
+            'Invalid property value',
+            'INVALID_ARGS',
+            'Property values must not contain newlines.',
+          )
+        }
+        nodeDecl += `${key} = ${value}\n`
       }
-      if (key.includes('=') || key.includes('\n') || key.includes('\r')) {
-        throw new GodotMCPError('Invalid property key', 'INVALID_ARGS', 'Property keys must not contain "=", newlines.')
-      }
-      if (value.includes('\n') || value.includes('\r')) {
-        throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property values must not contain newlines.')
-      }
-      nodeDecl += `${key} = ${value}\n`
     }
   }
 


### PR DESCRIPTION
This PR optimizes object iteration in `src/tools/composite/nodes.ts` and `src/tools/composite/ui.ts` by replacing `Object.entries()` with `for...in` and `Object.hasOwn()`. This avoids unnecessary array allocations in core composite tools. The requested fix for `src/tools/helpers/godot-types.ts` was already present in the codebase.

---
*PR created automatically by Jules for task [12333592622957560291](https://jules.google.com/task/12333592622957560291) started by @n24q02m*