### PR TITLE
[SECURITY] Insufficient Input Validation for Config Values

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Weak matching logic in error suggestions can mislead users or automated agents into calling unintended tools if they make a typo that partially matches multiple tool names.
 **Learning:** Prioritizing exact matches and closer prefix matches reduces the risk of incorrect "Did you mean...?" suggestions.
 **Prevention:** Implemented a length-difference based tie-breaker for prefix matches in `findClosestMatch` to ensure the most specific match is suggested.
+## 2025-05-23 - [Insufficient Input Validation for Config Values]
+**Vulnerability:** Insufficient validation for configuration values (timeout and paths) could allow passing unintended arguments or potentially dangerous strings that might be misused if executed in a shell.
+**Learning:** Even when using `spawn` or `execFile` without a shell, strict validation of all user-controlled configuration parameters is essential to prevent argument injection or logic bypass.
+**Prevention:** Implemented strict numeric validation for `timeout` (positive integer string, 1ms to 1hr) and tightened path validation to reject leading/trailing whitespace and multiple consecutive spaces. Integrated `validateNoNewlines` for consistent newline rejection across all config values.

--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -8,6 +8,7 @@ import { detectGodot, isExecutable, isVersionSupported, tryGetVersion } from '..
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists } from '../helpers/paths.js'
+import { validateNoNewlines } from '../helpers/security.js'
 
 // Mutable runtime config
 const runtimeConfig: Record<string, string> = {}
@@ -39,18 +40,44 @@ export async function handleConfig(action: string, args: Record<string, unknown>
         throw new GodotMCPError(`Invalid config key: ${key}`, 'INVALID_ARGS', `Valid keys: ${validKeys.join(', ')}`)
       }
 
-      // Validate paths don't contain shell metacharacters and don't start with hyphen
-      // Note: backslash (\) is allowed since it's the Windows path separator
-      // and we use spawnSync/spawn (not shell exec), so it's not a security risk
-      if (
-        (key === 'project_path' || key === 'godot_path') &&
-        (typeof value !== 'string' || /[;&|`$(){}<>'"\0\n\r]/.test(value) || value.startsWith('-'))
-      ) {
-        throw new GodotMCPError(
-          `Invalid characters or format in ${key}`,
-          'INVALID_ARGS',
-          'Path must not contain shell metacharacters and must not start with a hyphen.',
-        )
+      // Universal security validation: no newlines allowed in any config value
+      validateNoNewlines(`Invalid characters or format in ${key}`, value)
+
+      if (key === 'project_path' || key === 'godot_path') {
+        // Validate paths don't contain shell metacharacters and don't start with hyphen
+        // Note: backslash (\) is allowed since it's the Windows path separator
+        // and we use spawnSync/spawn (not shell exec), so it's not a security risk
+        if (
+          typeof value !== 'string' ||
+          /[;&|`$(){}<>'"\0]/.test(value) ||
+          value.startsWith('-') ||
+          value !== value.trim() || // No leading/trailing whitespace
+          value.includes('  ') // No multiple consecutive spaces (heuristic for injection)
+        ) {
+          throw new GodotMCPError(
+            `Invalid characters or format in ${key}`,
+            'INVALID_ARGS',
+            'Path must not contain shell metacharacters, leading/trailing whitespace, or consecutive spaces, and must not start with a hyphen.',
+          )
+        }
+      } else if (key === 'timeout') {
+        // Validate timeout is a positive integer string and within reasonable range
+        if (typeof value !== 'string' || !/^\d+$/.test(value)) {
+          throw new GodotMCPError(
+            `Invalid characters or format in ${key}`,
+            'INVALID_ARGS',
+            'Timeout must be a positive integer string.',
+          )
+        }
+        const timeoutMs = Number.parseInt(value, 10)
+        if (timeoutMs < 1 || timeoutMs > 3600000) {
+          // 1 hour max
+          throw new GodotMCPError(
+            `Invalid characters or format in ${key}`,
+            'INVALID_ARGS',
+            'Timeout must be between 1ms and 3600000ms (1 hour).',
+          )
+        }
       }
 
       // Validate before updating runtimeConfig to avoid storing invalid values

--- a/tests/security/config_validation.test.ts
+++ b/tests/security/config_validation.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as detector from '../../src/godot/detector.js'
+import type { GodotConfig } from '../../src/godot/types.js'
+import { handleConfig } from '../../src/tools/composite/config.js'
+import * as paths from '../../src/tools/helpers/paths.js'
+import { makeConfig } from '../fixtures.js'
+
+vi.mock('../../src/godot/detector.js', async () => {
+  const actual = await vi.importActual<typeof detector>('../../src/godot/detector.js')
+  return {
+    ...actual,
+    isExecutable: vi.fn(),
+    tryGetVersion: vi.fn(),
+    isVersionSupported: vi.fn(),
+  }
+})
+
+vi.mock('../../src/tools/helpers/paths.js', async () => {
+  const actual = await vi.importActual<typeof paths>('../../src/tools/helpers/paths.js')
+  return {
+    ...actual,
+    pathExists: vi.fn(),
+  }
+})
+
+describe('Config Validation Security', () => {
+  let config: GodotConfig
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    config = makeConfig({ godotPath: '/usr/bin/godot', projectPath: '/tmp/proj' })
+    vi.mocked(detector.isExecutable).mockReturnValue(true)
+    vi.mocked(detector.tryGetVersion).mockReturnValue({
+      major: 4,
+      minor: 2,
+      patch: 0,
+      label: 'stable',
+      raw: '4.2.stable',
+    })
+    vi.mocked(detector.isVersionSupported).mockReturnValue(true)
+    vi.mocked(paths.pathExists).mockResolvedValue(true)
+  })
+
+  it('should reject timeout with non-numeric characters', async () => {
+    // CURRENT BEHAVIOR: This might pass because there's no validation for timeout
+    await expect(handleConfig('set', { key: 'timeout', value: '5000; rm -rf /' }, config)).rejects.toThrow(
+      /Invalid characters or format/,
+    )
+  })
+
+  it('should reject timeout that is too large', async () => {
+    await expect(handleConfig('set', { key: 'timeout', value: '999999999999999' }, config)).rejects.toThrow(
+      /Invalid characters or format/,
+    )
+  })
+
+  it('should reject paths with leading whitespace', async () => {
+    await expect(handleConfig('set', { key: 'godot_path', value: ' /usr/bin/godot' }, config)).rejects.toThrow(
+      /Invalid characters or format/,
+    )
+  })
+
+  it('should reject paths with trailing whitespace', async () => {
+    await expect(handleConfig('set', { key: 'godot_path', value: '/usr/bin/godot ' }, config)).rejects.toThrow(
+      /Invalid characters or format/,
+    )
+  })
+
+  it('should reject paths with multiple consecutive spaces', async () => {
+    await expect(handleConfig('set', { key: 'godot_path', value: '/usr/bin/godot  --editor' }, config)).rejects.toThrow(
+      /Invalid characters or format/,
+    )
+  })
+})


### PR DESCRIPTION
This PR addresses a security vulnerability where configuration values (specifically `timeout`, `project_path`, and `godot_path`) had insufficient input validation. This could potentially allow for argument injection or other malicious activities if these values were misused.

Key changes:
- Implemented strict numeric validation for the `timeout` configuration key, ensuring it's a positive integer string within a reasonable range (1ms to 1 hour).
- Tightened validation for `project_path` and `godot_path` to reject leading/trailing whitespace and multiple consecutive spaces, which are common patterns in injection attacks.
- Integrated `validateNoNewlines` from `security.ts` to ensure consistent newline rejection across all configuration values.
- Added a new security test suite `tests/security/config_validation.test.ts` to verify the new validation rules.
- Recorded learnings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [6054428853530729359](https://jules.google.com/task/6054428853530729359) started by @n24q02m*