### PR TITLE
[CLEANUP] Avoid direct console.error

### DIFF
--- a/err.txt
+++ b/err.txt
@@ -1,0 +1,2 @@
+info to stderr
+error to stderr

--- a/src/tools/helpers/logger.ts
+++ b/src/tools/helpers/logger.ts
@@ -1,3 +1,5 @@
+import { format } from 'node:util'
+
 /**
  * Centralized logger utility for Better Godot MCP.
  * All logs are written to stderr to avoid interfering with MCP JSON-RPC on stdout.
@@ -8,26 +10,34 @@ const PREFIX = `[${SERVER_NAME}]`
 
 const isDebugEnabled = process.env.DEBUG === 'true' || process.env.NODE_ENV === 'development'
 
+/**
+ * Internal helper to write formatted logs to stderr.
+ */
+function emit(message: string, args: unknown[], levelPrefix = ''): void {
+  const formattedMessage = format(`${PREFIX}${levelPrefix} ${message}`, ...args)
+  process.stderr.write(`${formattedMessage}\n`)
+}
+
 export const logger = {
   /**
    * Log an info message.
    */
   info: (message: string, ...args: unknown[]) => {
-    console.error(`${PREFIX} ${message}`, ...args)
+    emit(message, args)
   },
 
   /**
    * Log a warning message.
    */
   warn: (message: string, ...args: unknown[]) => {
-    console.error(`${PREFIX} WARN: ${message}`, ...args)
+    emit(message, args, ' WARN:')
   },
 
   /**
    * Log an error message.
    */
   error: (message: string, ...args: unknown[]) => {
-    console.error(`${PREFIX} ERROR: ${message}`, ...args)
+    emit(message, args, ' ERROR:')
   },
 
   /**
@@ -35,7 +45,7 @@ export const logger = {
    */
   debug: (message: string, ...args: unknown[]) => {
     if (isDebugEnabled) {
-      console.error(`${PREFIX} DEBUG: ${message}`, ...args)
+      emit(message, args, ' DEBUG:')
     }
   },
 }

--- a/tests/helpers/logger.test.ts
+++ b/tests/helpers/logger.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { logger } from '../../src/tools/helpers/logger.js'
+
+describe('logger helper', () => {
+  let stderrWriteSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    stderrWriteSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+  })
+
+  it('should write info logs to stderr with prefix', () => {
+    logger.info('test message')
+    expect(stderrWriteSpy).toHaveBeenCalledWith('[better-godot-mcp] test message\n')
+  })
+
+  it('should write warn logs to stderr with WARN prefix', () => {
+    logger.warn('test warning')
+    expect(stderrWriteSpy).toHaveBeenCalledWith('[better-godot-mcp] WARN: test warning\n')
+  })
+
+  it('should write error logs to stderr with ERROR prefix', () => {
+    logger.error('test error')
+    expect(stderrWriteSpy).toHaveBeenCalledWith('[better-godot-mcp] ERROR: test error\n')
+  })
+
+  it('should format additional arguments', () => {
+    logger.info('message %s %d', 'string', 123)
+    expect(stderrWriteSpy).toHaveBeenCalledWith('[better-godot-mcp] message string 123\n')
+  })
+
+  it('should handle object arguments', () => {
+    logger.info('data:', { foo: 'bar' })
+    expect(stderrWriteSpy).toHaveBeenCalledWith("[better-godot-mcp] data: { foo: 'bar' }\n")
+  })
+})


### PR DESCRIPTION
Refactored the centralized logger to use `process.stderr.write` and `node:util.format` instead of `console.error`. This avoids potential issues with environments that intercept global console methods and ensures that all diagnostic output is explicitly directed to `stderr`, which is critical for MCP servers where `stdout` is used for protocol communication.

A new test suite `tests/helpers/logger.test.ts` was added to verify the fix and ensure correct formatting of log messages.

---
*PR created automatically by Jules for task [11402602413358641614](https://jules.google.com/task/11402602413358641614) started by @n24q02m*