### PR TITLE
perf(help): optimize doc loading with EAFP pattern

### DIFF
--- a/src/tools/composite/help.ts
+++ b/src/tools/composite/help.ts
@@ -69,13 +69,16 @@ async function loadDoc(topic: string): Promise<string> {
   const docsDir = await getDocsDir()
   const docPath = join(docsDir, `${topic}.md`)
 
-  // Performance optimization: using async file reading instead of sync
-  // to avoid blocking the Node.js event loop during I/O operations
-  if (await pathExists(docPath)) {
+  // ⚡ Bolt: Using EAFP (Easier to Ask Forgiveness than Permission) pattern
+  // to avoid redundant pathExists() syscall before reading the file.
+  try {
     return await readFile(docPath, 'utf-8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return `No documentation available for: ${topic}. This tool may not be implemented yet.`
+    }
+    throw error
   }
-
-  return `No documentation available for: ${topic}. This tool may not be implemented yet.`
 }
 
 export async function handleHelp(action: string, args: Record<string, unknown>) {

--- a/tests/composite/help.test.ts
+++ b/tests/composite/help.test.ts
@@ -17,22 +17,21 @@ vi.mock('../../src/tools/helpers/paths.js', () => ({
 describe('handleHelp', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Default mock for getDocsDir() logic (marker file exists)
+    vi.mocked(pathExists).mockResolvedValue(true)
   })
 
   it('should return documentation for valid topic', async () => {
     // Mock valid documentation file
-    vi.mocked(pathExists).mockResolvedValue(true)
     vi.mocked(readFile).mockResolvedValue('# Test Documentation')
 
     const result = await handleHelp('project', {})
 
     expect(result.content[0].text).toContain('# Test Documentation')
-    expect(pathExists).toHaveBeenCalled()
     expect(readFile).toHaveBeenCalled()
   })
 
   it('should use tool_name from arguments if provided', async () => {
-    vi.mocked(pathExists).mockResolvedValue(true)
     vi.mocked(readFile).mockResolvedValue('# Scenes Documentation')
 
     const result = await handleHelp('help', { tool_name: 'scenes' })
@@ -48,12 +47,23 @@ describe('handleHelp', () => {
     await expect(handleHelp('help', { tool_name: 'invalid_tool' })).rejects.toThrow('Unknown tool: invalid_tool')
   })
 
-  it('should return fallback message if documentation file is missing', async () => {
-    // Mock file not found
-    vi.mocked(pathExists).mockResolvedValue(false)
+  it('should return fallback message if documentation file is missing (ENOENT)', async () => {
+    // Mock readFile throwing ENOENT (EAFP pattern)
+    const enoent = new Error('File not found') as NodeJS.ErrnoException
+    enoent.code = 'ENOENT'
+    vi.mocked(readFile).mockRejectedValue(enoent)
 
     const result = await handleHelp('project', {})
 
     expect(result.content[0].text).toContain('No documentation available for: project')
+  })
+
+  it('should rethrow non-ENOENT errors from readFile', async () => {
+    // Mock readFile throwing a different error (e.g., EACCES)
+    const eacces = new Error('Permission denied') as NodeJS.ErrnoException
+    eacces.code = 'EACCES'
+    vi.mocked(readFile).mockRejectedValue(eacces)
+
+    await expect(handleHelp('project', {})).rejects.toThrow('Permission denied')
   })
 })


### PR DESCRIPTION
Refactored loadDoc in help.ts to use the "Easier to Ask for Forgiveness than Permission" (EAFP) pattern. By wrapping readFile in a try...catch block instead of checking pathExists first, we eliminate redundant filesystem syscalls and improve performance.

Updated help.test.ts to mock readFile failure instead of pathExists failure to match the new implementation. All tests passed.

---
*PR created automatically by Jules for task [14403198765653940004](https://jules.google.com/task/14403198765653940004) started by @n24q02m*