### PR TITLE
⚡ Bolt: [performance improvement] Replace Regex matchAll with parseSceneContent

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -26,3 +26,6 @@
 2. Best prefix/containment match, defined as the one with the smallest absolute length difference relative to the input.
 3. Fuzzy bigram similarity (Dice coefficient) with a threshold > 0.4.
 This ensures that "create" matches "create" even if "create_node" appears earlier in the options list, and "cre" matches "create" over "create_node".
+## 2025-06-15 - [Avoid Regex matchAll for Scene Parsing]
+**Learning:** Using `content.matchAll()` with complex regular expressions to extract structured data (like animations or nodes) from Godot `.tscn` files is significantly slower and creates many temporary array/string allocations compared to a dedicated, single-pass parser.
+**Action:** Replace `matchAll` regex loops with the centralized `parseSceneContent` utility (which does a single-pass character-by-character scan) to extract `subResources` and `nodes`.

--- a/src/tools/composite/animation.ts
+++ b/src/tools/composite/animation.ts
@@ -7,6 +7,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, resolveProjectRoot, safeResolve } from '../helpers/paths.js'
+import { parseSceneContent } from '../helpers/scene-parser.js'
 import { validateNoNewlines } from '../helpers/security.js'
 
 async function resolveScene(projectRoot: string, scenePath: string): Promise<string> {
@@ -127,32 +128,38 @@ async function handleListAnimations(projectPath: string, args: Record<string, un
   const fullPath = await resolveScene(projectPath, scenePath)
   const content = await readFile(fullPath, 'utf-8')
 
+  const parsed = parseSceneContent(content)
   const animations: { name: string; duration?: string; loop?: boolean }[] = []
-  const animRegex = /\[sub_resource type="Animation" id="([^"]+)"\]/g
-  for (const match of content.matchAll(animRegex)) {
-    const id = match[1]
 
-    // Isolate each animation block to avoid O(N^2) slicing and cross-talk
-    const startIndex = match.index
-    let endIndex = content.indexOf('\n[', startIndex + 1)
-    if (endIndex === -1) endIndex = content.length
-    const block = content.slice(startIndex, endIndex)
+  for (let i = 0; i < parsed.subResources.length; i++) {
+    const subRes = parsed.subResources[i]
+    if (subRes.type === 'Animation') {
+      const nameProp = subRes.properties.resource_name
+      const durationProp = subRes.properties.length
+      const loopProp = subRes.properties.loop_mode
 
-    const nameMatch = block.match(/resource_name\s*=\s*"([^"]*)"/)
-    const durationMatch = block.match(/length\s*=\s*([\d.]+)/)
-    const loopMatch = block.match(/loop_mode\s*=\s*(\d+)/)
-    animations.push({
-      name: nameMatch?.[1] || id,
-      duration: durationMatch?.[1],
-      loop: loopMatch ? loopMatch[1] !== '0' : false,
-    })
+      let name = subRes.id
+      if (nameProp) {
+        name =
+          nameProp.length >= 2 && nameProp.charCodeAt(0) === 34 && nameProp.charCodeAt(nameProp.length - 1) === 34
+            ? nameProp.slice(1, -1)
+            : nameProp
+      }
+
+      animations.push({
+        name,
+        duration: durationProp,
+        loop: loopProp ? loopProp !== '0' : false,
+      })
+    }
   }
 
-  // Also find AnimationPlayer nodes
   const players: string[] = []
-  const playerRegex = /\[node name="([^"]+)" type="AnimationPlayer"/g
-  for (const playerMatch of content.matchAll(playerRegex)) {
-    players.push(playerMatch[1])
+  for (let i = 0; i < parsed.nodes.length; i++) {
+    const node = parsed.nodes[i]
+    if (node.type === 'AnimationPlayer') {
+      players.push(node.name)
+    }
   }
 
   return formatJSON({ scene: scenePath, players, animations })


### PR DESCRIPTION
⚡ Bolt: [performance improvement] Replace Regex matchAll with parseSceneContent

💡 What: Replaced the slow `content.matchAll` regex loops in `handleListAnimations` within `src/tools/composite/animation.ts` with the robust, single-pass `parseSceneContent` utility.
🎯 Why: Using `.matchAll()` inside file parsing functions causes excessive string allocation overhead and performance scaling issues with larger files.
📊 Impact: Considerably faster parsing times on larger `.tscn` files and elimination of unnecessary memory allocations.
🔬 Measurement: Run `tests/composite/animation.test.ts` to verify the functionality remains identical.

---
*PR created automatically by Jules for task [9634939211767752999](https://jules.google.com/task/9634939211767752999) started by @n24q02m*