### PR TITLE
🛡️ Sentinel: [HIGH] Fix CLI flag injection bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Weak matching logic in error suggestions can mislead users or automated agents into calling unintended tools if they make a typo that partially matches multiple tool names.
 **Learning:** Prioritizing exact matches and closer prefix matches reduces the risk of incorrect "Did you mean...?" suggestions.
 **Prevention:** Implemented a length-difference based tie-breaker for prefix matches in `findClosestMatch` to ensure the most specific match is suggested.
+
+## 2025-05-23 - [CLI Flag Injection Bypass]
+**Vulnerability:** Argument injection checks (like checking if a path starts with `-` to avoid it being interpreted as a CLI flag by an external command) could be bypassed by padding the input with leading spaces.
+**Learning:** Checking for `.startsWith('-')` without trimming first allows malicious inputs like `" --flag"` to bypass validation and get injected into command line executions.
+**Prevention:** Always `trim()` string arguments before performing `.startsWith('-')` or similar security checks against CLI flag injection.

--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -44,7 +44,7 @@ export async function handleConfig(action: string, args: Record<string, unknown>
       // and we use spawnSync/spawn (not shell exec), so it's not a security risk
       if (
         (key === 'project_path' || key === 'godot_path') &&
-        (typeof value !== 'string' || /[;&|`$(){}<>'"\0\n\r]/.test(value) || value.startsWith('-'))
+        (typeof value !== 'string' || /[;&|`$(){}<>'"\0\n\r]/.test(value) || value.trim().startsWith('-'))
       ) {
         throw new GodotMCPError(
           `Invalid characters or format in ${key}`,

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -107,7 +107,7 @@ export async function handleProject(action: string, args: Record<string, unknown
           'Provide project_path argument or set it via config.set action.',
         )
       }
-      if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
+      if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
         throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
       }
       const info = await parseProjectGodot(safeResolve(config.projectPath || process.cwd(), projectPath))
@@ -128,7 +128,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       const projectPath = (args.project_path as string) || config.projectPath
       if (!projectPath)
         throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
-      if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
+      if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
         throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
       }
 
@@ -139,7 +139,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (scenePath && (scenePath.includes('\n') || scenePath.includes('\r'))) {
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain newlines.')
       }
-      if (scenePath?.startsWith('-')) {
+      if (scenePath?.trim().startsWith('-')) {
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not start with a hyphen.')
       }
 
@@ -193,7 +193,7 @@ export async function handleProject(action: string, args: Record<string, unknown
     case 'settings_get': {
       const projectPath = (args.project_path as string) || config.projectPath
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
-      if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
+      if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
         throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
       }
       const key = args.key as string
@@ -219,7 +219,7 @@ export async function handleProject(action: string, args: Record<string, unknown
     case 'settings_set': {
       const projectPath = (args.project_path as string) || config.projectPath
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
-      if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
+      if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
         throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
       }
       const key = args.key as string
@@ -257,7 +257,7 @@ export async function handleProject(action: string, args: Record<string, unknown
         throw new GodotMCPError('Godot not found', 'GODOT_NOT_FOUND', 'Set GODOT_PATH env var or install Godot.')
       const projectPath = (args.project_path as string) || config.projectPath
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
-      if (typeof args.project_path === 'string' && args.project_path.startsWith('-')) {
+      if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
         throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
       }
       const preset = args.preset as string
@@ -274,7 +274,7 @@ export async function handleProject(action: string, args: Record<string, unknown
         throw new GodotMCPError('Invalid arguments', 'INVALID_ARGS', 'Preset and output path must be strings.')
       }
 
-      if (preset.startsWith('-') || outputPath.startsWith('-')) {
+      if (preset.trim().startsWith('-') || outputPath.trim().startsWith('-')) {
         throw new GodotMCPError(
           'Invalid arguments',
           'INVALID_ARGS',


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability: Argument injection checks (like checking if a path or preset starts with `-` to avoid it being interpreted as a CLI flag by Godot) could be bypassed by padding the input with leading spaces (e.g. `" --script=malicious.gd"`).

🎯 Impact: A malicious actor could inject arbitrary command-line flags into Godot headless or editor processes, potentially leading to arbitrary code execution, file system manipulation, or bypassing security controls.

🔧 Fix: Added `.trim()` calls before all `.startsWith('-')` security checks in `src/tools/composite/project.ts` and `src/tools/composite/config.ts`. This ensures that padded arguments are correctly identified as flags and rejected.

✅ Verification: Run the unit test suite with `bun run test` to verify the fix works and does not introduce regressions. The `project-security.test.ts` suite passes, including tests that explicitly check for CLI flag rejection. Code review was also performed.

---
*PR created automatically by Jules for task [11625975539051686154](https://jules.google.com/task/11625975539051686154) started by @n24q02m*