### PR TITLE
fix: trim whitespace before hyphen check in config path validation

### DIFF
--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -44,7 +44,7 @@ export async function handleConfig(action: string, args: Record<string, unknown>
       // and we use spawnSync/spawn (not shell exec), so it's not a security risk
       if (
         (key === 'project_path' || key === 'godot_path') &&
-        (typeof value !== 'string' || /[;&|`$(){}<>'"\0\n\r]/.test(value) || value.startsWith('-'))
+        (typeof value !== 'string' || /[;&|`$(){}<>'"\0\n\r]/.test(value) || value.trim().startsWith('-'))
       ) {
         throw new GodotMCPError(
           `Invalid characters or format in ${key}`,


### PR DESCRIPTION
Completes the CLI-flag-injection hardening: project.ts already trims before the `.startsWith('-')` guard at all 7 action sites, but the config `set` validation (config.ts) still used a bare `value.startsWith('-')`, so a project_path/godot_path padded with leading whitespace ('  --flag') slipped past it. This mirrors the project.ts pattern for consistency. Strictly tightening: can only reject more pathological inputs, never a valid path. No-shell (spawn/execFile) so the practical risk is low; this closes the residual cleanly.

Supersedes the conflicting duplicate PRs #879/#890/#892/#895/#896.