### PR TITLE
⚡ Bolt: Avoid split('\n') for line-by-line parsing in Input Map

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -38,3 +38,7 @@ This ensures that "create" matches "create" even if "create_node" appears earlie
 ## 2026-06-20 - Pre-compile Regex in hot paths
 **Learning:** Evaluating regular expressions directly via `String.prototype.match()` in hot paths (like parsing metadata for every resource) unnecessarily recreates RegExp instances and allocates arrays. Using a module-level pre-compiled RegExp with `RegExp.prototype.exec()` reduces these overheads and handles iterations more efficiently.
 **Action:** Extract inline regular expressions to module-scoped constants and use `exec()` for faster parsing in large files or deep iterations.
+
+## 2025-06-18 - [Avoid `split('\\n')` for line-by-line parsing in Input Map]
+**Learning:** Using `split('\n')` creates an array of strings in memory. This array allocation and string duplication can be a bottleneck when repeatedly iterating through Godot's `project.godot` lines, especially if the file is large and parsing happens frequently in hot paths.
+**Action:** Replace `split('\n')` combined with iteration (e.g. `for (let i = 0; i < lines.length; i++)`) with a `while` loop that uses `indexOf('\n', pos)` and `slice(pos, lineEnd)` to extract lines continuously without intermediate array allocations.

--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -252,18 +252,24 @@ function transformInputMap(
   targetAction: string,
   transformer: (actionBlock: string) => string | null,
 ): { updated: string; found: boolean } {
-  const lines = content.split('\n')
+  // ⚡ Bolt: Removed content.split('\n') to avoid array allocation overhead on large files.
   const result: string[] = []
   let inInputSection = false
   let foundAction = false
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]
+  let pos = 0
+  const len = content.length
+
+  while (pos < len || (pos === len && len > 0 && content.endsWith('\n'))) {
+    const nextNewline = content.indexOf('\n', pos)
+    const lineEnd = nextNewline === -1 ? len : nextNewline
+    const line = content.slice(pos, lineEnd)
     const trimmed = line.trim()
 
     if (trimmed === '[input]') {
       inInputSection = true
       result.push(line)
+      pos = nextNewline === -1 ? len + 1 : nextNewline + 1
       continue
     }
 
@@ -283,10 +289,18 @@ function transformInputMap(
           foundAction = true
           let block = line
           const rest = line.slice(eqIdx + 1).trim()
+
+          let nextPos = nextNewline === -1 ? len + 1 : nextNewline + 1
           if (rest.startsWith('{') && !rest.endsWith('}')) {
-            while (i + 1 < lines.length && !lines[i].trim().endsWith('}')) {
-              i++
-              block += `\n${lines[i]}`
+            while (nextPos < len) {
+              const innerNextNewline = content.indexOf('\n', nextPos)
+              const innerLineEnd = innerNextNewline === -1 ? len : innerNextNewline
+              const innerLine = content.slice(nextPos, innerLineEnd)
+              block += `\n${innerLine}`
+              nextPos = innerNextNewline === -1 ? len + 1 : innerNextNewline + 1
+              if (innerLine.trim().endsWith('}')) {
+                break
+              }
             }
           }
 
@@ -294,12 +308,14 @@ function transformInputMap(
           if (transformed !== null) {
             result.push(transformed)
           }
+          pos = nextPos
           continue
         }
       }
     }
 
     result.push(line)
+    pos = nextNewline === -1 ? len + 1 : nextNewline + 1
   }
 
   return { updated: result.join('\n'), found: foundAction }


### PR DESCRIPTION
💡 **What**: The optimization implemented
Replaced the `content.split('\n')` operation in `transformInputMap` within `src/tools/composite/input-map.ts` with a `while` loop that leverages `indexOf('\n', pos)` and `slice(pos, lineEnd)` to extract lines continuously without intermediate array allocations.

🎯 **Why**: The performance problem it solves
Using `split('\n')` creates an array of strings in memory. This array allocation and string duplication can be a bottleneck when repeatedly iterating through Godot's `project.godot` lines, especially if the file is large and parsing happens frequently in hot paths.

📊 **Impact**: Expected performance improvement
Reduces peak memory usage and garbage collection overhead by eliminating the instantiation of a full-file array of strings in `transformInputMap`.

🔬 **Measurement**: How to verify the improvement
Verified by running the test suite (`bun run test`) which confirms no core logic or line-by-line parsing semantics are broken by the change. Tests confirm that the exact string building mechanics and handling of trailing newlines are faithfully replicated without the array overhead.

---
*PR created automatically by Jules for task [212087668551984096](https://jules.google.com/task/212087668551984096) started by @n24q02m*