### PR TITLE
⚡ Bolt: Optimize Godot structural type RegExp parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,7 @@ This ensures that "create" matches "create" even if "create_node" appears earlie
 ## 2025-06-11 - [Optimize redundant pathExists checks in tilemap tool]
 **Learning:** Sequential `pathExists` followed by I/O operations like `readFile` or `writeFile` causes redundant filesystem calls, which can impact performance. Additionally, checking `pathExists` before creating a file is not thread-safe/atomic.
 **Action:** Replaced `pathExists` followed by `readFile` with direct `readFile` wrapped in a `try...catch` handling `ENOENT`. Replaced `pathExists` + `writeFile` with `writeFile` using `flag: 'wx'` to atomically check for existence and create the file, catching `EEXIST`. Applied in `src/tools/composite/tilemap.ts`.
+
+## 2025-06-20 - [Optimize parseGodotValue structural types RegExp matching]
+**Learning:** Checking for string prefixes (`Vector2(`, `Rect2(`, etc.) is faster than immediately passing the string into a regular expression. Also, when extracting groups from non-global regular expressions, `REGEX.exec(string)` is generally preferred over `string.match(REGEX)`.
+**Action:** Guard Regular Expression evaluations in `parseGodotValue` with `.startsWith()` string checks, and replaced `.match()` with `.exec()`. Added `// ⚡ Bolt:` comments to indicate intentional performance optimization.

--- a/src/tools/helpers/godot-types.ts
+++ b/src/tools/helpers/godot-types.ts
@@ -75,49 +75,56 @@ export function parseGodotValue(expr: string, _depth = 0): unknown {
   // ⚡ Bolt: Fast path for checking structural Godot types by checking first character
   // Vector2, Vector2i, Vector3 ('V' = 86)
   if (firstChar === 86) {
-    const v2Match = trimmed.match(V2_RE)
-    if (v2Match) {
-      return { x: Number.parseFloat(v2Match[1]), y: Number.parseFloat(v2Match[2]) } as Vector2
-    }
-
-    const v2iMatch = trimmed.match(V2I_RE)
-    if (v2iMatch) {
-      return { x: Number.parseInt(v2iMatch[1], 10), y: Number.parseInt(v2iMatch[2], 10) } as Vector2
-    }
-
-    const v3Match = trimmed.match(V3_RE)
-    if (v3Match) {
-      return {
-        x: Number.parseFloat(v3Match[1]),
-        y: Number.parseFloat(v3Match[2]),
-        z: Number.parseFloat(v3Match[3]),
-      } as Vector3
+    // ⚡ Bolt: Fast-path with startsWith and exec to minimize RegExp matching overhead
+    if (trimmed.startsWith('Vector2(')) {
+      const v2Match = V2_RE.exec(trimmed)
+      if (v2Match) {
+        return { x: Number.parseFloat(v2Match[1]), y: Number.parseFloat(v2Match[2]) } as Vector2
+      }
+    } else if (trimmed.startsWith('Vector2i(')) {
+      const v2iMatch = V2I_RE.exec(trimmed)
+      if (v2iMatch) {
+        return { x: Number.parseInt(v2iMatch[1], 10), y: Number.parseInt(v2iMatch[2], 10) } as Vector2
+      }
+    } else if (trimmed.startsWith('Vector3(')) {
+      const v3Match = V3_RE.exec(trimmed)
+      if (v3Match) {
+        return {
+          x: Number.parseFloat(v3Match[1]),
+          y: Number.parseFloat(v3Match[2]),
+          z: Number.parseFloat(v3Match[3]),
+        } as Vector3
+      }
     }
   }
 
   // Color ('C' = 67)
   if (firstChar === 67) {
-    const colorMatch = trimmed.match(COLOR_RE)
-    if (colorMatch) {
-      return {
-        r: Number.parseFloat(colorMatch[1]),
-        g: Number.parseFloat(colorMatch[2]),
-        b: Number.parseFloat(colorMatch[3]),
-        a: colorMatch[4] ? Number.parseFloat(colorMatch[4]) : 1.0,
-      } as GodotColor
+    if (trimmed.startsWith('Color(')) {
+      const colorMatch = COLOR_RE.exec(trimmed)
+      if (colorMatch) {
+        return {
+          r: Number.parseFloat(colorMatch[1]),
+          g: Number.parseFloat(colorMatch[2]),
+          b: Number.parseFloat(colorMatch[3]),
+          a: colorMatch[4] ? Number.parseFloat(colorMatch[4]) : 1.0,
+        } as GodotColor
+      }
     }
   }
 
   // Rect2 ('R' = 82)
   if (firstChar === 82) {
-    const rectMatch = trimmed.match(RECT2_RE)
-    if (rectMatch) {
-      return {
-        x: Number.parseFloat(rectMatch[1]),
-        y: Number.parseFloat(rectMatch[2]),
-        w: Number.parseFloat(rectMatch[3]),
-        h: Number.parseFloat(rectMatch[4]),
-      } as Rect2
+    if (trimmed.startsWith('Rect2(')) {
+      const rectMatch = RECT2_RE.exec(trimmed)
+      if (rectMatch) {
+        return {
+          x: Number.parseFloat(rectMatch[1]),
+          y: Number.parseFloat(rectMatch[2]),
+          w: Number.parseFloat(rectMatch[3]),
+          h: Number.parseFloat(rectMatch[4]),
+        } as Rect2
+      }
     }
   }
 


### PR DESCRIPTION
💡 What: Implemented a fast-path prefix check (`.startsWith()`) before executing Regular Expressions for Godot structural types (`Vector2`, `Vector3`, `Color`, `Rect2`). Also replaced `.match()` with `.exec()`.
🎯 Why: Running regular expressions against every parsed Godot value expression adds unnecessary parsing overhead.
📊 Impact: Minimizes RegExp evaluation and array allocation overhead for non-matching strings by bailing early.
🔬 Measurement: Run the test suite (`bun run test tests/helpers/godot-types.test.ts`) to verify type parsing functionality is fully preserved.

---
*PR created automatically by Jules for task [18258947851837248174](https://jules.google.com/task/18258947851837248174) started by @n24q02m*