### PR TITLE
🛡️ Sentinel: Fix Flag Injection Vulnerability in handleEditor

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** Argument injection in CLI-invoking tools.
 **Learning:** Checking for leading hyphens using `startsWith('-')` on untrusted input can be bypassed if the attacker pads the flag with leading spaces (e.g., " -s malicious.gd").
 **Prevention:** Always `.trim()` user-provided strings before performing safety checks like hyphen-prefixed flag detection.
+## 2026-06-21 - Flag Injection via Tool Argument Validation Gap
+**Vulnerability:** Flag injection in CLI-invoking tools.
+**Learning:** Checking for leading hyphens must be applied consistently across all tools that accept file paths or similar arguments passed to external commands. The `handleEditor` tool lacked the protection already present in `handleProject`.
+**Prevention:** Apply the `.trim().startsWith('-')` check universally to any untrusted argument that will eventually be used as an argument to a spawned process.

--- a/src/tools/composite/editor.ts
+++ b/src/tools/composite/editor.ts
@@ -46,6 +46,9 @@ export async function handleEditor(action: string, args: Record<string, unknown>
       if (!projectPath) {
         throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
       }
+      if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
+        throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
+      }
 
       const { pid } = launchGodotEditor(config.godotPath, safeResolve(config.projectPath || process.cwd(), projectPath))
       if (pid) {

--- a/tests/composite/editor.test.ts
+++ b/tests/composite/editor.test.ts
@@ -56,6 +56,14 @@ describe('editor', () => {
 
       expect(result.content[0].text).toContain('Godot editor launched')
     })
+
+    it('should reject project_path starting with a hyphen', async () => {
+      config = makeConfig({ godotPath: '/usr/bin/godot', projectPath })
+
+      await expect(handleEditor('launch', { project_path: '--some-arg' }, config)).rejects.toThrow(
+        'Invalid project path',
+      )
+    })
   })
 
   // ==========================================


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Flag Injection via `project_path` in `handleEditor`

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `handleEditor` action lacked a validation check for `args.project_path` starting with a hyphen. This could allow an attacker or automated system to inject arbitrary CLI flags directly to the Godot binary during process spawning.
🎯 **Impact:** Unauthorized flag injection when launching the Godot editor (`--script`, etc.), potentially leading to unintended code execution.
🔧 **Fix:** Added a `.trim().startsWith('-')` validation check in `src/tools/composite/editor.ts` before spawning the process, mirroring the protection already present in `src/tools/composite/project.ts`.
✅ **Verification:** Verified by checking that `pnpm test` successfully ran the newly added unit tests in `tests/composite/editor.test.ts` where passing `--some-arg` correctly throws an 'Invalid project path' error.

---
*PR created automatically by Jules for task [8528834442080853948](https://jules.google.com/task/8528834442080853948) started by @n24q02m*