### PR TITLE
[PERF] Inefficient array traversal in handleListNodes

### DIFF
--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -182,14 +182,15 @@ async function handleListNodes(projectPath: string, args: Record<string, unknown
   const scene = parseSceneContent(content)
   // ⚡ Bolt: Removed double .map() passes and expensive object spread (...node.properties) in mapToSceneNode.
   // Iterating scene.nodes directly in a single pass reduces O(N) allocation overhead for scenes with many nodes.
-  const nodes = []
-  for (const n of scene.nodes) {
-    nodes.push({
+  const nodes = new Array(scene.nodes.length)
+  for (let i = 0; i < scene.nodes.length; i++) {
+    const n = scene.nodes[i]
+    nodes[i] = {
       name: n.name,
       type: n.type || 'Node',
       parent: n.parent || '(root)',
       hasScript: !!n.properties.script,
-    })
+    }
   }
 
   return formatJSON({


### PR DESCRIPTION
This PR optimizes the `handleListNodes` function in `src/tools/composite/nodes.ts` by pre-allocating the `nodes` array and using index-based assignment. This avoids redundant O(N) allocation overhead from dynamic array resizing during `.push()` operations in scenes with many nodes.

Verified with existing tests and full suite (872/872 passed).

---
*PR created automatically by Jules for task [14009675432857137957](https://jules.google.com/task/14009675432857137957) started by @n24q02m*