### PR TITLE
[TEST] Missing test for countSubstring with special characters

### DIFF
--- a/tests/helpers/strings.test.ts
+++ b/tests/helpers/strings.test.ts
@@ -38,5 +38,19 @@ describe('strings helper', () => {
     it('should handle empty search string', () => {
       expect(countSubstring('banana', '')).toBe(0)
     })
+
+    it('should count occurrences with special characters', () => {
+      expect(countSubstring('a[b]c[b]d', '[b]')).toBe(2)
+      expect(countSubstring('a.b.c.d', '.')).toBe(3)
+      expect(countSubstring('a\\b\\c', '\\')).toBe(2)
+      expect(countSubstring('a$b$c', '$')).toBe(2)
+      expect(countSubstring('a(b)c(b)d', '(b)')).toBe(2)
+      expect(countSubstring('a*b*c', '*')).toBe(2)
+      expect(countSubstring('a+b+c', '+')).toBe(2)
+      expect(countSubstring('a?b?c', '?')).toBe(2)
+      expect(countSubstring('a{b}c{b}d', '{b}')).toBe(2)
+      expect(countSubstring('a|b|c', '|')).toBe(2)
+      expect(countSubstring('a^b^c', '^')).toBe(2)
+    })
   })
 })


### PR DESCRIPTION
Added a new test case to 'tests/helpers/strings.test.ts' to ensure 'countSubstring' correctly handles substrings containing special characters (e.g., '[', ']', '\', '$', '*'). This confirms that the literal matching implementation using 'indexOf' works as expected for these characters.

---
*PR created automatically by Jules for task [1500073794205038066](https://jules.google.com/task/1500073794205038066) started by @n24q02m*