### PR TITLE
[TEST] Missing test for Object type properties that don't match Vector/Color/Rect types in toGodotValue

### DIFF
--- a/tests/helpers/godot-types.test.ts
+++ b/tests/helpers/godot-types.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest'
 import type { GodotColor, Rect2, Vector2, Vector3 } from '../../src/tools/helpers/godot-types.js'
-import { parseGodotValue, toGodotValue } from '../../src/tools/helpers/godot-types.js'
+import { parseGodotValue, toGodotValue, serializeGodotObject } from '../../src/tools/helpers/godot-types.js'
 
 describe('godot-types', () => {
   // ==========================================
@@ -161,6 +161,10 @@ describe('godot-types', () => {
       expect(parseGodotValue('Vector2(1, a)')).toBe('Vector2(1, a)')
     })
 
+    it('should return malformed Vector2i as-is', () => {
+      expect(parseGodotValue('Vector2i(1)')).toBe('Vector2i(1)')
+    })
+
     it('should return malformed Vector3 as-is', () => {
       expect(parseGodotValue('Vector3(1, 2)')).toBe('Vector3(1, 2)')
     })
@@ -274,6 +278,58 @@ describe('godot-types', () => {
 
     it('should fallback to string representation for unhandled objects', () => {
       expect(toGodotValue({ unhandled: true })).toBe('[object Object]')
+    })
+
+    it('should serialize generic object {a: 1} to string representation', () => {
+      expect(toGodotValue({ a: 1 })).toBe('[object Object]')
+    })
+
+    it('should serialize undefined to its string representation', () => {
+      expect(toGodotValue(undefined)).toBe('undefined')
+    })
+
+    it('should fallback for partial Vector2-like objects', () => {
+      expect(toGodotValue({ x: 1 })).toBe('[object Object]')
+    })
+
+    it('should fallback for partial Vector3-like objects', () => {
+      expect(toGodotValue({ x: 1, z: 3 })).toBe('[object Object]')
+    })
+
+    it('should fallback for partial Rect2-like objects', () => {
+      // Note: { x: 0, y: 0, w: 100 } matches Vector2(0, 0) because it has x and y
+      expect(toGodotValue({ x: 0, w: 100, h: 50 })).toBe('[object Object]')
+    })
+
+    it('should fallback for partial Color-like objects', () => {
+      expect(toGodotValue({ r: 1, g: 1 })).toBe('[object Object]')
+    })
+  })
+
+  // ==========================================
+  // serializeGodotObject
+  // ==========================================
+  describe('serializeGodotObject', () => {
+    it('should serialize a Godot Object with properties', () => {
+      const props = {
+        name: 'Player',
+        health: 100,
+        position: { x: 10, y: 20 },
+      }
+      expect(serializeGodotObject('KinematicBody2D', props)).toBe(
+        'Object(KinematicBody2D,"name":"Player","health":100,"position":Vector2(10, 20))'
+      )
+    })
+
+    it('should handle Object with no properties', () => {
+      expect(serializeGodotObject('Node', {})).toBe('Object(Node)')
+    })
+
+    it('should ignore inherited properties', () => {
+      const proto = { inherited: true }
+      const props = Object.create(proto)
+      props.own = 'value'
+      expect(serializeGodotObject('Node', props)).toBe('Object(Node,"own":"value")')
     })
   })
 

--- a/tests/helpers/godot-types.test.ts
+++ b/tests/helpers/godot-types.test.ts
@@ -3,8 +3,15 @@
  */
 
 import { describe, expect, it } from 'vitest'
-import type { GodotColor, Rect2, Vector2, Vector3 } from '../../src/tools/helpers/godot-types.js'
-import { parseGodotValue, toGodotValue, serializeGodotObject } from '../../src/tools/helpers/godot-types.js'
+import {
+  type GodotColor,
+  type Rect2,
+  type Vector2,
+  type Vector3,
+  parseGodotValue,
+  serializeGodotObject,
+  toGodotValue,
+} from '../../src/tools/helpers/godot-types.js'
 
 describe('godot-types', () => {
   // ==========================================

--- a/tests/helpers/godot-types.test.ts
+++ b/tests/helpers/godot-types.test.ts
@@ -5,12 +5,12 @@
 import { describe, expect, it } from 'vitest'
 import {
   type GodotColor,
-  type Rect2,
-  type Vector2,
-  type Vector3,
   parseGodotValue,
+  type Rect2,
   serializeGodotObject,
   toGodotValue,
+  type Vector2,
+  type Vector3,
 } from '../../src/tools/helpers/godot-types.js'
 
 describe('godot-types', () => {
@@ -324,7 +324,7 @@ describe('godot-types', () => {
         position: { x: 10, y: 20 },
       }
       expect(serializeGodotObject('KinematicBody2D', props)).toBe(
-        'Object(KinematicBody2D,"name":"Player","health":100,"position":Vector2(10, 20))'
+        'Object(KinematicBody2D,"name":"Player","health":100,"position":Vector2(10, 20))',
       )
     })
 


### PR DESCRIPTION
This PR addresses the missing test coverage in `src/tools/helpers/godot-types.ts`. 

Specifically:
- Added a test case to ensure `toGodotValue` correctly falls back to `String(value)` for generic objects (like `{a: 1}`) and objects that only partially match Godot types (like `{r: 1, g: 1}`).
- Added comprehensive tests for `serializeGodotObject`, which was previously uncovered. This includes testing for normal serialization, empty properties, and ensuring inherited properties are ignored.
- Added a test case for malformed `Vector2i` strings in `parseGodotValue` to cover the edge case where the string starts correctly but fails the regex match.

The changes result in 100% line and function coverage for the targeted file.

---
*PR created automatically by Jules for task [8176682874887124460](https://jules.google.com/task/8176682874887124460) started by @n24q02m*