### PR TITLE
[TEST] Untested formatSuccess edge case with very long strings

### DIFF
--- a/tests/helpers/errors.test.ts
+++ b/tests/helpers/errors.test.ts
@@ -99,6 +99,13 @@ describe('errors', () => {
       expect(result.content[0].text).toBe('Operation complete')
       expect((result as Record<string, unknown>).isError).toBeUndefined()
     })
+
+    it('should handle very long strings', () => {
+      const longString = 'a'.repeat(1024 * 1024) // 1MB
+      const result = formatSuccess(longString)
+      expect(result.content[0].text).toBe(longString)
+      expect(result.content[0].text.length).toBe(1024 * 1024)
+    })
   })
 
   // ==========================================


### PR DESCRIPTION
Added a test case to verify that formatSuccess correctly handles extremely long strings (1MB) without modification or truncation.

---
*PR created automatically by Jules for task [18176743104674385485](https://jules.google.com/task/18176743104674385485) started by @n24q02m*