### PR TITLE
[FIX] Extract string trim logic to helper

### DIFF
--- a/project-settings-diff.txt
+++ b/project-settings-diff.txt
@@ -1,0 +1,58 @@
+<<<<<<< SEARCH
+import { readFile } from 'node:fs/promises'
+
+export interface ProjectSettings {
+=======
+import { readFile } from 'node:fs/promises'
+import { trimEnd, trimStart } from './strings'
+
+export interface ProjectSettings {
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+    // Trim line manually (whitespace <= 32)
+    let start = pos
+    let end = lineEnd
+    while (start < end && content.charCodeAt(start) <= 32) start++
+    while (end > start && content.charCodeAt(end - 1) <= 32) end--
+
+    // Skip empty lines or comments (59 is ';')
+=======
+    // Trim line manually (whitespace <= 32)
+    const start = trimStart(content, pos, lineEnd)
+    const end = trimEnd(content, start, lineEnd)
+
+    // Skip empty lines or comments (59 is ';')
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+      const eqIdx = content.indexOf('=', start)
+      if (eqIdx !== -1 && eqIdx < end) {
+        let keyEnd = eqIdx
+        while (keyEnd > start && content.charCodeAt(keyEnd - 1) <= 32) keyEnd--
+
+        let valStart = eqIdx + 1
+        while (valStart < end && content.charCodeAt(valStart) <= 32) valStart++
+
+        const key = content.slice(start, keyEnd)
+=======
+      const eqIdx = content.indexOf('=', start)
+      if (eqIdx !== -1 && eqIdx < end) {
+        const keyEnd = trimEnd(content, start, eqIdx)
+        const valStart = trimStart(content, eqIdx + 1, end)
+
+        const key = content.slice(start, keyEnd)
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+    // Trim line manually for logic
+    let start = pos
+    let end = lineEnd
+    while (start < end && content.charCodeAt(start) <= 32) start++
+    while (end > start && content.charCodeAt(end - 1) <= 32) end--
+
+    if (start < end) {
+=======
+    // Trim line manually for logic
+    const start = trimStart(content, pos, lineEnd)
+    const end = trimEnd(content, start, lineEnd)
+
+    if (start < end) {
+>>>>>>> REPLACE

--- a/scene-parser-diff.txt
+++ b/scene-parser-diff.txt
@@ -1,0 +1,61 @@
+<<<<<<< SEARCH
+import { readFile } from 'node:fs/promises'
+import { parseCommaSeparatedList } from './strings.js'
+
+/**
+=======
+import { readFile } from 'node:fs/promises'
+import { parseCommaSeparatedList, trimEnd, trimStart } from './strings.js'
+
+/**
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+    let start = startIndex
+    // Skip leading whitespace manually
+    while (start < endIndex && content.charCodeAt(start) <= 32) {
+      start++
+    }
+
+    let end = endIndex
+    // Skip trailing whitespace manually
+    while (end > start && content.charCodeAt(end - 1) <= 32) {
+      end--
+    }
+=======
+    const start = trimStart(content, startIndex, endIndex)
+    const end = trimEnd(content, start, endIndex)
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+    // Trim key
+    let kEnd = eqIdx
+    while (kEnd > start && content.charCodeAt(kEnd - 1) <= 32) {
+      kEnd--
+    }
+    const key = content.slice(start, kEnd)
+
+    // Trim value
+    let vStart = eqIdx + 1
+    while (vStart < end && content.charCodeAt(vStart) <= 32) {
+      vStart++
+    }
+    const value = content.slice(vStart, end)
+=======
+    // Trim key
+    const kEnd = trimEnd(content, start, eqIdx)
+    const key = content.slice(start, kEnd)
+
+    // Trim value
+    const vStart = trimStart(content, eqIdx + 1, end)
+    const value = content.slice(vStart, end)
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+    let start = pos
+    // Skip leading whitespace to find the first character of the line
+    while (start < nextNewline && content.charCodeAt(start) <= 32) start++
+
+    const firstChar = content.charCodeAt(start)
+=======
+    let start = trimStart(content, pos, nextNewline)
+
+    const firstChar = content.charCodeAt(start)
+>>>>>>> REPLACE

--- a/src/tools/helpers/project-settings.ts
+++ b/src/tools/helpers/project-settings.ts
@@ -8,6 +8,7 @@
  */
 
 import { readFile } from 'node:fs/promises'
+import { trimEnd, trimStart } from './strings'
 
 export interface ProjectSettings {
   sections: Map<string, Map<string, string>>
@@ -39,10 +40,8 @@ export function parseProjectSettingsContent(content: string): ProjectSettings {
     const lineEnd = nextNewline === -1 ? len : nextNewline
 
     // Trim line manually (whitespace <= 32)
-    let start = pos
-    let end = lineEnd
-    while (start < end && content.charCodeAt(start) <= 32) start++
-    while (end > start && content.charCodeAt(end - 1) <= 32) end--
+    const start = trimStart(content, pos, lineEnd)
+    const end = trimEnd(content, start, lineEnd)
 
     // Skip empty lines or comments (59 is ';')
     if (start === end || content.charCodeAt(start) === 59) {
@@ -63,11 +62,8 @@ export function parseProjectSettingsContent(content: string): ProjectSettings {
       // Key=value
       const eqIdx = content.indexOf('=', start)
       if (eqIdx !== -1 && eqIdx < end) {
-        let keyEnd = eqIdx
-        while (keyEnd > start && content.charCodeAt(keyEnd - 1) <= 32) keyEnd--
-
-        let valStart = eqIdx + 1
-        while (valStart < end && content.charCodeAt(valStart) <= 32) valStart++
+        const keyEnd = trimEnd(content, start, eqIdx)
+        const valStart = trimStart(content, eqIdx + 1, end)
 
         const key = content.slice(start, keyEnd)
         const value = content.slice(valStart, end)
@@ -121,10 +117,8 @@ export function setSettingInContent(content: string, path: string, value: string
     const lineEnd = nextNewline === -1 ? len : nextNewline
 
     // Trim line manually for logic
-    let start = pos
-    let end = lineEnd
-    while (start < end && content.charCodeAt(start) <= 32) start++
-    while (end > start && content.charCodeAt(end - 1) <= 32) end--
+    const start = trimStart(content, pos, lineEnd)
+    const end = trimEnd(content, start, lineEnd)
 
     if (start < end) {
       const firstChar = content.charCodeAt(start)

--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -12,7 +12,7 @@
  */
 
 import { readFile } from 'node:fs/promises'
-import { parseCommaSeparatedList } from './strings.js'
+import { parseCommaSeparatedList, trimEnd, trimStart } from './strings.js'
 
 /**
  * Fast-path string extraction for attributes like name="value"
@@ -145,17 +145,8 @@ export function parseSceneContent(content: string): ParsedScene {
     let endIndex = content.indexOf('\n', startIndex)
     if (endIndex === -1) endIndex = len
 
-    let start = startIndex
-    // Skip leading whitespace manually
-    while (start < endIndex && content.charCodeAt(start) <= 32) {
-      start++
-    }
-
-    let end = endIndex
-    // Skip trailing whitespace manually
-    while (end > start && content.charCodeAt(end - 1) <= 32) {
-      end--
-    }
+    const start = trimStart(content, startIndex, endIndex)
+    const end = trimEnd(content, start, endIndex)
 
     if (start < end) {
       const firstChar = content.charCodeAt(start)
@@ -326,17 +317,11 @@ function parseProperty(content: string, start: number, end: number, target: Reco
   const eqIdx = content.indexOf('=', start)
   if (eqIdx !== -1 && eqIdx < end) {
     // Trim key
-    let kEnd = eqIdx
-    while (kEnd > start && content.charCodeAt(kEnd - 1) <= 32) {
-      kEnd--
-    }
+    const kEnd = trimEnd(content, start, eqIdx)
     const key = content.slice(start, kEnd)
 
     // Trim value
-    let vStart = eqIdx + 1
-    while (vStart < end && content.charCodeAt(vStart) <= 32) {
-      vStart++
-    }
+    const vStart = trimStart(content, eqIdx + 1, end)
     const value = content.slice(vStart, end)
 
     target[key] = value
@@ -362,9 +347,7 @@ function transformSceneContent(
     let nextNewline = content.indexOf('\n', pos)
     if (nextNewline === -1) nextNewline = len
 
-    let start = pos
-    // Skip leading whitespace to find the first character of the line
-    while (start < nextNewline && content.charCodeAt(start) <= 32) start++
+    const start = trimStart(content, pos, nextNewline)
 
     const firstChar = content.charCodeAt(start)
     const line = content.slice(pos, nextNewline)

--- a/src/tools/helpers/strings.ts
+++ b/src/tools/helpers/strings.ts
@@ -47,3 +47,19 @@ export function countSubstring(str: string, search: string): number {
   }
   return count
 }
+
+/**
+ * Efficiently find the start of a trimmed range within a string.
+ */
+export function trimStart(str: string, start: number, end: number): number {
+  while (start < end && str.charCodeAt(start) <= 32) start++
+  return start
+}
+
+/**
+ * Efficiently find the end of a trimmed range within a string.
+ */
+export function trimEnd(str: string, start: number, end: number): number {
+  while (end > start && str.charCodeAt(end - 1) <= 32) end--
+  return end
+}

--- a/tests/helpers/strings.test.ts
+++ b/tests/helpers/strings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { countSubstring, parseCommaSeparatedList } from '../../src/tools/helpers/strings.js'
+import { countSubstring, parseCommaSeparatedList, trimEnd, trimStart } from '../../src/tools/helpers/strings.js'
 
 describe('strings helper', () => {
   describe('parseCommaSeparatedList', () => {
@@ -37,6 +37,40 @@ describe('strings helper', () => {
 
     it('should handle empty search string', () => {
       expect(countSubstring('banana', '')).toBe(0)
+    })
+  })
+
+  describe('trimStart', () => {
+    it('should trim leading whitespace', () => {
+      const s = '  hello'
+      expect(trimStart(s, 0, s.length)).toBe(2)
+    })
+
+    it('should handle no leading whitespace', () => {
+      const s = 'hello'
+      expect(trimStart(s, 0, s.length)).toBe(0)
+    })
+
+    it('should respect end boundary', () => {
+      const s = '    '
+      expect(trimStart(s, 0, 2)).toBe(2)
+    })
+  })
+
+  describe('trimEnd', () => {
+    it('should trim trailing whitespace', () => {
+      const s = 'hello  '
+      expect(trimEnd(s, 0, s.length)).toBe(5)
+    })
+
+    it('should handle no trailing whitespace', () => {
+      const s = 'hello'
+      expect(trimEnd(s, 0, s.length)).toBe(5)
+    })
+
+    it('should respect start boundary', () => {
+      const s = '    '
+      expect(trimEnd(s, 2, s.length)).toBe(2)
     })
   })
 })


### PR DESCRIPTION
This PR centralizes the manual string trimming logic used across high-performance parsers into reusable helpers in `src/tools/helpers/strings.ts`. This reduces code duplication while maintaining the zero-allocation performance characteristics required for large Godot file parsing.

Key changes:
- Created `trimStart` and `trimEnd` in `strings.ts`.
- Replaced 6 occurrences of manual loops with these helpers.
- Added comprehensive unit tests in `strings.test.ts`.
- Verified all 872 tests pass.

---
*PR created automatically by Jules for task [3687337659686752250](https://jules.google.com/task/3687337659686752250) started by @n24q02m*