### PR TITLE
[PERF] Inefficient node lookup by find

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -46,3 +46,7 @@ This ensures that "create" matches "create" even if "create_node" appears earlie
 ## 2025-06-25 - [Avoid RegExp.matchAll() for structural parsing]
 **Learning:** Using `RegExp.prototype.matchAll()` or `String.prototype.match()` to parse structured file formats (like Godot's `.tscn` files) requires executing complex regex patterns and creating intermediate array objects for each match. This is less efficient than using a centralized, single-pass structural parser (like `parseSceneContent`), which avoids regex execution overhead entirely.
 **Action:** Replace `matchAll` and `match` usage with existing single-pass structural parsers when analyzing `.tscn` contents. Reusing a standard parser prevents redundant parsing work, eliminates regular expression array allocations, and improves maintainability.
+
+## 2026-06-23 - Optimization of WinGet binary detection
+**Learning:** Using `array.find()` with inline regexes inside a loop can lead to redundant array iterations and excessive regex object allocations.
+**Action:** Replace multiple `find()` calls with a single manual `for` loop and use pre-compiled `RegExp` constants to minimize overhead in hot paths like file system scanning.

--- a/src/godot/detector.ts
+++ b/src/godot/detector.ts
@@ -26,6 +26,10 @@ import type { DetectionResult, GodotVersion } from './types.js'
 const GODOT_BINARY_NAMES = ['godot', 'godot4', 'godot-preview', 'Godot_v4']
 const MIN_VERSION = { major: 4, minor: 1 }
 
+// ⚡ Bolt: Pre-compile regexes for WinGet binary detection to avoid redundant allocations
+const WINGET_REGULAR_EXE_RE = /^Godot_v[\d.]+-\w+_win64\.exe$/i
+const WINGET_CONSOLE_EXE_RE = /^Godot_v[\d.]+-\w+_win64_console\.exe$/i
+
 /**
  * Parse Godot version string (e.g., "Godot Engine v4.6.stable.official")
  */
@@ -179,10 +183,21 @@ function findWinGetGodotBinaries(localAppData: string): string[] {
       const pkgDir = join(packagesDir, dir.name)
       try {
         const files = readdirSync(pkgDir)
-        // Prefer GUI version (has actual editor window), then console as fallback
-        const regularExe = files.find((f) => /^Godot_v[\d.]+-\w+_win64\.exe$/i.test(f) && !f.includes('console'))
+        // ⚡ Bolt: Single-pass manual loop to find both binaries and avoid redundant iterations/regex allocations
+        let regularExe: string | undefined
+        let consoleExe: string | undefined
+
+        for (let i = 0; i < files.length; i++) {
+          const f = files[i]
+          if (!regularExe && WINGET_REGULAR_EXE_RE.test(f) && !f.includes('console')) {
+            regularExe = f
+          } else if (!consoleExe && WINGET_CONSOLE_EXE_RE.test(f)) {
+            consoleExe = f
+          }
+          if (regularExe && consoleExe) break
+        }
+
         if (regularExe) results.push(join(pkgDir, regularExe))
-        const consoleExe = files.find((f) => /^Godot_v[\d.]+-\w+_win64_console\.exe$/i.test(f))
         if (consoleExe) results.push(join(pkgDir, consoleExe))
       } catch {
         // Skip unreadable package directories


### PR DESCRIPTION
Refactored `findWinGetGodotBinaries` in `src/godot/detector.ts` to optimize Godot binary detection in WinGet packages.

Changes:
- Pre-compiled WinGet binary regexes (`WINGET_REGULAR_EXE_RE`, `WINGET_CONSOLE_EXE_RE`) to avoid redundant allocations.
- Replaced multiple `files.find()` calls with a single manual `for` loop to scan the directory in one pass.
- Added a `break` condition when both regular and console binaries are found to minimize unnecessary iterations.

This optimization reduces CPU overhead and memory pressure during system-wide Godot detection on Windows.

---
*PR created automatically by Jules for task [15430038617254891948](https://jules.google.com/task/15430038617254891948) started by @n24q02m*