### PR TITLE
[TEST] Missing error test for throwUnknownAction truncating extremely long valid actions list

### DIFF
--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -174,9 +174,14 @@ export function throwUnknownAction(action: string, validActions: string[]): neve
   const safeAction = action.length > 100 ? `${action.slice(0, 100)}...` : action
   const closest = findClosestMatch(safeAction, validActions)
   const suggestion = closest ? ` Did you mean '${closest}'?` : ''
+  const validActionsList =
+    validActions.length > 20
+      ? `${validActions.slice(0, 20).join(', ')}... and ${validActions.length - 20} more`
+      : validActions.join(', ')
+
   throw new GodotMCPError(
     `Unknown action: ${safeAction}.${suggestion}`,
     'INVALID_ACTION',
-    `Valid actions: ${validActions.join(', ')}. Use help tool for full docs.`,
+    `Valid actions: ${validActionsList}. Use help tool for full docs.`,
   )
 }

--- a/tests/helpers/errors.test.ts
+++ b/tests/helpers/errors.test.ts
@@ -260,5 +260,19 @@ describe('errors', () => {
         expect(error.message.length).toBeLessThan(250)
       }
     })
+
+    it('should truncate extremely long valid actions list in the suggestion field', () => {
+      const manyActions = Array.from({ length: 100 }, (_, i) => `action_${i}`)
+      try {
+        throwUnknownAction('unknown', manyActions)
+      } catch (err) {
+        const error = err as GodotMCPError
+        // Should show 20 actions and "and 80 more"
+        expect(error.suggestion).toContain('action_0, action_1,')
+        expect(error.suggestion).toContain('action_19...')
+        expect(error.suggestion).toContain('and 80 more')
+        expect(error.suggestion).not.toContain('action_20')
+      }
+    })
   })
 })


### PR DESCRIPTION
Modified `throwUnknownAction` in `src/tools/helpers/errors.ts` to truncate the `validActions` suggestion list. If the list contains more than 20 actions, it now shows the first 20 and appends "... and N more". This prevents log bloat and memory issues for tools with many actions. 

Added a test case in `tests/helpers/errors.test.ts` to ensure this truncation works as expected.

---
*PR created automatically by Jules for task [13465871589344365317](https://jules.google.com/task/13465871589344365317) started by @n24q02m*