### PR TITLE
[TEST] Missing array bounds test for getSetting in project-settings.ts

### DIFF
--- a/tests/helpers/project-settings.test.ts
+++ b/tests/helpers/project-settings.test.ts
@@ -158,6 +158,33 @@ describe('project-settings', () => {
       const settings = parseProjectSettingsContent(SAMPLE_PROJECT_GODOT)
       expect(getSetting(settings, 'application')).toBeUndefined()
     })
+
+    it('should return undefined for empty path', () => {
+      const settings = parseProjectSettingsContent(SAMPLE_PROJECT_GODOT)
+      expect(getSetting(settings, '')).toBeUndefined()
+    })
+
+    it('should return undefined for path starting with slash (empty section)', () => {
+      const settings = parseProjectSettingsContent('[application]\nkey="value"')
+      expect(getSetting(settings, '/key')).toBeUndefined()
+    })
+
+    it('should return undefined for path ending with slash (empty key)', () => {
+      const settings = parseProjectSettingsContent('[application]\nkey="value"')
+      expect(getSetting(settings, 'application/')).toBeUndefined()
+    })
+
+    it('should return undefined for path consisting only of a slash', () => {
+      const settings = parseProjectSettingsContent(SAMPLE_PROJECT_GODOT)
+      expect(getSetting(settings, '/')).toBeUndefined()
+    })
+
+    it('should handle path with multiple slashes correctly', () => {
+      const content = '[audio_canvas_events]\ncanvas_item/audio_bus_name="Master"'
+      const settings = parseProjectSettingsContent(content)
+      // Section: audio_canvas_events, Key: canvas_item/audio_bus_name
+      expect(getSetting(settings, 'audio_canvas_events/canvas_item/audio_bus_name')).toBe('"Master"')
+    })
   })
 
   // ==========================================


### PR DESCRIPTION
This PR adds missing edge-case tests for the getSetting function in src/tools/helpers/project-settings.ts. These tests ensure that the function handles various malformed or unusual path strings (such as empty segments, multiple slashes, or missing delimiters) correctly and achieves full code coverage.

---
*PR created automatically by Jules for task [10435150758381104680](https://jules.google.com/task/10435150758381104680) started by @n24q02m*