### PR TITLE
[SECURITY] Potential Path Traversal in File Operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -46,3 +46,6 @@ This ensures that "create" matches "create" even if "create_node" appears earlie
 ## 2025-06-25 - [Avoid RegExp.matchAll() for structural parsing]
 **Learning:** Using `RegExp.prototype.matchAll()` or `String.prototype.match()` to parse structured file formats (like Godot's `.tscn` files) requires executing complex regex patterns and creating intermediate array objects for each match. This is less efficient than using a centralized, single-pass structural parser (like `parseSceneContent`), which avoids regex execution overhead entirely.
 **Action:** Replace `matchAll` and `match` usage with existing single-pass structural parsers when analyzing `.tscn` contents. Reusing a standard parser prevents redundant parsing work, eliminates regular expression array allocations, and improves maintainability.
+## 2025-05-14 - [SECURITY] Unified Project Root Resolution
+**Learning:** Using a centralized `resolveProjectRoot` helper not only improves security by ensuring consistent path confinement but also simplifies handler logic by removing redundant `safeResolve` calls.
+**Action:** Prefer `resolveProjectRoot` for all tools that accept a `project_path` argument to maintain a unified security posture and cleaner code.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** Argument injection in CLI-invoking tools.
 **Learning:** Checking for leading hyphens using `startsWith('-')` on untrusted input can be bypassed if the attacker pads the flag with leading spaces (e.g., " -s malicious.gd").
 **Prevention:** Always `.trim()` user-provided strings before performing safety checks like hyphen-prefixed flag detection.
+## 2025-05-14 - [SECURITY] Potential Path Traversal in File Operations
+**Vulnerability:** Weak path resolution in `scenes.ts` and a bug in the custom `canonicalize` logic in `paths.ts`.
+**Learning:** Manual path component extraction using `slice(parent.length + 1)` is brittle and fails when the parent is the filesystem root (e.g., `/` has length 1, so it skips the first 2 characters of `/foo`, resulting in `oo`).
+**Prevention:** Always use standard path utilities like `basename()` for component extraction. Centralize project root resolution using `resolveProjectRoot` to ensure consistent confinement checks across all tool handlers.

--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -6,7 +6,7 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { pathExists, safeResolve } from '../helpers/paths.js'
+import { pathExists, resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 import {
   getNodeProperty,
   parseSceneContent,
@@ -263,8 +263,7 @@ const NODE_ACTIONS: Record<
 }
 
 export async function handleNodes(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const baseProjectPath = config.projectPath || process.cwd()
-  const projectPath = args.project_path ? safeResolve(baseProjectPath, args.project_path as string) : baseProjectPath
+  const projectPath = resolveProjectRoot(args.project_path, config.projectPath)
 
   const handler = NODE_ACTIONS[action]
   if (handler) {

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -7,7 +7,7 @@ import { copyFile, mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/p
 import { basename, dirname, join } from 'node:path'
 import type { GodotConfig, SceneInfo } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { pathExists, safeResolve } from '../helpers/paths.js'
+import { pathExists, resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 import { setSettingInContent } from '../helpers/project-settings.js'
 import { parseSceneContent } from '../helpers/scene-parser.js'
 
@@ -44,18 +44,13 @@ function generateTscnContent(rootName: string, rootType: string): string {
 }
 
 function validateSceneArgs(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const baseDir = config.projectPath || process.cwd()
-  // Validate args.project_path against the trusted baseDir to prevent path traversal vulnerabilities
-  const projectPath = args.project_path
-    ? safeResolve(baseDir, args.project_path as string)
-    : config.projectPath || undefined
-  const scenePath = args.scene_path as string
-  const newPath = args.new_path as string
-
-  // project_path required
-  if (['create', 'list', 'set_main'].includes(action) && !projectPath) {
+  const projectPathArg = args.project_path
+  if (!projectPathArg && !config.projectPath && ['create', 'list', 'set_main'].includes(action)) {
     throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
   }
+  const projectPath = resolveProjectRoot(args.project_path, config.projectPath)
+  const scenePath = args.scene_path as string
+  const newPath = args.new_path as string
 
   // scene_path required
   if (['create', 'info', 'delete', 'set_main'].includes(action) && !scenePath) {
@@ -88,7 +83,6 @@ function resolvePath(base: string | undefined, relativePath: string): string {
 }
 
 export async function handleScenes(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const baseDir = config.projectPath || process.cwd()
   const { projectPath, scenePath, newPath } = validateSceneArgs(action, args, config)
 
   switch (action) {
@@ -122,13 +116,11 @@ export async function handleScenes(action: string, args: Record<string, unknown>
     }
 
     case 'list': {
-      // projectPath is guaranteed
-      const resolvedPath = safeResolve(baseDir, projectPath as string)
-      const scenes = await findSceneFiles(resolvedPath)
+      const scenes = await findSceneFiles(projectPath)
 
       // OPTIMIZATION: Use substring and a pre-allocated array instead of .map() and node:path.relative
       // for significantly faster execution on large arrays of prefixed paths.
-      const prefixLen = resolvedPath.length + (resolvedPath.endsWith('/') || resolvedPath.endsWith('\\') ? 0 : 1)
+      const prefixLen = projectPath.length + (projectPath.endsWith('/') || projectPath.endsWith('\\') ? 0 : 1)
       const relativePaths = new Array(scenes.length)
       for (let i = 0; i < scenes.length; i++) {
         // ⚡ Bolt: Using replaceAll('\\', '/') avoids RegExp allocation overhead
@@ -136,7 +128,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       }
 
       return formatJSON({
-        project: resolvedPath,
+        project: projectPath,
         count: relativePaths.length,
         scenes: relativePaths,
       })
@@ -217,7 +209,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain quotes or newlines.')
       }
 
-      const configPath = join(safeResolve(baseDir, projectPath as string), 'project.godot')
+      const configPath = join(projectPath, 'project.godot')
 
       // ⚡ Bolt: Using replaceAll('\\', '/') avoids RegExp allocation overhead
       const resPath = `res://${scenePath.replaceAll('\\', '/')}`

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -7,7 +7,7 @@ import { mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { pathExists, safeResolve } from '../helpers/paths.js'
+import { pathExists, resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 import { parseSceneContent, updateNodeInScene } from '../helpers/scene-parser.js'
 
 const SCRIPT_TEMPLATES: Record<string, string> = {
@@ -263,9 +263,11 @@ async function deleteScript(args: Record<string, unknown>, resolvePath: (path: s
 }
 
 export async function handleScripts(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const baseDir = config.projectPath || process.cwd()
-  // Validate args.project_path against the trusted baseDir to prevent path traversal vulnerabilities
-  const projectPath = args.project_path ? safeResolve(baseDir, args.project_path as string) : config.projectPath
+  const projectPathArg = args.project_path
+  if (!projectPathArg && !config.projectPath) {
+    throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
+  }
+  const projectPath = resolveProjectRoot(args.project_path, config.projectPath)
 
   if (!projectPath && action !== 'list') {
     // List handles missing projectPath internally, but others need it for safeResolve base
@@ -292,7 +294,7 @@ export async function handleScripts(action: string, args: Record<string, unknown
     case 'attach':
       return attachScript(args, resolvePath)
     case 'list':
-      return listScripts(baseDir, projectPath ?? undefined)
+      return listScripts(config.projectPath || process.cwd(), projectPath ?? undefined)
     case 'delete':
       return deleteScript(args, resolvePath)
     default:

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,5 +1,5 @@
 import { realpathSync } from 'node:fs'
-import { dirname, isAbsolute, relative, resolve, sep } from 'node:path'
+import { basename, dirname, isAbsolute, relative, resolve, sep } from 'node:path'
 import { GodotMCPError } from './errors.js'
 
 /**
@@ -28,7 +28,7 @@ function canonicalize(targetPath: string): string {
         // the lexical resolution so brand-new trees still validate.
         return resolve(targetPath)
       }
-      tail.push(current.slice(parent.length + 1))
+      tail.push(basename(current))
       current = parent
     }
   }


### PR DESCRIPTION
Fixed a potential path traversal vulnerability by hardening the `canonicalize` helper and unifying project root resolution across composite tools. The `canonicalize` function was incorrectly slicing path components directly under the root, which could bypass containment checks. Additionally, `scenes`, `nodes`, and `scripts` tools were refactored to use `resolveProjectRoot` for consistent confinement to the trusted project base.

---
*PR created automatically by Jules for task [5862017781836314270](https://jules.google.com/task/5862017781836314270) started by @n24q02m*