### PR TITLE
⚡ Bolt: optimize file reading in nodes.ts by removing redundant pathExists checks

### DIFF
--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -6,7 +6,7 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { pathExists, safeResolve } from '../helpers/paths.js'
+import { safeResolve } from '../helpers/paths.js'
 import {
   getNodeProperty,
   parseSceneContent,
@@ -17,6 +17,18 @@ import {
 
 function resolveScenePath(projectPath: string, scenePath: string): string {
   return safeResolve(projectPath, scenePath)
+}
+
+// ⚡ Bolt: Using try-to-perform instead of pathExists to reduce redundant I/O calls
+async function readSceneFile(fullPath: string, scenePath: string): Promise<string> {
+  try {
+    return await readFile(fullPath, 'utf-8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
+    }
+    throw error
+  }
 }
 
 /**
@@ -83,10 +95,15 @@ async function handleAddNode(projectPath: string, args: Record<string, unknown>)
   }
 
   const fullPath = resolveScenePath(projectPath, scenePath)
-  if (!(await pathExists(fullPath)))
-    throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
-
-  const content = await readFile(fullPath, 'utf-8')
+  let content: string
+  try {
+    content = await readFile(fullPath, 'utf-8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
+    }
+    throw error
+  }
   const scene = parseSceneContent(content)
   const duplicate = scene.nodesByPath.get(`${parent}:${nodeName}`)
   if (duplicate) {
@@ -137,10 +154,7 @@ async function handleRemoveNode(projectPath: string, args: Record<string, unknow
   const { path: nodeName } = normalizeNodePath(rawName)
 
   const fullPath = resolveScenePath(projectPath, scenePath)
-  if (!(await pathExists(fullPath)))
-    throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
-
-  const content = await readFile(fullPath, 'utf-8')
+  const content = await readSceneFile(fullPath, scenePath)
   const updated = removeNodeFromContent(content, nodeName)
   await writeFile(fullPath, updated, 'utf-8')
 
@@ -160,10 +174,7 @@ async function handleRenameNode(projectPath: string, args: Record<string, unknow
   }
 
   const fullPath = resolveScenePath(projectPath, scenePath)
-  if (!(await pathExists(fullPath)))
-    throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
-
-  const content = await readFile(fullPath, 'utf-8')
+  const content = await readSceneFile(fullPath, scenePath)
   const updated = renameNodeInContent(content, nodeName, newName)
   await writeFile(fullPath, updated, 'utf-8')
 
@@ -175,10 +186,7 @@ async function handleListNodes(projectPath: string, args: Record<string, unknown
   if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
 
   const fullPath = resolveScenePath(projectPath, scenePath)
-  if (!(await pathExists(fullPath)))
-    throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
-
-  const content = await readFile(fullPath, 'utf-8')
+  const content = await readSceneFile(fullPath, scenePath)
   const scene = parseSceneContent(content)
   // ⚡ Bolt: Removed double .map() passes and expensive object spread (...node.properties) in mapToSceneNode.
   // Iterating scene.nodes directly in a single pass reduces O(N) allocation overhead for scenes with many nodes.
@@ -217,10 +225,7 @@ async function handleSetNodeProperty(projectPath: string, args: Record<string, u
   }
 
   const fullPath = resolveScenePath(projectPath, scenePath)
-  if (!(await pathExists(fullPath)))
-    throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
-
-  const content = await readFile(fullPath, 'utf-8')
+  const content = await readSceneFile(fullPath, scenePath)
   const updated = setNodePropertyInContent(content, nodeName, property, value)
   await writeFile(fullPath, updated, 'utf-8')
 
@@ -237,10 +242,7 @@ async function handleGetNodeProperty(projectPath: string, args: Record<string, u
   }
 
   const fullPath = resolveScenePath(projectPath, scenePath)
-  if (!(await pathExists(fullPath)))
-    throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
-
-  const content = await readFile(fullPath, 'utf-8')
+  const content = await readSceneFile(fullPath, scenePath)
   const scene = parseSceneContent(content)
   const val = getNodeProperty(scene, nodeName, property)
 


### PR DESCRIPTION
💡 What: Replaced redundant `pathExists` checks preceding `readFile` calls in `src/tools/composite/nodes.ts` with a new `readSceneFile` helper that uses a `try...catch` block.
🎯 Why: `pathExists` followed by `readFile` causes two filesystem calls for a single read operation and introduces a Time-of-Check to Time-of-Use (TOCTOU) race condition. EAFP (Easier to Ask for Forgiveness than Permission) is more efficient.
📊 Impact: Reduces filesystem syscalls for node operations (add, remove, rename, list, get_property, set_property) by approximately 50%.
🔬 Measurement: Verify by running `bun run test tests/composite/nodes.test.ts`. All 30 tests pass cleanly.

---
*PR created automatically by Jules for task [13009071136005588319](https://jules.google.com/task/13009071136005588319) started by @n24q02m*