### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Argument Injection via Space-Padded Flags in editor

### DIFF
--- a/src/tools/composite/editor.ts
+++ b/src/tools/composite/editor.ts
@@ -46,6 +46,9 @@ export async function handleEditor(action: string, args: Record<string, unknown>
       if (!projectPath) {
         throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
       }
+      if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
+        throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
+      }
 
       const { pid } = launchGodotEditor(config.godotPath, safeResolve(config.projectPath || process.cwd(), projectPath))
       if (pid) {

--- a/tests/composite/editor.test.ts
+++ b/tests/composite/editor.test.ts
@@ -56,6 +56,17 @@ describe('editor', () => {
 
       expect(result.content[0].text).toContain('Godot editor launched')
     })
+
+    it('should throw INVALID_ARGS when project_path starts with a hyphen', async () => {
+      config = makeConfig({ godotPath: '/usr/bin/godot', projectPath })
+
+      await expect(handleEditor('launch', { project_path: '--headless' }, config)).rejects.toThrow(
+        'Invalid project path',
+      )
+      await expect(handleEditor('launch', { project_path: ' -headless' }, config)).rejects.toThrow(
+        'Invalid project path',
+      )
+    })
   })
 
   // ==========================================


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Argument injection via space-padded flags in `handleEditor`'s `launch` action. The `project_path` argument was passed to the Godot CLI without checking if it started with a hyphen, which could allow an attacker to inject arbitrary CLI flags if they padded the input with spaces (e.g., `" --script=malicious.gd"`).
🎯 **Impact:** An attacker could execute arbitrary code by injecting flags like `--script` to the Godot executable if they can control the `project_path` argument to the `editor` MCP tool.
🔧 **Fix:** Added a strict `.trim().startsWith('-')` check on `args.project_path` in `src/tools/composite/editor.ts`, throwing an `INVALID_ARGS` error if it violates this policy. This matches existing validation logic in `project.ts` and `config.ts`. Also added tests to verify this check.
✅ **Verification:** Verified by running `bun run test tests/composite/editor.test.ts`. Tests correctly cover that the error is thrown.

---
*PR created automatically by Jules for task [13080730674609565251](https://jules.google.com/task/13080730674609565251) started by @n24q02m*