### PR TITLE
🛡️ Sentinel: Fix CLI Flag Injection in Editor Launch

### DIFF
--- a/src/tools/composite/editor.ts
+++ b/src/tools/composite/editor.ts
@@ -46,6 +46,9 @@ export async function handleEditor(action: string, args: Record<string, unknown>
       if (!projectPath) {
         throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
       }
+      if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
+        throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
+      }
 
       const { pid } = launchGodotEditor(config.godotPath, safeResolve(config.projectPath || process.cwd(), projectPath))
       if (pid) {

--- a/tests/composite/editor.test.ts
+++ b/tests/composite/editor.test.ts
@@ -49,6 +49,17 @@ describe('editor', () => {
       await expect(handleEditor('launch', {}, config)).rejects.toThrow('No project path specified')
     })
 
+    it('should throw INVALID_ARGS when project_path starts with a hyphen', async () => {
+      config = makeConfig({ godotPath: '/usr/bin/godot' })
+
+      await expect(handleEditor('launch', { project_path: '-headless' }, config)).rejects.toThrow(
+        'Invalid project path',
+      )
+      await expect(handleEditor('launch', { project_path: ' -headless' }, config)).rejects.toThrow(
+        'Invalid project path',
+      )
+    })
+
     it('should use config.projectPath when args.project_path not set', async () => {
       config = makeConfig({ godotPath: '/usr/bin/godot', projectPath })
 


### PR DESCRIPTION
## 🛡️ Sentinel: [HIGH] Fix CLI flag injection in Editor launch

### 🚨 Severity: HIGH
### 💡 Vulnerability: 
The Editor tool (`src/tools/composite/editor.ts`) accepted arbitrary string values for `args.project_path` without checking for a leading hyphen. This exposed the spawn command to CLI flag injection (e.g., passing `-headless`) when executing the Godot editor process via `spawn`.
### 🎯 Impact: 
An attacker could bypass normal tool arguments by providing command-line options that are parsed directly by the execution engine, resulting in unauthorized operations or state mutations not expected in standard runs.
### 🔧 Fix: 
Added a check to strictly validate that `args.project_path` (after `.trim()`) does not start with a hyphen.
### ✅ Verification: 
The patch was verified using unit tests in `tests/composite/editor.test.ts` where values like `-headless` and ` -headless` are correctly rejected. The full test suite passed successfully without errors.

---
*PR created automatically by Jules for task [7604706125727525435](https://jules.google.com/task/7604706125727525435) started by @n24q02m*