### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix argument injection in editor tool

### DIFF
--- a/src/tools/composite/editor.ts
+++ b/src/tools/composite/editor.ts
@@ -47,6 +47,10 @@ export async function handleEditor(action: string, args: Record<string, unknown>
         throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
       }
 
+      if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
+        throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
+      }
+
       const { pid } = launchGodotEditor(config.godotPath, safeResolve(config.projectPath || process.cwd(), projectPath))
       if (pid) {
         validatePid(pid)

--- a/tests/composite/editor.test.ts
+++ b/tests/composite/editor.test.ts
@@ -56,6 +56,12 @@ describe('editor', () => {
 
       expect(result.content[0].text).toContain('Godot editor launched')
     })
+
+    it('should reject project_path starting with a hyphen', async () => {
+      config = makeConfig({ godotPath: '/usr/bin/godot', projectPath })
+
+      await expect(handleEditor('launch', { project_path: ' -x' }, config)).rejects.toThrow('Invalid project path')
+    })
   })
 
   // ==========================================


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix argument injection in editor tool

🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The `handleEditor` function for the `launch` action spawned the Godot CLI without checking if the user-provided `project_path` started with a hyphen.
🎯 **Impact**: If an attacker supplies a value like ` --script=malicious.gd` as the `project_path`, they could inject arbitrary flags into the Godot CLI (e.g. running an arbitrary GDScript).
🔧 **Fix**: Implemented validation to reject `args.project_path` inputs that begin with a hyphen after trimming, preventing any possibility of interpreting paths as Godot CLI flags. Added test cases to ensure correct rejection behavior.
✅ **Verification**: Run `bun run test tests/composite/editor.test.ts`.

---
*PR created automatically by Jules for task [14442159648639181153](https://jules.google.com/task/14442159648639181153) started by @n24q02m*