### PR TITLE
🛡️ Sentinel: [HIGH] Fix prototype pollution in action dispatchers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Argument injection in CLI-invoking tools.
 **Learning:** Checking for leading hyphens using `startsWith('-')` on untrusted input can be bypassed if the attacker pads the flag with leading spaces (e.g., " -s malicious.gd").
 **Prevention:** Always `.trim()` user-provided strings before performing safety checks like hyphen-prefixed flag detection.
+
+## 2024-06-27 - Prototype Pollution / Property Injection in Action Dispatchers
+**Vulnerability:** Action dispatchers in composite tools (e.g. `nodes.ts`, `signals.ts`) were using plain object lookups (e.g. `const handler = NODE_ACTIONS[action]`) without `Object.hasOwn()` checks.
+**Learning:** This exposes the server to prototype pollution or property injection, where an attacker could provide an `action` string like `toString` or `constructor`, causing the server to incorrectly evaluate `Object.prototype` methods as valid tool handlers, potentially leading to errors or crashes.
+**Prevention:** Always use `Object.hasOwn(ACTIONS, action)` to verify that the `action` is a direct property of the mapping object, rather than relying on standard property access or the `in` operator, before accessing the handler.

--- a/src/tools/composite/animation.ts
+++ b/src/tools/composite/animation.ts
@@ -179,9 +179,11 @@ const ANIMATION_ACTIONS: Record<string, (projectPath: string, args: Record<strin
 export async function handleAnimation(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const projectPath = resolveProjectRoot(args.project_path, config.projectPath)
 
-  const handler = ANIMATION_ACTIONS[action]
-  if (handler) {
-    return handler(projectPath, args)
+  if (Object.hasOwn(ANIMATION_ACTIONS, action)) {
+    const handler = ANIMATION_ACTIONS[action]
+    if (handler) {
+      return handler(projectPath, args)
+    }
   }
 
   throwUnknownAction(action, Object.keys(ANIMATION_ACTIONS))

--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -266,9 +266,11 @@ export async function handleNodes(action: string, args: Record<string, unknown>,
   const baseProjectPath = config.projectPath || process.cwd()
   const projectPath = args.project_path ? safeResolve(baseProjectPath, args.project_path as string) : baseProjectPath
 
-  const handler = NODE_ACTIONS[action]
-  if (handler) {
-    return handler(projectPath, args)
+  if (Object.hasOwn(NODE_ACTIONS, action)) {
+    const handler = NODE_ACTIONS[action]
+    if (handler) {
+      return handler(projectPath, args)
+    }
   }
 
   throwUnknownAction(action, Object.keys(NODE_ACTIONS))

--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -198,9 +198,11 @@ export async function handleResources(action: string, args: Record<string, unkno
     throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
   }
 
-  const handler = RESOURCE_ACTIONS[action]
-  if (handler) {
-    return handler(projectRoot, args)
+  if (Object.hasOwn(RESOURCE_ACTIONS, action)) {
+    const handler = RESOURCE_ACTIONS[action]
+    if (handler) {
+      return handler(projectRoot, args)
+    }
   }
 
   throwUnknownAction(action, Object.keys(RESOURCE_ACTIONS))

--- a/src/tools/composite/signals.ts
+++ b/src/tools/composite/signals.ts
@@ -163,9 +163,11 @@ const SIGNAL_ACTIONS: Record<
 export async function handleSignals(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const projectPath = resolveProjectRoot(args.project_path, config.projectPath)
 
-  const handler = SIGNAL_ACTIONS[action]
-  if (handler) {
-    return handler(projectPath, args)
+  if (Object.hasOwn(SIGNAL_ACTIONS, action)) {
+    const handler = SIGNAL_ACTIONS[action]
+    if (handler) {
+      return handler(projectPath, args)
+    }
   }
 
   throwUnknownAction(action, Object.keys(SIGNAL_ACTIONS))

--- a/tests/security/prototype-pollution.test.ts
+++ b/tests/security/prototype-pollution.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { handleAnimation } from '../../src/tools/composite/animation.js'
+import { handleNodes } from '../../src/tools/composite/nodes.js'
+import { handleResources } from '../../src/tools/composite/resources.js'
+import { handleSignals } from '../../src/tools/composite/signals.js'
+import { GodotMCPError } from '../../src/tools/helpers/errors.js'
+
+describe('Security: Prototype Pollution Prevention', () => {
+  const config = { activePids: [], projectPath: '/mock/path' }
+  const args = { project_path: '/mock/path' }
+
+  // Object.prototype methods to test
+  const maliciousActions = ['toString', 'valueOf', 'constructor', 'hasOwnProperty', 'isPrototypeOf']
+
+  it('handleNodes rejects Object.prototype properties', async () => {
+    for (const action of maliciousActions) {
+      await expect(handleNodes(action, args, config as import('../../src/godot/types.js').GodotConfig)).rejects.toThrow(
+        GodotMCPError,
+      )
+
+      await expect(handleNodes(action, args, config as import('../../src/godot/types.js').GodotConfig)).rejects.toThrow(
+        /Unknown action:/,
+      )
+    }
+  })
+
+  it('handleSignals rejects Object.prototype properties', async () => {
+    for (const action of maliciousActions) {
+      await expect(
+        handleSignals(action, args, config as import('../../src/godot/types.js').GodotConfig),
+      ).rejects.toThrow(GodotMCPError)
+
+      await expect(
+        handleSignals(action, args, config as import('../../src/godot/types.js').GodotConfig),
+      ).rejects.toThrow(/Unknown action:/)
+    }
+  })
+
+  it('handleResources rejects Object.prototype properties', async () => {
+    for (const action of maliciousActions) {
+      await expect(
+        handleResources(action, args, config as import('../../src/godot/types.js').GodotConfig),
+      ).rejects.toThrow(GodotMCPError)
+
+      await expect(
+        handleResources(action, args, config as import('../../src/godot/types.js').GodotConfig),
+      ).rejects.toThrow(/Unknown action:/)
+    }
+  })
+
+  it('handleAnimation rejects Object.prototype properties', async () => {
+    for (const action of maliciousActions) {
+      await expect(
+        handleAnimation(action, args, config as import('../../src/godot/types.js').GodotConfig),
+      ).rejects.toThrow(GodotMCPError)
+
+      await expect(
+        handleAnimation(action, args, config as import('../../src/godot/types.js').GodotConfig),
+      ).rejects.toThrow(/Unknown action:/)
+    }
+  })
+})


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Action dispatchers in several composite tools (`nodes.ts`, `signals.ts`, `resources.ts`, `animation.ts`) were using plain object mapping lookups (e.g., `const handler = NODE_ACTIONS[action]`) without validating that the `action` was a direct property of the mapping object.
🎯 **Impact:** This allowed Prototype Pollution / Property Injection. An attacker or malicious prompt could supply `action` names like `"toString"` or `"constructor"`, causing the server to execute inherited `Object.prototype` properties instead of intended tool logic, potentially leading to undefined behavior, errors, or crashes.
🔧 **Fix:** Wrapped action handler lookups with `Object.hasOwn(ACTIONS, action)` to ensure that only explicitly defined direct properties are treated as valid tool sub-actions. Safely fallback to the `throwUnknownAction` handler otherwise. Added an explicit unit test `tests/security/prototype-pollution.test.ts` to enforce this rule and ensure all affected tool handlers throw "Unknown action" for `.prototype` properties. Documented the learning in `.jules/sentinel.md`.
✅ **Verification:** Ran `bun x vitest run tests/security/prototype-pollution.test.ts` successfully. Ran `bun run check:fix && bun run lint && bun run test` to verify the patch caused no regressions.

---
*PR created automatically by Jules for task [6898075911217218165](https://jules.google.com/task/6898075911217218165) started by @n24q02m*