### PR TITLE
🛡️ Sentinel: [HIGH] Fix argument injection in editor tool

### DIFF
--- a/src/tools/composite/editor.ts
+++ b/src/tools/composite/editor.ts
@@ -46,6 +46,9 @@ export async function handleEditor(action: string, args: Record<string, unknown>
       if (!projectPath) {
         throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
       }
+      if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
+        throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
+      }
 
       const { pid } = launchGodotEditor(config.godotPath, safeResolve(config.projectPath || process.cwd(), projectPath))
       if (pid) {

--- a/tests/composite/editor.test.ts
+++ b/tests/composite/editor.test.ts
@@ -56,6 +56,22 @@ describe('editor', () => {
 
       expect(result.content[0].text).toContain('Godot editor launched')
     })
+
+    it('should reject project_path starting with a hyphen', async () => {
+      config = makeConfig({ godotPath: '/usr/bin/godot', projectPath })
+
+      await expect(handleEditor('launch', { project_path: '--malicious' }, config)).rejects.toThrow(
+        'Invalid project path',
+      )
+    })
+
+    it('should reject space-padded project_path starting with a hyphen', async () => {
+      config = makeConfig({ godotPath: '/usr/bin/godot', projectPath })
+
+      await expect(handleEditor('launch', { project_path: '  --malicious' }, config)).rejects.toThrow(
+        'Invalid project path',
+      )
+    })
   })
 
   // ==========================================


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Argument injection vulnerability in the `editor` tool's `launch` action.
🎯 **Impact:** An attacker could exploit this by providing a maliciously crafted, space-padded `project_path` (e.g., `  --malicious-script`) that bypasses naive CLI argument parsing and executes unintended commands or modifies execution behavior.
🔧 **Fix:** Reused the robust validation mechanism present in other composite tools (e.g., `project.ts` and `config.ts`). Specifically, added a `trim().startsWith('-')` check to ensure the untrusted `project_path` parameter cannot be used as an unintended command line flag when spawning the Godot editor process. Also, added explicit integration test cases mimicking padded and non-padded argument injection attacks.
✅ **Verification:** Validated by `tests/composite/editor.test.ts` where both `--malicious` and `  --malicious` inputs are now gracefully rejected. Tests run cleanly.

---
*PR created automatically by Jules for task [13707112989941981994](https://jules.google.com/task/13707112989941981994) started by @n24q02m*