### PR TITLE
[PERF] O(n) find array iteration in detector

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,7 @@ This ensures that "create" matches "create" even if "create_node" appears earlie
 ## 2025-02-12 - [FIX] Extract string trim logic to helper
 **Learning:** Manual string trimming loops (`while (charCodeAt(i) <= 32)`) were duplicated across multiple structural parsers (`input-map.ts`, `project-settings.ts`, `scene-parser.ts`, `project.ts`). Centralizing this into a `fastTrimRange` helper reduces code duplication and ensures consistent whitespace handling across the codebase while maintaining zero-allocation performance.
 **Action:** Use `fastTrimRange(str, start, end)` in `src/tools/helpers/strings.ts` for any future structural parsers that need to handle Godot-style whitespace trimming within string ranges.
+
+## 2026-06-21 - [Optimize findWinGetGodotBinaries array iteration]
+**Learning:** Performing multiple `.find()` calls on the same array with different regular expressions results in multiple O(n) passes. In performance-sensitive detection logic, this can be optimized into a single pass.
+**Action:** Replaced two `files.find()` calls in `src/godot/detector.ts` with a single `for...of` loop that identifies both `regularExe` and `consoleExe` in one pass, using early breaks and pre-compiled regexes for maximum efficiency. Added `// ⚡ Bolt:` comments to denote intentional optimization.

--- a/src/godot/detector.ts
+++ b/src/godot/detector.ts
@@ -172,6 +172,9 @@ function findWinGetGodotBinaries(localAppData: string): string[] {
   const packagesDir = join(localAppData, 'Microsoft', 'WinGet', 'Packages')
   if (!existsSync(packagesDir)) return results
 
+  const REGULAR_REGEX = /^Godot_v[\d.]+-\w+_win64\.exe$/i
+  const CONSOLE_REGEX = /^Godot_v[\d.]+-\w+_win64_console\.exe$/i
+
   try {
     const dirs = readdirSync(packagesDir, { withFileTypes: true })
     for (const dir of dirs) {
@@ -179,10 +182,18 @@ function findWinGetGodotBinaries(localAppData: string): string[] {
       const pkgDir = join(packagesDir, dir.name)
       try {
         const files = readdirSync(pkgDir)
-        // Prefer GUI version (has actual editor window), then console as fallback
-        const regularExe = files.find((f) => /^Godot_v[\d.]+-\w+_win64\.exe$/i.test(f) && !f.includes('console'))
+        // ⚡ Bolt: Prefer GUI version (has actual editor window), then console as fallback in a single pass
+        let regularExe: string | undefined
+        let consoleExe: string | undefined
+        for (const f of files) {
+          if (regularExe && consoleExe) break
+          if (!regularExe && REGULAR_REGEX.test(f) && !f.includes('console')) {
+            regularExe = f
+          } else if (!consoleExe && CONSOLE_REGEX.test(f)) {
+            consoleExe = f
+          }
+        }
         if (regularExe) results.push(join(pkgDir, regularExe))
-        const consoleExe = files.find((f) => /^Godot_v[\d.]+-\w+_win64_console\.exe$/i.test(f))
         if (consoleExe) results.push(join(pkgDir, consoleExe))
       } catch {
         // Skip unreadable package directories


### PR DESCRIPTION
Optimized findWinGetGodotBinaries in src/godot/detector.ts by replacing two O(n) .find() calls with a single for...of loop. Pre-compiled the regexes to avoid repeated instantiation and added an early break if both binaries are found. This reduces the number of iterations and RegExp allocations in the WinGet detection path.

---
*PR created automatically by Jules for task [17650472401832968149](https://jules.google.com/task/17650472401832968149) started by @n24q02m*