### PR TITLE
[TEST] Missing test file for stdio.ts

### DIFF
--- a/tests/transports/stdio.test.ts
+++ b/tests/transports/stdio.test.ts
@@ -1,0 +1,34 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { describe, expect, it, vi } from 'vitest'
+import { startStdio } from '../../src/transports/stdio.js'
+
+// Mock the SDK
+vi.mock('@modelcontextprotocol/sdk/server/index.js', () => {
+  const mockConnect = vi.fn().mockResolvedValue(undefined)
+  return {
+    Server: vi.fn().mockImplementation(
+      class {
+        connect = mockConnect
+      },
+    ),
+  }
+})
+
+vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => {
+  return {
+    StdioServerTransport: vi.fn().mockImplementation(class {}),
+  }
+})
+
+describe('stdio transport', () => {
+  it('should initialize and connect stdio transport', async () => {
+    // @ts-expect-error - mock constructor
+    const mockServer = new Server({ name: 'test', version: '1.0.0' }, { capabilities: {} })
+
+    await startStdio(mockServer as unknown as Server)
+
+    expect(StdioServerTransport).toHaveBeenCalled()
+    expect(mockServer.connect).toHaveBeenCalledWith(expect.any(Object))
+  })
+})


### PR DESCRIPTION
This PR adds unit test coverage for the `src/transports/stdio.ts` file. 

The new test file `tests/transports/stdio.test.ts` verifies that the `startStdio` function correctly instantiates the `StdioServerTransport` and connects it to the MCP server.

Key changes:
- Created `tests/transports/stdio.test.ts`.
- Implemented mocks for `@modelcontextprotocol/sdk/server/index.js` and `@modelcontextprotocol/sdk/server/stdio.js` using class-based implementations to satisfy constructor requirements in Vitest.
- Verified the test passes and adheres to project linting standards.
- Confirmed that the full test suite continues to pass.

---
*PR created automatically by Jules for task [11094910789029869217](https://jules.google.com/task/11094910789029869217) started by @n24q02m*