### PR TITLE
[FIX] Strip specific prefixes

### DIFF
--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -33,44 +33,83 @@ async function readSceneFile(fullPath: string, scenePath: string): Promise<strin
 
 /**
  * Normalize node path: strip common LLM mistakes like "/root/SceneName/" prefix.
- * Handles backslashes, case-insensitivity, and absolute vs relative paths.
+ * Handles backslashes, case-insensitivity, absolute vs relative paths, and Godot markers (^, $, NodePath).
  * Returns the corrected path and whether it was auto-corrected.
  */
-function normalizeNodePath(path: string): { path: string; corrected: boolean } {
+export function normalizeNodePath(path: string): { path: string; corrected: boolean } {
   if (!path || path === '.') return { path, corrected: false }
 
-  // Normalize backslashes to forward slashes
-  const normalized = path.replace(/\\/g, '/')
-  const corrected = path.includes('\\')
+  let current = path
+  let corrected = false
 
-  // Case-insensitive check for /root/ or root/ prefix
-  // These are common LLM mistakes when they try to use absolute paths.
-  const rootMatch = normalized.match(/^\/?root\/(.+)$/i)
+  // 1. Normalize backslashes to forward slashes
+  if (current.includes('\\')) {
+    current = current.replace(/\\/g, '/')
+    corrected = true
+  }
+
+  // 2. Unwrap Godot wrappers: NodePath("..."), ^"...", $"..."
+  if (current.startsWith('NodePath("') && current.endsWith('")')) {
+    current = current.slice(10, -2)
+    corrected = true
+  } else if ((current.startsWith('^"') || current.startsWith('$"')) && current.endsWith('"')) {
+    current = current.slice(2, -1)
+    corrected = true
+  }
+
+  // 3. Strip Godot location prefixes: res://, user://
+  if (current.startsWith('res://')) {
+    current = current.slice(6)
+    corrected = true
+  } else if (current.startsWith('user://')) {
+    current = current.slice(7)
+    corrected = true
+  }
+
+  // 4. Strip leading markers: ^, $
+  if (current.startsWith('^') || current.startsWith('$')) {
+    current = current.slice(1)
+    corrected = true
+  }
+
+  // 5. Collapse redundant slashes (e.g. Player//Head -> Player/Head)
+  if (current.includes('//')) {
+    current = current.replace(/\/+/g, '/')
+    corrected = true
+  }
+
+  // 6. Handle /root/ or root/ prefix (LLM absolute path mistakes)
+  // Case-insensitive check.
+  // We strictly require a leading slash or a trailing slash to avoid stripping a standalone "root" node name.
+  const rootMatch = current.match(/^(\/root\/|root\/|\/root$)(.*)$/i)
   if (rootMatch) {
-    const afterRoot = rootMatch[1]
-    const segments = afterRoot.split('/').filter(Boolean)
-    if (segments.length <= 1) {
-      return { path: '.', corrected: true }
+    const afterRoot = rootMatch[2]
+    if (!afterRoot) {
+      current = '.'
+    } else {
+      const segments = afterRoot.split('/').filter(Boolean)
+      // If it's /root/SceneName, it refers to the scene root ('.')
+      // If it's /root/SceneName/Node, it refers to 'Node'
+      if (segments.length <= 1) {
+        current = '.'
+      } else {
+        current = segments.slice(1).join('/')
+      }
     }
-    const remaining = segments.slice(1).join('/')
-    return { path: remaining, corrected: true }
+    corrected = true
+  } else if (current.startsWith('/')) {
+    // Strip other leading slashes
+    current = current.slice(1)
+    corrected = true
   }
 
-  // Handle /root or root (exact match)
-  // We only treat it as the scene root if it's explicitly "/root" or "root" (case-insensitive)
-  // But wait, if someone has a node named "Root" that is NOT the scene root?
-  // In Godot, the root of the scene being edited is often named after the scene or "Root".
-  // LLMs often use "/root/SceneName/..."
-  if (normalized.toLowerCase() === '/root') {
-    return { path: '.', corrected: true }
+  // Final cleanup: if empty or just a slash, it's the root
+  if (!current || current === '/') {
+    current = '.'
+    corrected = true
   }
 
-  // Strip leading slash
-  if (normalized.startsWith('/')) {
-    return { path: normalized.slice(1), corrected: true }
-  }
-
-  return { path: normalized, corrected }
+  return { path: current, corrected: corrected || current !== path }
 }
 
 async function handleAddNode(projectPath: string, args: Record<string, unknown>) {

--- a/tests/composite/nodes-normalization.test.ts
+++ b/tests/composite/nodes-normalization.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeNodePath } from '../../src/tools/composite/nodes.js'
+
+describe('normalizeNodePath', () => {
+  it('should handle basic paths', () => {
+    expect(normalizeNodePath('Player/Head')).toEqual({ path: 'Player/Head', corrected: false })
+    expect(normalizeNodePath('.')).toEqual({ path: '.', corrected: false })
+  })
+
+  it('should normalize backslashes', () => {
+    expect(normalizeNodePath('Player\\Head')).toEqual({ path: 'Player/Head', corrected: true })
+  })
+
+  it('should strip leading slashes (except /root)', () => {
+    expect(normalizeNodePath('/Player/Head')).toEqual({ path: 'Player/Head', corrected: true })
+  })
+
+  it('should handle /root/ prefixes (absolute paths from LLMs)', () => {
+    expect(normalizeNodePath('/root/World/Player')).toEqual({ path: 'Player', corrected: true })
+    expect(normalizeNodePath('root/World/Player')).toEqual({ path: 'Player', corrected: true })
+    expect(normalizeNodePath('/ROOT/World/Player')).toEqual({ path: 'Player', corrected: true })
+  })
+
+  it('should handle /root as current scene root', () => {
+    expect(normalizeNodePath('/root')).toEqual({ path: '.', corrected: true })
+    expect(normalizeNodePath('/ROOT')).toEqual({ path: '.', corrected: true })
+    expect(normalizeNodePath('/root/World')).toEqual({ path: '.', corrected: true })
+    expect(normalizeNodePath('root/World')).toEqual({ path: '.', corrected: true })
+  })
+
+  it('should preserve standalone node names like Root or root', () => {
+    expect(normalizeNodePath('Root')).toEqual({ path: 'Root', corrected: false })
+    expect(normalizeNodePath('root')).toEqual({ path: 'root', corrected: false })
+  })
+
+  it('should unwrap NodePath("...")', () => {
+    expect(normalizeNodePath('NodePath("Player/Head")')).toEqual({ path: 'Player/Head', corrected: true })
+  })
+
+  it('should unwrap ^"..." and $"..."', () => {
+    expect(normalizeNodePath('^"Player/Head"')).toEqual({ path: 'Player/Head', corrected: true })
+    expect(normalizeNodePath('$"Player/Head"')).toEqual({ path: 'Player/Head', corrected: true })
+  })
+
+  it('should strip Godot markers ^ and $', () => {
+    expect(normalizeNodePath('^Player/Head')).toEqual({ path: 'Player/Head', corrected: true })
+    expect(normalizeNodePath('$Player/Head')).toEqual({ path: 'Player/Head', corrected: true })
+  })
+
+  it('should strip res:// and user://', () => {
+    expect(normalizeNodePath('res://Player/Head')).toEqual({ path: 'Player/Head', corrected: true })
+    expect(normalizeNodePath('user://Player/Head')).toEqual({ path: 'Player/Head', corrected: true })
+  })
+
+  it('should collapse redundant slashes', () => {
+    expect(normalizeNodePath('Player//Head')).toEqual({ path: 'Player/Head', corrected: true })
+  })
+
+  it('should handle empty or slash-only input', () => {
+    expect(normalizeNodePath('')).toEqual({ path: '', corrected: false })
+    expect(normalizeNodePath('/')).toEqual({ path: '.', corrected: true })
+    expect(normalizeNodePath('///')).toEqual({ path: '.', corrected: true })
+  })
+})


### PR DESCRIPTION
This PR enhances the `normalizeNodePath` utility in `src/tools/composite/nodes.ts` to handle a wider range of common LLM mistakes and Godot-specific path conventions. 

Key improvements:
- **Godot Wrapper Unwrapping**: Handles `NodePath("...")`, `^"..."`, and `$"..."`.
- **Location Prefix Stripping**: Removes `res://` and `user://`.
- **Marker Stripping**: Removes leading `^` and `$` markers.
- **Redundant Slash Collapsing**: Collapses multiple slashes (e.g., `Player//Head` -> `Player/Head`).
- **Robust `/root/` Handling**: Case-insensitive stripping that resolves to the scene root (`.`) or a relative path, while specifically protecting standalone node names like `Root`.
- **Standardization**: Ensures empty or slash-only inputs resolve correctly to the root identifier `.`.
- **Exported**: The function is now exported as a project-wide standard for node path normalization.

Verified with a new test suite (`tests/composite/nodes-normalization.test.ts`) and existing integration tests.

---
*PR created automatically by Jules for task [4788147639580576800](https://jules.google.com/task/4788147639580576800) started by @n24q02m*