### PR TITLE
[PERF] Unnecessary string allocation inside loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,7 @@ This ensures that "create" matches "create" even if "create_node" appears earlie
 ## 2025-02-12 - [FIX] Extract string trim logic to helper
 **Learning:** Manual string trimming loops (`while (charCodeAt(i) <= 32)`) were duplicated across multiple structural parsers (`input-map.ts`, `project-settings.ts`, `scene-parser.ts`, `project.ts`). Centralizing this into a `fastTrimRange` helper reduces code duplication and ensures consistent whitespace handling across the codebase while maintaining zero-allocation performance.
 **Action:** Use `fastTrimRange(str, start, end)` in `src/tools/helpers/strings.ts` for any future structural parsers that need to handle Godot-style whitespace trimming within string ranges.
+
+## 2025-04-03 - [Optimize Map iteration and string unquoting in Physics tool]
+**Learning:** Iterating over Map entries via `for...of settings.sections.get('layer_names')` allocates a new `[key, value]` array for every entry. Additionally, using `.replaceAll('"', '')` for simple unquoting is inefficient as it searches the entire string and always allocates a new string.
+**Action:** Replace `for...of` iteration on Map entries with `Map.prototype.forEach((value, key) => { ... })` to avoid entry array allocations. Implement a faster manual unquoting check by verifying `charCodeAt(0) === 34` and `slice(1, -1)` only if quotes are present. Applied in `src/tools/composite/physics.ts`.

--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -30,13 +30,21 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       const layers2d: Record<string, string> = {}
       const layers3d: Record<string, string> = {}
 
-      for (const [key, value] of settings.sections.get('layer_names') || []) {
-        // ⚡ Bolt: Use .replaceAll('"', '') instead of .replace(/"/g, '') to avoid RegExp compilation overhead
-        if (key.startsWith('2d_physics/layer_')) {
-          layers2d[key] = value.replaceAll('"', '')
-        } else if (key.startsWith('3d_physics/layer_')) {
-          layers3d[key] = value.replaceAll('"', '')
-        }
+      const layerNames = settings.sections.get('layer_names')
+      if (layerNames) {
+        // ⚡ Bolt: Use .forEach() to avoid entry array allocations and perform faster unquoting
+        layerNames.forEach((value, key) => {
+          const unquoted =
+            value.length >= 2 && value.charCodeAt(0) === 34 && value.charCodeAt(value.length - 1) === 34
+              ? value.slice(1, -1)
+              : value
+
+          if (key.startsWith('2d_physics/layer_')) {
+            layers2d[key] = unquoted
+          } else if (key.startsWith('3d_physics/layer_')) {
+            layers3d[key] = unquoted
+          }
+        })
       }
 
       return formatJSON({ layers2d, layers3d })


### PR DESCRIPTION
This PR optimizes the `layers` action in the physics tool (`src/tools/composite/physics.ts`) by addressing unnecessary string allocations and inefficient iteration.

Key changes:
1. **Iterate Map without entry arrays**: Switched from `for...of settings.sections.get(...)` to `Map.prototype.forEach`. The former creates a new `[key, value]` array for every entry in the Map, while the latter provides the key and value directly via a callback, avoiding these allocations.
2. **Efficient Unquoting**: Replaced `value.replaceAll('"', '')` with a manual check for surrounding quotes (`charCodeAt(0) === 34`). The previous implementation was not only inefficient (it used `replaceAll` which iterates the entire string and potentially uses regex depending on engine implementation/Node version, though `replaceAll` with string is usually optimized, manual unquoting is still faster as it targets exactly what's needed). More importantly, `replaceAll` creates a new string even if no quotes are present, whereas `slice` is only called if necessary.
3. **Recorded Learnings**: Added a new entry to `.jules/bolt.md` documenting this pattern for future reference.

These optimizations are particularly relevant when processing large Godot projects with many layer names.

---
*PR created automatically by Jules for task [8219470548165332497](https://jules.google.com/task/8219470548165332497) started by @n24q02m*