### PR TITLE
fix(composite): extract common property parsing into helper

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,6 @@ This ensures that "create" matches "create" even if "create_node" appears earlie
 ## 2025-02-12 - [FIX] Extract string trim logic to helper
 **Learning:** Manual string trimming loops (`while (charCodeAt(i) <= 32)`) were duplicated across multiple structural parsers (`input-map.ts`, `project-settings.ts`, `scene-parser.ts`, `project.ts`). Centralizing this into a `fastTrimRange` helper reduces code duplication and ensures consistent whitespace handling across the codebase while maintaining zero-allocation performance.
 **Action:** Use `fastTrimRange(str, start, end)` in `src/tools/helpers/strings.ts` for any future structural parsers that need to handle Godot-style whitespace trimming within string ranges.
+## 2025-05-14 - Centralized Godot property validation
+**Learning:** Duplicated property validation for Godot .tscn/.tres files across multiple tools (nodes, ui) increases maintenance risk and potential for inconsistent validation rules.
+**Action:** Centralized .tscn property validation and formatting into a shared helper `validateAndFormatTscnProperties` in `scene-parser.ts` to ensure consistent security (newline/equals injection prevention) and reduce code churn.

--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -13,6 +13,7 @@ import {
   removeNodeFromContent,
   renameNodeInContent,
   setNodePropertyInContent,
+  validateAndFormatTscnProperties,
 } from '../helpers/scene-parser.js'
 
 function resolveScenePath(projectPath: string, scenePath: string): string {
@@ -115,30 +116,9 @@ async function handleAddNode(projectPath: string, args: Record<string, unknown>)
   }
 
   const parentAttr = parent === '.' ? '' : ` parent="${parent}"`
-  let nodeDecl = `\n[node name="${nodeName}" type="${nodeType}"${parentAttr}]\n`
-
-  // Handle properties parsing
-  if (args.properties !== undefined) {
-    if (typeof args.properties !== 'object' || args.properties === null || Array.isArray(args.properties)) {
-      throw new GodotMCPError(
-        'Invalid properties format',
-        'INVALID_ARGS',
-        'properties must be an object with string keys and values.',
-      )
-    }
-    for (const [key, value] of Object.entries(args.properties)) {
-      if (typeof key !== 'string' || typeof value !== 'string') {
-        throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property keys and values must be strings.')
-      }
-      if (key.includes('=') || key.includes('\n') || key.includes('\r')) {
-        throw new GodotMCPError('Invalid property key', 'INVALID_ARGS', 'Property keys must not contain "=", newlines.')
-      }
-      if (value.includes('\n') || value.includes('\r')) {
-        throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property values must not contain newlines.')
-      }
-      nodeDecl += `${key} = ${value}\n`
-    }
-  }
+  const nodeDecl = `\n[node name="${nodeName}" type="${nodeType}"${parentAttr}]\n${validateAndFormatTscnProperties(
+    args.properties,
+  )}`
 
   const updated = `${content.trimEnd()}\n${nodeDecl}`
   await writeFile(fullPath, updated, 'utf-8')

--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -8,7 +8,7 @@ import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, resolveProjectRoot, safeResolve } from '../helpers/paths.js'
-import { parseScene, updateNodeInScene } from '../helpers/scene-parser.js'
+import { parseScene, updateNodeInScene, validateAndFormatTscnProperties } from '../helpers/scene-parser.js'
 
 const CONTROL_TEMPLATES: Record<string, Record<string, string>> = {
   Button: { text: '"Click"' },
@@ -115,27 +115,7 @@ async function handleCreateControl(projectPath: string, args: Record<string, unk
   }
 
   // Add custom properties
-  if (args.properties !== undefined) {
-    if (typeof args.properties !== 'object' || args.properties === null || Array.isArray(args.properties)) {
-      throw new GodotMCPError(
-        'Invalid properties format',
-        'INVALID_ARGS',
-        'properties must be an object with string keys and values.',
-      )
-    }
-    for (const [key, value] of Object.entries(args.properties)) {
-      if (typeof key !== 'string' || typeof value !== 'string') {
-        throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property keys and values must be strings.')
-      }
-      if (key.includes('=') || key.includes('\n') || key.includes('\r')) {
-        throw new GodotMCPError('Invalid property key', 'INVALID_ARGS', 'Property keys must not contain "=", newlines.')
-      }
-      if (value.includes('\n') || value.includes('\r')) {
-        throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property values must not contain newlines.')
-      }
-      nodeDecl += `${key} = ${value}\n`
-    }
-  }
+  nodeDecl += validateAndFormatTscnProperties(args.properties)
 
   content = `${content.trimEnd()}\n${nodeDecl}`
   await writeFile(fullPath, content, 'utf-8')

--- a/src/tools/helpers/scene-parser.ts
+++ b/src/tools/helpers/scene-parser.ts
@@ -12,6 +12,7 @@
  */
 
 import { readFile } from 'node:fs/promises'
+import { GodotMCPError } from './errors.js'
 import { fastTrimRange, parseCommaSeparatedList } from './strings.js'
 
 /**
@@ -542,4 +543,35 @@ export function setNodePropertyInContent(content: string, nodeName: string, prop
 export function getNodeProperty(scene: ParsedScene, nodeName: string, property: string): string | undefined {
   const node = findNode(scene, nodeName)
   return node?.properties[property]
+}
+
+/**
+ * Validates and formats properties for inclusion in a .tscn or .tres file.
+ * Used by tools that add nodes or resources with custom properties.
+ */
+export function validateAndFormatTscnProperties(properties: unknown): string {
+  if (properties === undefined) return ''
+
+  if (typeof properties !== 'object' || properties === null || Array.isArray(properties)) {
+    throw new GodotMCPError(
+      'Invalid properties format',
+      'INVALID_ARGS',
+      'properties must be an object with string keys and values.',
+    )
+  }
+
+  let result = ''
+  for (const [key, value] of Object.entries(properties)) {
+    if (typeof key !== 'string' || typeof value !== 'string') {
+      throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property keys and values must be strings.')
+    }
+    if (key.includes('=') || key.includes('\n') || key.includes('\r')) {
+      throw new GodotMCPError('Invalid property key', 'INVALID_ARGS', 'Property keys must not contain "=", newlines.')
+    }
+    if (value.includes('\n') || value.includes('\r')) {
+      throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property values must not contain newlines.')
+    }
+    result += `${key} = ${value}\n`
+  }
+  return result
 }

--- a/tests/helpers/validate-format-tscn-properties.test.ts
+++ b/tests/helpers/validate-format-tscn-properties.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { validateAndFormatTscnProperties } from '../../src/tools/helpers/scene-parser.js'
+import { GodotMCPError } from '../../src/tools/helpers/errors.js'
+
+describe('validateAndFormatTscnProperties', () => {
+  it('returns empty string for undefined input', () => {
+    expect(validateAndFormatTscnProperties(undefined)).toBe('')
+  })
+
+  it('formats valid properties correctly', () => {
+    const properties = {
+      text: '"Hello"',
+      value: '42',
+      color: 'Color(1, 0, 0, 1)'
+    }
+    const expected = 'text = "Hello"\nvalue = 42\ncolor = Color(1, 0, 0, 1)\n'
+    expect(validateAndFormatTscnProperties(properties)).toBe(expected)
+  })
+
+  it('throws GodotMCPError for non-object input', () => {
+    expect(() => validateAndFormatTscnProperties('invalid')).toThrow('Invalid properties format')
+    expect(() => validateAndFormatTscnProperties(null)).toThrow('Invalid properties format')
+    expect(() => validateAndFormatTscnProperties([1, 2, 3])).toThrow('Invalid properties format')
+  })
+
+  it('throws GodotMCPError for non-string keys or values', () => {
+    try {
+        validateAndFormatTscnProperties({ key: 123 });
+        expect.fail('Should have thrown');
+    } catch (e) {
+        expect(e).toBeInstanceOf(GodotMCPError);
+        expect((e as GodotMCPError).message).toBe('Invalid property value');
+        expect((e as GodotMCPError).suggestion).toBe('Property keys and values must be strings.');
+    }
+  })
+
+  it('throws GodotMCPError for invalid characters in keys', () => {
+    try {
+        validateAndFormatTscnProperties({ 'key=': 'value' });
+        expect.fail('Should have thrown');
+    } catch (e) {
+        expect(e).toBeInstanceOf(GodotMCPError);
+        expect((e as GodotMCPError).message).toBe('Invalid property key');
+        expect((e as GodotMCPError).suggestion).toBe('Property keys must not contain "=", newlines.');
+    }
+  })
+
+  it('throws GodotMCPError for invalid characters in values', () => {
+    try {
+        validateAndFormatTscnProperties({ key: 'value\n' });
+        expect.fail('Should have thrown');
+    } catch (e) {
+        expect(e).toBeInstanceOf(GodotMCPError);
+        expect((e as GodotMCPError).message).toBe('Invalid property value');
+        expect((e as GodotMCPError).suggestion).toBe('Property values must not contain newlines.');
+    }
+  })
+})


### PR DESCRIPTION
Extracted duplicated property validation and formatting logic from handleAddNode (nodes.ts) and handleCreateControl (ui.ts) into a shared helper function validateAndFormatTscnProperties in scene-parser.ts. Added unit tests for the helper.

---
*PR created automatically by Jules for task [5601476726030926422](https://jules.google.com/task/5601476726030926422) started by @n24q02m*