### PR TITLE
[SECURITY] Path Traversal Risk via Unsafe 'join' Usage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,7 @@
 **Vulnerability:** Action dispatchers in composite tools (e.g. `nodes.ts`, `signals.ts`) were using plain object lookups (e.g. `const handler = NODE_ACTIONS[action]`) without `Object.hasOwn()` checks.
 **Learning:** This exposes the server to prototype pollution or property injection, where an attacker could provide an `action` string like `toString` or `constructor`, causing the server to incorrectly evaluate `Object.prototype` methods as valid tool handlers, potentially leading to errors or crashes.
 **Prevention:** Always use `Object.hasOwn(ACTIONS, action)` to verify that the `action` is a direct property of the mapping object, rather than relying on standard property access or the `in` operator, before accessing the handler.
+## 2025-05-14 - Path Traversal Risk via Unsafe 'join' Usage
+**Vulnerability:** Path Traversal and Symlink Escape
+**Learning:** Using standard node:path `join()` on user-provided path components or during recursive directory traversal can be bypassed using symlinks or traversal characters.
+**Prevention:** Always use a canonicalizing and containment-checking resolver like `safeResolve()` for any path construction involving external input or recursive operations.

--- a/src/tools/composite/audio.ts
+++ b/src/tools/composite/audio.ts
@@ -4,7 +4,6 @@
  */
 
 import { readFile, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { resolveProjectRoot, safeResolve } from '../helpers/paths.js'
@@ -17,7 +16,7 @@ function resolveBusLayoutPath(projectPath: string | null | undefined, baseDir: s
   if (!projectPath) {
     throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
   }
-  return join(safeResolve(baseDir, projectPath), 'default_bus_layout.tres')
+  return safeResolve(safeResolve(baseDir, projectPath), 'default_bus_layout.tres')
 }
 
 /**

--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -3,11 +3,10 @@
  * Actions: status | set | detect_godot | check
  */
 
-import { join } from 'node:path'
 import { detectGodot, isExecutable, isVersionSupported, tryGetVersion } from '../../godot/detector.js'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { pathExists } from '../helpers/paths.js'
+import { pathExists, safeResolve } from '../helpers/paths.js'
 
 // Mutable runtime config
 const runtimeConfig: Record<string, string> = {}
@@ -55,7 +54,7 @@ export async function handleConfig(action: string, args: Record<string, unknown>
 
       // Validate before updating runtimeConfig to avoid storing invalid values
       if (key === 'project_path') {
-        if (!(await pathExists(join(value, 'project.godot')))) {
+        if (!(await pathExists(safeResolve(value, 'project.godot')))) {
           throw new GodotMCPError(
             'Invalid project path',
             'INVALID_ARGS',
@@ -131,7 +130,7 @@ export async function handleConfig(action: string, args: Record<string, unknown>
               path: projectPath,
               // Performance optimization: using async pathExists instead of existsSync
               // to avoid blocking the Node.js event loop during I/O operations
-              valid: await pathExists(join(projectPath, 'project.godot')),
+              valid: await pathExists(safeResolve(projectPath, 'project.godot')),
             }
           : { path: null },
       }

--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -4,7 +4,6 @@
  */
 
 import { readFile, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { serializeGodotObject } from '../helpers/godot-types.js'
@@ -167,7 +166,7 @@ function parseEventsList(str: string): string[] {
 
 async function getProjectGodotPath(projectPath: string | null | undefined, baseDir: string): Promise<string> {
   if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
-  const configPath = join(safeResolve(baseDir, projectPath), 'project.godot')
+  const configPath = safeResolve(safeResolve(baseDir, projectPath), 'project.godot')
   if (!(await pathExists(configPath)))
     throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')
   return configPath

--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -4,7 +4,6 @@
  */
 
 import { readFile, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { toGodotValue } from '../helpers/godot-types.js'
@@ -19,7 +18,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
   switch (action) {
     case 'layers': {
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
-      const configPath = join(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
+      const configPath = safeResolve(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
 
       const settings = await parseProjectSettingsAsync(configPath).catch((err) => {
         if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
@@ -137,7 +136,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
         throw new GodotMCPError('Invalid layer_number: must be a number', 'INVALID_ARGS')
       }
 
-      const configPath = join(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
+      const configPath = safeResolve(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
 
       let content: string
       try {

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -5,7 +5,6 @@
 
 import { execFileSync } from 'node:child_process'
 import { readFile, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
 import { execGodotAsync, runGodotProject } from '../../godot/headless.js'
 import type { GodotConfig, ProjectInfo } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
@@ -20,7 +19,7 @@ import { isValidPid, validatePid } from '../helpers/security.js'
 import { fastTrimRange, parseCommaSeparatedList } from '../helpers/strings.js'
 
 async function parseProjectGodot(projectPath: string): Promise<ProjectInfo> {
-  const configPath = join(projectPath, 'project.godot')
+  const configPath = safeResolve(projectPath, 'project.godot')
 
   let content: string
   try {
@@ -197,7 +196,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (!key)
         throw new GodotMCPError('No key specified', 'INVALID_ARGS', 'Provide key (e.g., "application/config/name").')
 
-      const configPath = join(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
+      const configPath = safeResolve(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
 
       let settings: ProjectSettings
       try {
@@ -232,7 +231,7 @@ export async function handleProject(action: string, args: Record<string, unknown
         throw new GodotMCPError('Invalid value format', 'INVALID_ARGS', 'Value must not contain newlines.')
       }
 
-      const configPath = join(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
+      const configPath = safeResolve(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
 
       let content: string
       try {

--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -4,7 +4,7 @@
  */
 
 import { readdir, readFile, stat, unlink } from 'node:fs/promises'
-import { extname, join } from 'node:path'
+import { extname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { resolveProjectRoot, safeResolve } from '../helpers/paths.js'
@@ -51,7 +51,7 @@ async function findResourceFiles(
       const name = entry.name
       if (name.startsWith('.') || name === 'node_modules' || name === 'build') continue
 
-      const fullPath = join(dir, name)
+      const fullPath = safeResolve(dir, name)
       if (entry.isDirectory()) {
         promises.push(findResourceFiles(fullPath, exts, results).then(() => {}))
       } else if (name.includes('.') && exts.has(name.slice(name.lastIndexOf('.')).toLowerCase())) {

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -4,7 +4,7 @@
  */
 
 import { copyFile, mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/promises'
-import { basename, dirname, join } from 'node:path'
+import { basename, dirname } from 'node:path'
 import type { GodotConfig, SceneInfo } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
@@ -21,7 +21,7 @@ async function findSceneFiles(dir: string, results: string[] = []): Promise<stri
       const name = entry.name
       if (name.startsWith('.') || name === 'node_modules' || name === 'build') continue
 
-      const fullPath = join(dir, name)
+      const fullPath = safeResolve(dir, name)
       if (entry.isDirectory()) {
         promises.push(findSceneFiles(fullPath, results))
       } else if (name.endsWith('.tscn')) {
@@ -217,7 +217,8 @@ export async function handleScenes(action: string, args: Record<string, unknown>
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain quotes or newlines.')
       }
 
-      const configPath = join(safeResolve(baseDir, projectPath as string), 'project.godot')
+      safeResolve(projectPath as string, scenePath)
+      const configPath = safeResolve(safeResolve(baseDir, projectPath as string), 'project.godot')
 
       // ⚡ Bolt: Using replaceAll('\\', '/') avoids RegExp allocation overhead
       const resPath = `res://${scenePath.replaceAll('\\', '/')}`

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -4,7 +4,7 @@
  */
 
 import { mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
@@ -108,7 +108,7 @@ async function findScriptFiles(dir: string, results: string[] = []): Promise<str
       const name = entry.name
       if (name.startsWith('.') || name === 'node_modules' || name === 'build' || name === 'addons') continue
 
-      const fullPath = join(dir, name)
+      const fullPath = safeResolve(dir, name)
       if (entry.isDirectory()) {
         promises.push(findScriptFiles(fullPath, results))
       } else if (name.endsWith('.gd')) {

--- a/src/tools/composite/shader.ts
+++ b/src/tools/composite/shader.ts
@@ -4,7 +4,7 @@
  */
 
 import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { dirname } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { resolveProjectRoot, safeResolve } from '../helpers/paths.js'
@@ -59,7 +59,7 @@ async function findShaderFiles(dir: string, results: string[] = []): Promise<str
       const name = entry.name
       if (name.startsWith('.') || name === 'node_modules' || name === 'build') continue
 
-      const fullPath = join(dir, name)
+      const fullPath = safeResolve(dir, name)
       if (entry.isDirectory()) {
         promises.push(findShaderFiles(fullPath, results))
       } else if (entry.isFile() && (name.endsWith('.gdshader') || name.endsWith('.gdshaderinc'))) {


### PR DESCRIPTION
Refactored path joining to use safeResolve across all composite tools to prevent path traversal and ensure containment within the project root. This fix addresses the vulnerability where unsafe join usage could allow reading/writing files outside the project directory, including via symlink escapes.

---
*PR created automatically by Jules for task [710731343448679480](https://jules.google.com/task/710731343448679480) started by @n24q02m*