### PR TITLE
[PERF] Synchronous realpathSync in paths helper

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,7 @@ This ensures that "create" matches "create" even if "create_node" appears earlie
 ## 2025-02-12 - [FIX] Extract string trim logic to helper
 **Learning:** Manual string trimming loops (`while (charCodeAt(i) <= 32)`) were duplicated across multiple structural parsers (`input-map.ts`, `project-settings.ts`, `scene-parser.ts`, `project.ts`). Centralizing this into a `fastTrimRange` helper reduces code duplication and ensures consistent whitespace handling across the codebase while maintaining zero-allocation performance.
 **Action:** Use `fastTrimRange(str, start, end)` in `src/tools/helpers/strings.ts` for any future structural parsers that need to handle Godot-style whitespace trimming within string ranges.
+
+## 2024-05-20 - [Replace synchronous realpathSync with asynchronous realpath]
+**Learning:** Using `realpathSync` in path resolution helpers blocks the event loop, which can degrade performance in an MCP server that handles multiple concurrent requests or large file operations. Canonicalization is necessary for security (path traversal prevention), but it doesn't need to be synchronous.
+**Action:** Replaced `realpathSync` from `node:fs` with `await realpath` from `node:fs/promises` in `src/tools/helpers/paths.ts`. This required making `canonicalize`, `safeResolve`, and `resolveProjectRoot` asynchronous, and subsequently updating all call sites in `src/tools/composite/` to use `await`.

--- a/src/tools/composite/animation.ts
+++ b/src/tools/composite/animation.ts
@@ -11,7 +11,7 @@ import { parseSceneContent } from '../helpers/scene-parser.js'
 import { validateNoNewlines } from '../helpers/security.js'
 
 async function resolveScene(projectRoot: string, scenePath: string): Promise<string> {
-  const fullPath = safeResolve(projectRoot, scenePath)
+  const fullPath = await safeResolve(projectRoot, scenePath)
   if (!(await pathExists(fullPath)))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
   return fullPath
@@ -177,7 +177,7 @@ const ANIMATION_ACTIONS: Record<string, (projectPath: string, args: Record<strin
 }
 
 export async function handleAnimation(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = resolveProjectRoot(args.project_path, config.projectPath)
+  const projectPath = await resolveProjectRoot(args.project_path, config.projectPath)
 
   if (Object.hasOwn(ANIMATION_ACTIONS, action)) {
     const handler = ANIMATION_ACTIONS[action]

--- a/src/tools/composite/audio.ts
+++ b/src/tools/composite/audio.ts
@@ -13,11 +13,11 @@ import { resolveProjectRoot, safeResolve } from '../helpers/paths.js'
  * Helper to resolve the default bus layout path.
  * Throws GodotMCPError if project path is missing.
  */
-function resolveBusLayoutPath(projectPath: string | null | undefined, baseDir: string): string {
+async function resolveBusLayoutPath(projectPath: string | null | undefined, baseDir: string): Promise<string> {
   if (!projectPath) {
     throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
   }
-  return join(safeResolve(baseDir, projectPath), 'default_bus_layout.tres')
+  return join(await safeResolve(baseDir, projectPath), 'default_bus_layout.tres')
 }
 
 /**
@@ -80,7 +80,7 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
 
   switch (action) {
     case 'list_buses': {
-      const busLayoutPath = resolveBusLayoutPath(projectPath, baseDir)
+      const busLayoutPath = await resolveBusLayoutPath(projectPath, baseDir)
 
       let content: string
       try {
@@ -104,7 +104,7 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
     }
 
     case 'add_bus': {
-      const busLayoutPath = resolveBusLayoutPath(projectPath, baseDir)
+      const busLayoutPath = await resolveBusLayoutPath(projectPath, baseDir)
       const busName = args.bus_name as string
       if (!busName) throw new GodotMCPError('No bus_name specified', 'INVALID_ARGS', 'Provide bus name.')
       const sendTo = (args.send_to as string) || 'Master'
@@ -164,7 +164,7 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
     }
 
     case 'add_effect': {
-      const busLayoutPath = resolveBusLayoutPath(projectPath, baseDir)
+      const busLayoutPath = await resolveBusLayoutPath(projectPath, baseDir)
       const busName = args.bus_name as string
       const effectType = args.effect_type as string
       if (!busName || !effectType) {
@@ -279,7 +279,7 @@ export async function handleAudio(action: string, args: Record<string, unknown>,
       }
 
       // Confine caller project_path to the trusted base before resolving the scene.
-      const fullPath = safeResolve(resolveProjectRoot(args.project_path, config.projectPath), scenePath)
+      const fullPath = await safeResolve(await resolveProjectRoot(args.project_path, config.projectPath), scenePath)
       let content: string
       try {
         content = await readFile(fullPath, 'utf-8')

--- a/src/tools/composite/editor.ts
+++ b/src/tools/composite/editor.ts
@@ -50,7 +50,10 @@ export async function handleEditor(action: string, args: Record<string, unknown>
         throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
       }
 
-      const { pid } = launchGodotEditor(config.godotPath, safeResolve(config.projectPath || process.cwd(), projectPath))
+      const { pid } = launchGodotEditor(
+        config.godotPath,
+        await safeResolve(config.projectPath || process.cwd(), projectPath),
+      )
       if (pid) {
         validatePid(pid)
         config.activePids.push(pid)

--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -167,7 +167,7 @@ function parseEventsList(str: string): string[] {
 
 async function getProjectGodotPath(projectPath: string | null | undefined, baseDir: string): Promise<string> {
   if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
-  const configPath = join(safeResolve(baseDir, projectPath), 'project.godot')
+  const configPath = join(await safeResolve(baseDir, projectPath), 'project.godot')
   if (!(await pathExists(configPath)))
     throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')
   return configPath

--- a/src/tools/composite/navigation.ts
+++ b/src/tools/composite/navigation.ts
@@ -9,7 +9,7 @@ import { formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/err
 import { pathExists, resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 
 async function resolveScene(projectRoot: string, scenePath: string): Promise<string> {
-  const fullPath = safeResolve(projectRoot, scenePath)
+  const fullPath = await safeResolve(projectRoot, scenePath)
   if (!(await pathExists(fullPath)))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
   return fullPath
@@ -23,7 +23,7 @@ function appendNode(content: string, name: string, type: string, parent: string,
 }
 
 export async function handleNavigation(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = resolveProjectRoot(args.project_path, config.projectPath)
+  const projectPath = await resolveProjectRoot(args.project_path, config.projectPath)
 
   switch (action) {
     case 'create_region': {

--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -15,8 +15,8 @@ import {
   setNodePropertyInContent,
 } from '../helpers/scene-parser.js'
 
-function resolveScenePath(projectPath: string, scenePath: string): string {
-  return safeResolve(projectPath, scenePath)
+async function resolveScenePath(projectPath: string, scenePath: string): Promise<string> {
+  return await safeResolve(projectPath, scenePath)
 }
 
 // ⚡ Bolt: Using try-to-perform instead of pathExists to reduce redundant I/O calls
@@ -94,7 +94,7 @@ async function handleAddNode(projectPath: string, args: Record<string, unknown>)
     throw new GodotMCPError('Invalid parent path', 'INVALID_ARGS', 'Parent path must not contain quotes or newlines.')
   }
 
-  const fullPath = resolveScenePath(projectPath, scenePath)
+  const fullPath = await resolveScenePath(projectPath, scenePath)
   let content: string
   try {
     content = await readFile(fullPath, 'utf-8')
@@ -153,7 +153,7 @@ async function handleRemoveNode(projectPath: string, args: Record<string, unknow
   if (!rawName) throw new GodotMCPError('No node name specified', 'INVALID_ARGS', 'Provide name of node to remove.')
   const { path: nodeName } = normalizeNodePath(rawName)
 
-  const fullPath = resolveScenePath(projectPath, scenePath)
+  const fullPath = await resolveScenePath(projectPath, scenePath)
   const content = await readSceneFile(fullPath, scenePath)
   const updated = removeNodeFromContent(content, nodeName)
   await writeFile(fullPath, updated, 'utf-8')
@@ -173,7 +173,7 @@ async function handleRenameNode(projectPath: string, args: Record<string, unknow
     throw new GodotMCPError('Invalid node name', 'INVALID_ARGS', 'New node name must not contain quotes or newlines.')
   }
 
-  const fullPath = resolveScenePath(projectPath, scenePath)
+  const fullPath = await resolveScenePath(projectPath, scenePath)
   const content = await readSceneFile(fullPath, scenePath)
   const updated = renameNodeInContent(content, nodeName, newName)
   await writeFile(fullPath, updated, 'utf-8')
@@ -185,7 +185,7 @@ async function handleListNodes(projectPath: string, args: Record<string, unknown
   const scenePath = args.scene_path as string
   if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
 
-  const fullPath = resolveScenePath(projectPath, scenePath)
+  const fullPath = await resolveScenePath(projectPath, scenePath)
   const content = await readSceneFile(fullPath, scenePath)
   const scene = parseSceneContent(content)
   // ⚡ Bolt: Removed double .map() passes and expensive object spread (...node.properties) in mapToSceneNode.
@@ -224,7 +224,7 @@ async function handleSetNodeProperty(projectPath: string, args: Record<string, u
     throw new GodotMCPError('Invalid property value', 'INVALID_ARGS', 'Property values must not contain newlines.')
   }
 
-  const fullPath = resolveScenePath(projectPath, scenePath)
+  const fullPath = await resolveScenePath(projectPath, scenePath)
   const content = await readSceneFile(fullPath, scenePath)
   const updated = setNodePropertyInContent(content, nodeName, property, value)
   await writeFile(fullPath, updated, 'utf-8')
@@ -241,7 +241,7 @@ async function handleGetNodeProperty(projectPath: string, args: Record<string, u
     throw new GodotMCPError('name and property required', 'INVALID_ARGS', 'Provide name and property.')
   }
 
-  const fullPath = resolveScenePath(projectPath, scenePath)
+  const fullPath = await resolveScenePath(projectPath, scenePath)
   const content = await readSceneFile(fullPath, scenePath)
   const scene = parseSceneContent(content)
   const val = getNodeProperty(scene, nodeName, property)
@@ -266,7 +266,9 @@ const NODE_ACTIONS: Record<
 
 export async function handleNodes(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const baseProjectPath = config.projectPath || process.cwd()
-  const projectPath = args.project_path ? safeResolve(baseProjectPath, args.project_path as string) : baseProjectPath
+  const projectPath = args.project_path
+    ? await safeResolve(baseProjectPath, args.project_path as string)
+    : baseProjectPath
 
   if (Object.hasOwn(NODE_ACTIONS, action)) {
     const handler = NODE_ACTIONS[action]

--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -19,7 +19,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
   switch (action) {
     case 'layers': {
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
-      const configPath = join(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
+      const configPath = join(await safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
 
       const settings = await parseProjectSettingsAsync(configPath).catch((err) => {
         if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
@@ -53,7 +53,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       const collisionLayer = args.collision_layer
       const collisionMask = args.collision_mask
 
-      const fullPath = safeResolve(safeResolve(config.projectPath || process.cwd(), projectPath), scenePath)
+      const fullPath = await safeResolve(await safeResolve(config.projectPath || process.cwd(), projectPath), scenePath)
 
       let content: string
       try {
@@ -94,7 +94,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
 
       validateNoNewlines(undefined, scenePath, nodeName)
 
-      const fullPath = safeResolve(safeResolve(config.projectPath || process.cwd(), projectPath), scenePath)
+      const fullPath = await safeResolve(await safeResolve(config.projectPath || process.cwd(), projectPath), scenePath)
 
       let content: string
       try {
@@ -137,7 +137,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
         throw new GodotMCPError('Invalid layer_number: must be a number', 'INVALID_ARGS')
       }
 
-      const configPath = join(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
+      const configPath = join(await safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
 
       let content: string
       try {

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -107,7 +107,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
         throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
       }
-      const info = await parseProjectGodot(safeResolve(config.projectPath || process.cwd(), projectPath))
+      const info = await parseProjectGodot(await safeResolve(config.projectPath || process.cwd(), projectPath))
       return formatJSON(info)
     }
 
@@ -142,7 +142,7 @@ export async function handleProject(action: string, args: Record<string, unknown
 
       const { pid } = runGodotProject(
         config.godotPath,
-        safeResolve(config.projectPath || process.cwd(), projectPath),
+        await safeResolve(config.projectPath || process.cwd(), projectPath),
         scenePath,
       )
       if (pid) {
@@ -197,7 +197,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (!key)
         throw new GodotMCPError('No key specified', 'INVALID_ARGS', 'Provide key (e.g., "application/config/name").')
 
-      const configPath = join(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
+      const configPath = join(await safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
 
       let settings: ProjectSettings
       try {
@@ -232,7 +232,7 @@ export async function handleProject(action: string, args: Record<string, unknown
         throw new GodotMCPError('Invalid value format', 'INVALID_ARGS', 'Value must not contain newlines.')
       }
 
-      const configPath = join(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
+      const configPath = join(await safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
 
       let content: string
       try {
@@ -279,14 +279,14 @@ export async function handleProject(action: string, args: Record<string, unknown
         )
       }
 
-      const resolvedProjectPath = safeResolve(config.projectPath || process.cwd(), projectPath)
+      const resolvedProjectPath = await safeResolve(config.projectPath || process.cwd(), projectPath)
       const result = await execGodotAsync(config.godotPath, [
         '--headless',
         '--path',
         resolvedProjectPath,
         '--export-release',
         preset,
-        safeResolve(resolvedProjectPath, outputPath),
+        await safeResolve(resolvedProjectPath, outputPath),
       ])
 
       return formatSuccess(`Export complete: ${outputPath}\n${result.stdout}`)

--- a/src/tools/composite/resources.ts
+++ b/src/tools/composite/resources.ts
@@ -109,7 +109,7 @@ async function handleListResources(projectRoot: string, args: Record<string, unk
 async function handleResourceInfo(projectRoot: string, args: Record<string, unknown>) {
   const resPath = args.resource_path as string
   if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-  const fullPath = safeResolve(projectRoot, resPath)
+  const fullPath = await safeResolve(projectRoot, resPath)
 
   try {
     const fileStat = await stat(fullPath)
@@ -141,7 +141,7 @@ async function handleResourceInfo(projectRoot: string, args: Record<string, unkn
 async function handleDeleteResource(projectRoot: string, args: Record<string, unknown>) {
   const resPath = args.resource_path as string
   if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
-  const fullPath = safeResolve(projectRoot, resPath)
+  const fullPath = await safeResolve(projectRoot, resPath)
 
   try {
     await unlink(fullPath)
@@ -165,7 +165,7 @@ async function handleImportConfig(projectRoot: string, args: Record<string, unkn
   const resPath = args.resource_path as string
   if (!resPath) throw new GodotMCPError('No resource_path specified', 'INVALID_ARGS', 'Provide resource_path.')
 
-  const importPath = safeResolve(projectRoot, `${resPath}.import`)
+  const importPath = await safeResolve(projectRoot, `${resPath}.import`)
 
   try {
     const content = await readFile(importPath, 'utf-8')
@@ -192,7 +192,7 @@ const RESOURCE_ACTIONS: Record<
 }
 
 export async function handleResources(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectRoot = resolveProjectRoot(args.project_path, config.projectPath)
+  const projectRoot = await resolveProjectRoot(args.project_path, config.projectPath)
 
   if (action === 'list' && !args.project_path && !config.projectPath) {
     throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -43,11 +43,11 @@ function generateTscnContent(rootName: string, rootType: string): string {
   return [`[gd_scene format=3]`, '', `[node name="${rootName}" type="${rootType}"]`, ''].join('\n')
 }
 
-function validateSceneArgs(action: string, args: Record<string, unknown>, config: GodotConfig) {
+async function validateSceneArgs(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const baseDir = config.projectPath || process.cwd()
   // Validate args.project_path against the trusted baseDir to prevent path traversal vulnerabilities
   const projectPath = args.project_path
-    ? safeResolve(baseDir, args.project_path as string)
+    ? await safeResolve(baseDir, args.project_path as string)
     : config.projectPath || undefined
   const scenePath = args.scene_path as string
   const newPath = args.new_path as string
@@ -82,14 +82,14 @@ function validateSceneArgs(action: string, args: Record<string, unknown>, config
   return { projectPath, scenePath, newPath }
 }
 
-function resolvePath(base: string | undefined, relativePath: string): string {
-  if (base) return safeResolve(base, relativePath)
-  return safeResolve(process.cwd(), relativePath)
+async function resolvePath(base: string | undefined, relativePath: string): Promise<string> {
+  if (base) return await safeResolve(base, relativePath)
+  return await safeResolve(process.cwd(), relativePath)
 }
 
 export async function handleScenes(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const baseDir = config.projectPath || process.cwd()
-  const { projectPath, scenePath, newPath } = validateSceneArgs(action, args, config)
+  const { projectPath, scenePath, newPath } = await validateSceneArgs(action, args, config)
 
   switch (action) {
     case 'create': {
@@ -105,7 +105,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
         throw new GodotMCPError('Invalid root type', 'INVALID_ARGS', 'Root type must not contain quotes or newlines.')
       }
 
-      const fullPath = safeResolve(projectPath as string, scenePath)
+      const fullPath = await safeResolve(projectPath as string, scenePath)
       if (await pathExists(fullPath)) {
         throw new GodotMCPError(
           `Scene already exists: ${scenePath}`,
@@ -123,7 +123,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
 
     case 'list': {
       // projectPath is guaranteed
-      const resolvedPath = safeResolve(baseDir, projectPath as string)
+      const resolvedPath = await safeResolve(baseDir, projectPath as string)
       const scenes = await findSceneFiles(resolvedPath)
 
       // OPTIMIZATION: Use substring and a pre-allocated array instead of .map() and node:path.relative
@@ -144,7 +144,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
 
     case 'info': {
       // scenePath is guaranteed
-      const fullPath = resolvePath(projectPath, scenePath)
+      const fullPath = await resolvePath(projectPath, scenePath)
       let rawContent: string
       try {
         rawContent = await readFile(fullPath, 'utf-8')
@@ -174,7 +174,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
 
     case 'delete': {
       // scenePath is guaranteed
-      const fullPath = resolvePath(projectPath, scenePath)
+      const fullPath = await resolvePath(projectPath, scenePath)
       try {
         await unlink(fullPath)
       } catch (error) {
@@ -188,8 +188,8 @@ export async function handleScenes(action: string, args: Record<string, unknown>
 
     case 'duplicate': {
       // scenePath and newPath are guaranteed
-      const srcFull = resolvePath(projectPath, scenePath)
-      const dstFull = resolvePath(projectPath, newPath as string)
+      const srcFull = await resolvePath(projectPath, scenePath)
+      const dstFull = await resolvePath(projectPath, newPath as string)
 
       if (await pathExists(dstFull)) {
         throw new GodotMCPError(
@@ -217,7 +217,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain quotes or newlines.')
       }
 
-      const configPath = join(safeResolve(baseDir, projectPath as string), 'project.godot')
+      const configPath = join(await safeResolve(baseDir, projectPath as string), 'project.godot')
 
       // ⚡ Bolt: Using replaceAll('\\', '/') avoids RegExp allocation overhead
       const resPath = `res://${scenePath.replaceAll('\\', '/')}`

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -126,14 +126,14 @@ async function findScriptFiles(dir: string, results: string[] = []): Promise<str
   }
 }
 
-async function createScript(args: Record<string, unknown>, resolvePath: (path: string) => string) {
+async function createScript(args: Record<string, unknown>, resolvePath: (path: string) => Promise<string>) {
   const scriptPath = args.script_path as string
   if (!scriptPath)
     throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path (e.g., "player.gd").')
   const extendsType = (args.extends as string) || 'Node'
   const content = (args.content as string) || getTemplate(extendsType)
 
-  const fullPath = resolvePath(scriptPath)
+  const fullPath = await resolvePath(scriptPath)
   if (await pathExists(fullPath)) {
     throw new GodotMCPError(
       `Script already exists: ${scriptPath}`,
@@ -147,11 +147,11 @@ async function createScript(args: Record<string, unknown>, resolvePath: (path: s
   return formatSuccess(`Created script: ${scriptPath}\nExtends: ${extendsType}`)
 }
 
-async function readScript(args: Record<string, unknown>, resolvePath: (path: string) => string) {
+async function readScript(args: Record<string, unknown>, resolvePath: (path: string) => Promise<string>) {
   const scriptPath = args.script_path as string
   if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path.')
 
-  const fullPath = resolvePath(scriptPath)
+  const fullPath = await resolvePath(scriptPath)
   if (!(await pathExists(fullPath)))
     throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
 
@@ -159,20 +159,20 @@ async function readScript(args: Record<string, unknown>, resolvePath: (path: str
   return formatSuccess(`File: ${scriptPath}\n\n${content}`)
 }
 
-async function writeScript(args: Record<string, unknown>, resolvePath: (path: string) => string) {
+async function writeScript(args: Record<string, unknown>, resolvePath: (path: string) => Promise<string>) {
   const scriptPath = args.script_path as string
   if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path.')
   const content = args.content as string
   if (content === undefined || content === null)
     throw new GodotMCPError('No content specified', 'INVALID_ARGS', 'Provide content to write.')
 
-  const fullPath = resolvePath(scriptPath)
+  const fullPath = await resolvePath(scriptPath)
   await mkdir(dirname(fullPath), { recursive: true })
   await writeFile(fullPath, content, 'utf-8')
   return formatSuccess(`Written: ${scriptPath} (${content.length} chars)`)
 }
 
-async function attachScript(args: Record<string, unknown>, resolvePath: (path: string) => string) {
+async function attachScript(args: Record<string, unknown>, resolvePath: (path: string) => Promise<string>) {
   const scenePath = args.scene_path as string
   const scriptPath = args.script_path as string
   let nodeName = args.node_name as string
@@ -199,7 +199,7 @@ async function attachScript(args: Record<string, unknown>, resolvePath: (path: s
     )
   }
 
-  const sceneFullPath = resolvePath(scenePath)
+  const sceneFullPath = await resolvePath(scenePath)
   if (!(await pathExists(sceneFullPath)))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
 
@@ -235,7 +235,7 @@ async function listScripts(baseDir: string, projectPath: string | undefined) {
   if (!projectPath)
     throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
 
-  const resolvedPath = safeResolve(baseDir, projectPath)
+  const resolvedPath = await safeResolve(baseDir, projectPath)
   const scripts = await findScriptFiles(resolvedPath)
 
   // OPTIMIZATION: Use substring and a pre-allocated array instead of .map() and node:path.relative
@@ -250,11 +250,11 @@ async function listScripts(baseDir: string, projectPath: string | undefined) {
   return formatJSON({ project: resolvedPath, count: relativePaths.length, scripts: relativePaths })
 }
 
-async function deleteScript(args: Record<string, unknown>, resolvePath: (path: string) => string) {
+async function deleteScript(args: Record<string, unknown>, resolvePath: (path: string) => Promise<string>) {
   const scriptPath = args.script_path as string
   if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path to delete.')
 
-  const fullPath = resolvePath(scriptPath)
+  const fullPath = await resolvePath(scriptPath)
   if (!(await pathExists(fullPath)))
     throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
 
@@ -265,7 +265,7 @@ async function deleteScript(args: Record<string, unknown>, resolvePath: (path: s
 export async function handleScripts(action: string, args: Record<string, unknown>, config: GodotConfig) {
   const baseDir = config.projectPath || process.cwd()
   // Validate args.project_path against the trusted baseDir to prevent path traversal vulnerabilities
-  const projectPath = args.project_path ? safeResolve(baseDir, args.project_path as string) : config.projectPath
+  const projectPath = args.project_path ? await safeResolve(baseDir, args.project_path as string) : config.projectPath
 
   if (!projectPath && action !== 'list') {
     // List handles missing projectPath internally, but others need it for safeResolve base
@@ -274,12 +274,12 @@ export async function handleScripts(action: string, args: Record<string, unknown
   }
 
   // Helper to resolve path securely
-  const resolvePath = (path: string) => {
+  const resolvePath = async (path: string) => {
     if (!projectPath) {
       // Should be caught by action-specific checks, but fallback for safety
       throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path argument.')
     }
-    return safeResolve(projectPath, path)
+    return await safeResolve(projectPath, path)
   }
 
   switch (action) {

--- a/src/tools/composite/shader.ts
+++ b/src/tools/composite/shader.ts
@@ -82,7 +82,7 @@ export async function handleShader(action: string, args: Record<string, unknown>
   const baseDir = config.projectPath || process.cwd()
   // Confined trusted project root for per-file actions (create/read/write/get_params):
   // the caller-supplied project_path must stay within baseDir (path-traversal guard).
-  const projectRoot = resolveProjectRoot(args.project_path, config.projectPath)
+  const projectRoot = await resolveProjectRoot(args.project_path, config.projectPath)
 
   switch (action) {
     case 'create': {
@@ -96,7 +96,7 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderType = (args.shader_type as string) || 'canvas_item'
       const content = (args.content as string) || SHADER_TEMPLATES[shaderType] || SHADER_TEMPLATES.canvas_item
 
-      const fullPath = safeResolve(projectRoot, shaderPath)
+      const fullPath = await safeResolve(projectRoot, shaderPath)
 
       // Ensure directory exists
       await mkdir(dirname(fullPath), { recursive: true })
@@ -118,7 +118,7 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderPath = args.shader_path as string
       if (!shaderPath) throw new GodotMCPError('No shader_path specified', 'INVALID_ARGS', 'Provide shader_path.')
 
-      const fullPath = safeResolve(projectRoot, shaderPath)
+      const fullPath = await safeResolve(projectRoot, shaderPath)
 
       try {
         const content = await readFile(fullPath, 'utf-8')
@@ -137,7 +137,7 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const content = args.content as string
       if (!content) throw new GodotMCPError('No content specified', 'INVALID_ARGS', 'Provide shader content.')
 
-      const fullPath = safeResolve(projectRoot, shaderPath)
+      const fullPath = await safeResolve(projectRoot, shaderPath)
       await mkdir(dirname(fullPath), { recursive: true })
       await writeFile(fullPath, content, 'utf-8')
       return formatSuccess(`Written: ${shaderPath} (${content.length} chars)`)
@@ -147,7 +147,7 @@ export async function handleShader(action: string, args: Record<string, unknown>
       const shaderPath = args.shader_path as string
       if (!shaderPath) throw new GodotMCPError('No shader_path specified', 'INVALID_ARGS', 'Provide shader_path.')
 
-      const fullPath = safeResolve(projectRoot, shaderPath)
+      const fullPath = await safeResolve(projectRoot, shaderPath)
 
       try {
         const content = await readFile(fullPath, 'utf-8')
@@ -180,7 +180,7 @@ export async function handleShader(action: string, args: Record<string, unknown>
     case 'list': {
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
 
-      const resolvedPath = safeResolve(baseDir, projectPath)
+      const resolvedPath = await safeResolve(baseDir, projectPath)
       const shaders = await findShaderFiles(resolvedPath)
 
       // OPTIMIZATION: Use substring and a pre-allocated array instead of .map() and node:path.relative

--- a/src/tools/composite/signals.ts
+++ b/src/tools/composite/signals.ts
@@ -39,7 +39,7 @@ async function readSceneContent(fullPath: string, scenePath: string) {
 async function handleListSignals(projectPath: string, args: Record<string, unknown>) {
   const scenePath = args.scene_path as string
   if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
-  const fullPath = safeResolve(projectPath, scenePath)
+  const fullPath = await safeResolve(projectPath, scenePath)
 
   const content = await readSceneContent(fullPath, scenePath)
   const scene = parseSceneContent(content)
@@ -54,7 +54,7 @@ async function handleListSignals(projectPath: string, args: Record<string, unkno
 async function handleConnectSignal(projectPath: string, args: Record<string, unknown>) {
   const scenePath = args.scene_path as string
   if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
-  const fullPath = safeResolve(projectPath, scenePath)
+  const fullPath = await safeResolve(projectPath, scenePath)
 
   const signal = args.signal as string
   const from = args.from as string
@@ -96,7 +96,7 @@ async function handleConnectSignal(projectPath: string, args: Record<string, unk
 async function handleDisconnectSignal(projectPath: string, args: Record<string, unknown>) {
   const scenePath = args.scene_path as string
   if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
-  const fullPath = safeResolve(projectPath, scenePath)
+  const fullPath = await safeResolve(projectPath, scenePath)
 
   const signal = args.signal as string
   const from = args.from as string
@@ -161,7 +161,7 @@ const SIGNAL_ACTIONS: Record<
 }
 
 export async function handleSignals(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = resolveProjectRoot(args.project_path, config.projectPath)
+  const projectPath = await resolveProjectRoot(args.project_path, config.projectPath)
 
   if (Object.hasOwn(SIGNAL_ACTIONS, action)) {
     const handler = SIGNAL_ACTIONS[action]

--- a/src/tools/composite/tilemap.ts
+++ b/src/tools/composite/tilemap.ts
@@ -11,7 +11,7 @@ import { resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 import { countSubstring } from '../helpers/strings.js'
 
 export async function handleTilemap(action: string, args: Record<string, unknown>, config: GodotConfig) {
-  const projectPath = resolveProjectRoot(args.project_path, config.projectPath)
+  const projectPath = await resolveProjectRoot(args.project_path, config.projectPath)
 
   switch (action) {
     case 'create_tileset': {
@@ -24,7 +24,7 @@ export async function handleTilemap(action: string, args: Record<string, unknown
         )
       const tileSize = (args.tile_size as number) || 16
 
-      const fullPath = safeResolve(projectPath, tilesetPath)
+      const fullPath = await safeResolve(projectPath, tilesetPath)
 
       const content = [
         `[gd_resource type="TileSet" format=3]`,
@@ -63,7 +63,7 @@ export async function handleTilemap(action: string, args: Record<string, unknown
         )
       }
 
-      const fullPath = safeResolve(projectPath, tilesetPath)
+      const fullPath = await safeResolve(projectPath, tilesetPath)
 
       let content: string
       try {
@@ -115,7 +115,7 @@ export async function handleTilemap(action: string, args: Record<string, unknown
       const scenePath = args.scene_path as string
       if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
 
-      const fullPath = safeResolve(projectPath, scenePath)
+      const fullPath = await safeResolve(projectPath, scenePath)
 
       let content: string
       try {

--- a/src/tools/composite/ui.ts
+++ b/src/tools/composite/ui.ts
@@ -67,7 +67,7 @@ const CONTROL_TYPES = new Set([
 ])
 
 async function resolveScene(projectRoot: string, scenePath: string): Promise<string> {
-  const fullPath = safeResolve(projectRoot, scenePath)
+  const fullPath = await safeResolve(projectRoot, scenePath)
   if (!(await pathExists(fullPath)))
     throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the file path.')
   return fullPath
@@ -148,7 +148,7 @@ async function handleSetTheme(projectPath: string, args: Record<string, unknown>
   if (!themePath)
     throw new GodotMCPError('No theme_path specified', 'INVALID_ARGS', 'Provide theme_path (e.g., "themes/main.tres").')
 
-  const fullPath = safeResolve(projectPath || process.cwd(), themePath)
+  const fullPath = await safeResolve(projectPath || process.cwd(), themePath)
 
   const fontSize = (args.font_size as number) || 16
 
@@ -272,7 +272,7 @@ async function handleListControls(projectPath: string, args: Record<string, unkn
 export async function handleUI(action: string, args: Record<string, unknown>, config: GodotConfig) {
   // project_path is caller-controlled and untrusted; confine it to the trusted
   // project root before any handler uses it as a file-resolution base.
-  const projectPath = resolveProjectRoot(args.project_path, config.projectPath)
+  const projectPath = await resolveProjectRoot(args.project_path, config.projectPath)
 
   switch (action) {
     case 'create_control':

--- a/src/tools/helpers/paths.ts
+++ b/src/tools/helpers/paths.ts
@@ -1,4 +1,4 @@
-import { realpathSync } from 'node:fs'
+import { access, realpath } from 'node:fs/promises'
 import { dirname, isAbsolute, relative, resolve, sep } from 'node:path'
 import { GodotMCPError } from './errors.js'
 
@@ -8,17 +8,17 @@ import { GodotMCPError } from './errors.js'
  *
  * A plain lexical `resolve()` cannot see through symlinks or the macOS firmlink
  * layout (e.g. `/tmp` -> `/private/tmp`), so a containment check on lexical
- * paths alone can be bypassed. `realpathSync` would throw for paths that do not
+ * paths alone can be bypassed. `realpath` would throw for paths that do not
  * exist yet (the common "create a new file" case), so we canonicalize only the
  * portion that exists on disk and keep the rest lexical.
  */
-function canonicalize(targetPath: string): string {
+async function canonicalize(targetPath: string): Promise<string> {
   let current = resolve(targetPath)
   const tail: string[] = []
   // Walk up until we hit a component that exists on disk (or the filesystem root).
   for (;;) {
     try {
-      const real = realpathSync(current)
+      const real = await realpath(current)
       // Re-attach the non-existent remainder (if any) to the real prefix.
       return tail.length > 0 ? resolve(real, ...tail.reverse()) : real
     } catch {
@@ -46,7 +46,7 @@ function canonicalize(targetPath: string): string {
  * @returns The resolved absolute path
  * @throws GodotMCPError if the path attempts to traverse outside the base directory
  */
-export function safeResolve(baseDir: string, targetPath: string): string {
+export async function safeResolve(baseDir: string, targetPath: string): Promise<string> {
   // Lexically resolve the requested target first; this is what callers expect
   // back (it keeps not-yet-created paths intact for downstream file writes).
   const resolvedBase = resolve(baseDir)
@@ -54,8 +54,8 @@ export function safeResolve(baseDir: string, targetPath: string): string {
 
   // Canonicalize BOTH sides (realpath the existing portions) so the containment
   // check sees through symlinks/firmlinks rather than trusting lexical strings.
-  const canonicalBase = canonicalize(resolvedBase)
-  const canonicalTarget = canonicalize(resolvedTarget)
+  const canonicalBase = await canonicalize(resolvedBase)
+  const canonicalTarget = await canonicalize(resolvedTarget)
 
   // Calculate relative path from canonical base to canonical target.
   const relativePath = relative(canonicalBase, canonicalTarget)
@@ -91,15 +91,16 @@ export function safeResolve(baseDir: string, targetPath: string): string {
  *          subsequent per-file `safeResolve` calls
  * @throws GodotMCPError if `projectPathArg` escapes the trusted base
  */
-export function resolveProjectRoot(projectPathArg: unknown, trustedBase: string | null | undefined): string {
+export async function resolveProjectRoot(
+  projectPathArg: unknown,
+  trustedBase: string | null | undefined,
+): Promise<string> {
   const base = trustedBase || process.cwd()
   if (typeof projectPathArg === 'string' && projectPathArg.length > 0) {
-    return safeResolve(base, projectPathArg)
+    return await safeResolve(base, projectPathArg)
   }
   return resolve(base)
 }
-
-import { access } from 'node:fs/promises'
 
 /**
  * Asynchronously checks if a file or directory exists.

--- a/tests/helpers/paths.test.ts
+++ b/tests/helpers/paths.test.ts
@@ -1,4 +1,3 @@
-import { realpathSync } from 'node:fs'
 import { access, mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, relative, resolve } from 'node:path'
@@ -6,100 +5,91 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { GodotMCPError } from '../../src/tools/helpers/errors.js'
 import { pathExists, resolveProjectRoot, safeResolve } from '../../src/tools/helpers/paths.js'
 
-vi.mock('node:fs', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs')>()
-  return {
-    ...actual,
-    realpathSync: vi.fn(actual.realpathSync),
-  }
-})
-
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>()
   return {
     ...actual,
     access: vi.fn(actual.access),
+    realpath: vi.fn(actual.realpath),
   }
 })
 
 describe('safeResolve', () => {
   const baseDir = resolve('/mock/base/dir')
 
-  it('resolves valid relative paths inside the base directory', () => {
+  it('resolves valid relative paths inside the base directory', async () => {
     const target = 'src/file.ts'
-    const result = safeResolve(baseDir, target)
+    const result = await safeResolve(baseDir, target)
     expect(result).toBe(resolve(baseDir, target))
   })
 
-  it('resolves valid absolute paths inside the base directory', () => {
+  it('resolves valid absolute paths inside the base directory', async () => {
     const target = resolve(baseDir, 'src/file.ts')
-    const result = safeResolve(baseDir, target)
+    const result = await safeResolve(baseDir, target)
     expect(result).toBe(target)
   })
 
-  it('resolves paths with dot (.) correctly', () => {
+  it('resolves paths with dot (.) correctly', async () => {
     const target = './src/file.ts'
-    const result = safeResolve(baseDir, target)
+    const result = await safeResolve(baseDir, target)
     expect(result).toBe(resolve(baseDir, 'src/file.ts'))
   })
 
-  it('resolves paths with dot-dot (..) that remain inside the base directory', () => {
+  it('resolves paths with dot-dot (..) that remain inside the base directory', async () => {
     const target = 'src/../lib/file.ts'
-    const result = safeResolve(baseDir, target)
+    const result = await safeResolve(baseDir, target)
     expect(result).toBe(resolve(baseDir, 'lib/file.ts'))
   })
 
-  it('throws GodotMCPError when path attempts to traverse outside base directory', () => {
+  it('throws GodotMCPError when path attempts to traverse outside base directory', async () => {
     const target = '../outside.ts'
-    expect(() => safeResolve(baseDir, target)).toThrowError(GodotMCPError)
-    expect(() => safeResolve(baseDir, target)).toThrow(/Access denied/)
+    await expect(safeResolve(baseDir, target)).rejects.toThrowError(GodotMCPError)
+    await expect(safeResolve(baseDir, target)).rejects.toThrow(/Access denied/)
   })
 
-  it('throws GodotMCPError when absolute path is outside base directory', () => {
+  it('throws GodotMCPError when absolute path is outside base directory', async () => {
     const target = resolve('/some/other/path')
-    expect(() => safeResolve(baseDir, target)).toThrowError(GodotMCPError)
+    await expect(safeResolve(baseDir, target)).rejects.toThrowError(GodotMCPError)
   })
 
-  it('throws GodotMCPError when path traverses up and outside, even if it tries to go back in', () => {
+  it('throws GodotMCPError when path traverses up and outside, even if it tries to go back in', async () => {
     const target = '../../mock/base/dir/file.ts'
-    expect(() => safeResolve(baseDir, target)).toThrowError(GodotMCPError)
+    await expect(safeResolve(baseDir, target)).rejects.toThrowError(GodotMCPError)
   })
 
-  it('throws GodotMCPError on complex path traversals (e.g., Unix /etc/passwd)', () => {
+  it('throws GodotMCPError on complex path traversals (e.g., Unix /etc/passwd)', async () => {
     const target = '../../../../../../../../../../etc/passwd'
-    expect(() => safeResolve(baseDir, target)).toThrowError(GodotMCPError)
-    expect(() => safeResolve(baseDir, target)).toThrow(/Access denied/)
+    await expect(safeResolve(baseDir, target)).rejects.toThrowError(GodotMCPError)
+    await expect(safeResolve(baseDir, target)).rejects.toThrow(/Access denied/)
   })
 
-  it.skipIf(process.platform !== 'win32')('throws GodotMCPError on Windows-style path traversals', () => {
+  it.skipIf(process.platform !== 'win32')('throws GodotMCPError on Windows-style path traversals', async () => {
     const target = '..\\..\\..\\Windows\\System32\\cmd.exe'
-    expect(() => safeResolve(baseDir, target)).toThrowError(GodotMCPError)
-    expect(() => safeResolve(baseDir, target)).toThrow(/Access denied/)
+    await expect(safeResolve(baseDir, target)).rejects.toThrowError(GodotMCPError)
+    await expect(safeResolve(baseDir, target)).rejects.toThrow(/Access denied/)
   })
 
-  it('throws GodotMCPError for prefix-matching directory traversal attempts (relative)', () => {
+  it('throws GodotMCPError for prefix-matching directory traversal attempts (relative)', async () => {
     const target = '../dir-secret/file.ts'
-    expect(() => safeResolve(baseDir, target)).toThrowError(GodotMCPError)
-    expect(() => safeResolve(baseDir, target)).toThrow(/Access denied/)
+    await expect(safeResolve(baseDir, target)).rejects.toThrowError(GodotMCPError)
+    await expect(safeResolve(baseDir, target)).rejects.toThrow(/Access denied/)
   })
 
-  it('throws GodotMCPError for prefix-matching directory traversal attempts (absolute)', () => {
+  it('throws GodotMCPError for prefix-matching directory traversal attempts (absolute)', async () => {
     const target = '/mock/base/dir-secret/file.ts'
-    expect(() => safeResolve(baseDir, target)).toThrowError(GodotMCPError)
-    expect(() => safeResolve(baseDir, target)).toThrow(/Access denied/)
+    await expect(safeResolve(baseDir, target)).rejects.toThrowError(GodotMCPError)
+    await expect(safeResolve(baseDir, target)).rejects.toThrow(/Access denied/)
   })
 
-  it('covers canonicalize root fallback when realpathSync throws at root', () => {
-    const mockedRealpathSync = vi.mocked(realpathSync)
-    mockedRealpathSync.mockImplementation(() => {
-      throw new Error('Root error')
-    })
+  it('covers canonicalize root fallback when realpath throws at root', async () => {
+    const mockedRealpath = vi.mocked(realpath)
+    mockedRealpath.mockRejectedValue(new Error('Root error'))
 
     try {
-      const result = safeResolve('/some/dir', 'file.ts')
+      const result = await safeResolve('/some/dir', 'file.ts')
       expect(result).toBe(resolve('/some/dir', 'file.ts'))
     } finally {
-      mockedRealpathSync.mockRestore()
+      mockedRealpath.mockRestore()
     }
   })
 })
@@ -109,8 +99,6 @@ describe('safeResolve canonicalization (symlink / firmlink hardening)', () => {
   let outsideDir: string
 
   beforeAll(async () => {
-    // realpath the temp dir up front so assertions are not confused by the
-    // macOS firmlink layout (/var -> /private/var) of the OS temp location.
     const root = await realpath(await mkdtemp(join(tmpdir(), 'godot-mcp-safe-resolve-')))
     realBase = join(root, 'project')
     outsideDir = join(root, 'outside')
@@ -123,22 +111,19 @@ describe('safeResolve canonicalization (symlink / firmlink hardening)', () => {
     await rm(dirname(realBase), { recursive: true, force: true })
   })
 
-  it('allows a legitimate path inside the real base directory', () => {
-    const result = safeResolve(realBase, 'scenes/level.tscn')
+  it('allows a legitimate path inside the real base directory', async () => {
+    const result = await safeResolve(realBase, 'scenes/level.tscn')
     expect(result).toBe(resolve(realBase, 'scenes/level.tscn'))
   })
 
   it.skipIf(process.platform === 'win32')(
     'blocks traversal that escapes via a symlinked directory component',
     async () => {
-      // Create a symlink INSIDE the base that points to a sibling outside dir.
-      // A purely lexical check would treat `escape/secret.txt` as in-base, but
-      // canonicalization reveals it resolves to the outside directory.
       const link = join(realBase, 'escape')
       await symlink(outsideDir, link, 'dir')
 
-      expect(() => safeResolve(realBase, 'escape/secret.txt')).toThrowError(GodotMCPError)
-      expect(() => safeResolve(realBase, 'escape/secret.txt')).toThrow(/Access denied/)
+      await expect(safeResolve(realBase, 'escape/secret.txt')).rejects.toThrowError(GodotMCPError)
+      await expect(safeResolve(realBase, 'escape/secret.txt')).rejects.toThrow(/Access denied/)
     },
   )
 
@@ -150,10 +135,8 @@ describe('safeResolve canonicalization (symlink / firmlink hardening)', () => {
       const innerLink = join(realBase, 'inner-link')
       await symlink(innerReal, innerLink, 'dir')
 
-      // inner-link -> real-inner, both inside base, so this must be allowed.
-      expect(() => safeResolve(realBase, 'inner-link/file.tscn')).not.toThrow()
-      const result = safeResolve(realBase, 'inner-link/file.tscn')
-      // The returned (lexical) path is still inside the base directory.
+      await expect(safeResolve(realBase, 'inner-link/file.tscn')).resolves.not.toThrow()
+      const result = await safeResolve(realBase, 'inner-link/file.tscn')
       const rel = relative(realBase, result)
       expect(rel.startsWith('..')).toBe(false)
     },
@@ -163,38 +146,38 @@ describe('safeResolve canonicalization (symlink / firmlink hardening)', () => {
 describe('resolveProjectRoot', () => {
   const trustedBase = resolve('/mock/trusted/project')
 
-  it('returns the resolved trusted base when no project_path is given', () => {
-    expect(resolveProjectRoot(undefined, trustedBase)).toBe(trustedBase)
-    expect(resolveProjectRoot('', trustedBase)).toBe(trustedBase)
-    expect(resolveProjectRoot(null, trustedBase)).toBe(trustedBase)
+  it('returns the resolved trusted base when no project_path is given', async () => {
+    expect(await resolveProjectRoot(undefined, trustedBase)).toBe(trustedBase)
+    expect(await resolveProjectRoot('', trustedBase)).toBe(trustedBase)
+    expect(await resolveProjectRoot(null, trustedBase)).toBe(trustedBase)
   })
 
-  it('falls back to process.cwd() when trusted base is unset', () => {
-    expect(resolveProjectRoot(undefined, null)).toBe(resolve(process.cwd()))
-    expect(resolveProjectRoot(undefined, undefined)).toBe(resolve(process.cwd()))
+  it('falls back to process.cwd() when trusted base is unset', async () => {
+    expect(await resolveProjectRoot(undefined, null)).toBe(resolve(process.cwd()))
+    expect(await resolveProjectRoot(undefined, undefined)).toBe(resolve(process.cwd()))
   })
 
-  it('confines a relative project_path within the trusted base', () => {
-    expect(resolveProjectRoot('sub/project', trustedBase)).toBe(resolve(trustedBase, 'sub/project'))
+  it('confines a relative project_path within the trusted base', async () => {
+    expect(await resolveProjectRoot('sub/project', trustedBase)).toBe(resolve(trustedBase, 'sub/project'))
   })
 
-  it('accepts an absolute project_path that is inside the trusted base', () => {
+  it('accepts an absolute project_path that is inside the trusted base', async () => {
     const inside = resolve(trustedBase, 'inner')
-    expect(resolveProjectRoot(inside, trustedBase)).toBe(inside)
+    expect(await resolveProjectRoot(inside, trustedBase)).toBe(inside)
   })
 
-  it('rejects an absolute project_path outside the trusted base', () => {
-    expect(() => resolveProjectRoot(resolve('/etc'), trustedBase)).toThrowError(GodotMCPError)
-    expect(() => resolveProjectRoot(resolve('/etc'), trustedBase)).toThrow(/Access denied/)
+  it('rejects an absolute project_path outside the trusted base', async () => {
+    await expect(resolveProjectRoot(resolve('/etc'), trustedBase)).rejects.toThrowError(GodotMCPError)
+    await expect(resolveProjectRoot(resolve('/etc'), trustedBase)).rejects.toThrow(/Access denied/)
   })
 
-  it('rejects a relative project_path that traverses outside the trusted base', () => {
-    expect(() => resolveProjectRoot('../../etc', trustedBase)).toThrowError(GodotMCPError)
+  it('rejects a relative project_path that traverses outside the trusted base', async () => {
+    await expect(resolveProjectRoot('../../etc', trustedBase)).rejects.toThrowError(GodotMCPError)
   })
 
-  it('ignores non-string project_path values', () => {
-    expect(resolveProjectRoot(123, trustedBase)).toBe(trustedBase)
-    expect(resolveProjectRoot({ evil: '../../etc' }, trustedBase)).toBe(trustedBase)
+  it('ignores non-string project_path values', async () => {
+    expect(await resolveProjectRoot(123, trustedBase)).toBe(trustedBase)
+    expect(await resolveProjectRoot({ evil: '../../etc' }, trustedBase)).toBe(trustedBase)
   })
 })
 


### PR DESCRIPTION
Replacing realpathSync with realpath from fs/promises to avoid blocking the event loop. This change makes canonicalize, safeResolve, and resolveProjectRoot asynchronous, and all dependent composite tool call sites and unit tests have been updated accordingly.

---
*PR created automatically by Jules for task [16408482632860177430](https://jules.google.com/task/16408482632860177430) started by @n24q02m*