### PR TITLE
⚡ Bolt: Remove redundant pathExists in scripts tool

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,7 @@ This ensures that "create" matches "create" even if "create_node" appears earlie
 ## 2025-02-12 - [FIX] Extract string trim logic to helper
 **Learning:** Manual string trimming loops (`while (charCodeAt(i) <= 32)`) were duplicated across multiple structural parsers (`input-map.ts`, `project-settings.ts`, `scene-parser.ts`, `project.ts`). Centralizing this into a `fastTrimRange` helper reduces code duplication and ensures consistent whitespace handling across the codebase while maintaining zero-allocation performance.
 **Action:** Use `fastTrimRange(str, start, end)` in `src/tools/helpers/strings.ts` for any future structural parsers that need to handle Godot-style whitespace trimming within string ranges.
+
+## 2025-06-25 - [Optimize redundant pathExists checks in scripts tool]
+**Learning:** Sequential `pathExists` followed by I/O operations like `readFile`, `writeFile`, or `unlink` causes redundant filesystem calls, which can impact performance. Additionally, checking `pathExists` before creating a file is not atomic.
+**Action:** Replaced `pathExists` followed by `readFile`/`unlink` with direct `readFile`/`unlink` wrapped in a `try...catch` handling `ENOENT`. Replaced `pathExists` + `writeFile` with `writeFile` using `flag: 'wx'` to atomically check for existence and create the file, catching `EEXIST`. Applied in `src/tools/composite/scripts.ts`.

--- a/src/tools/composite/scripts.ts
+++ b/src/tools/composite/scripts.ts
@@ -7,7 +7,7 @@ import { mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { pathExists, safeResolve } from '../helpers/paths.js'
+import { safeResolve } from '../helpers/paths.js'
 import { parseSceneContent, updateNodeInScene } from '../helpers/scene-parser.js'
 
 const SCRIPT_TEMPLATES: Record<string, string> = {
@@ -134,16 +134,20 @@ async function createScript(args: Record<string, unknown>, resolvePath: (path: s
   const content = (args.content as string) || getTemplate(extendsType)
 
   const fullPath = resolvePath(scriptPath)
-  if (await pathExists(fullPath)) {
-    throw new GodotMCPError(
-      `Script already exists: ${scriptPath}`,
-      'SCRIPT_ERROR',
-      'Use write action to modify existing scripts.',
-    )
-  }
-
   await mkdir(dirname(fullPath), { recursive: true })
-  await writeFile(fullPath, content, 'utf-8')
+  try {
+    // ⚡ Bolt: Using 'wx' flag to atomically check for existence and create file, reducing redundant I/O calls
+    await writeFile(fullPath, content, { encoding: 'utf-8', flag: 'wx' })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      throw new GodotMCPError(
+        `Script already exists: ${scriptPath}`,
+        'SCRIPT_ERROR',
+        'Use write action to modify existing scripts.',
+      )
+    }
+    throw error
+  }
   return formatSuccess(`Created script: ${scriptPath}\nExtends: ${extendsType}`)
 }
 
@@ -152,10 +156,16 @@ async function readScript(args: Record<string, unknown>, resolvePath: (path: str
   if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path.')
 
   const fullPath = resolvePath(scriptPath)
-  if (!(await pathExists(fullPath)))
-    throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
-
-  const content = await readFile(fullPath, 'utf-8')
+  let content: string
+  try {
+    // ⚡ Bolt: Using try-to-perform instead of pathExists to reduce redundant I/O calls
+    content = await readFile(fullPath, 'utf-8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
+    }
+    throw error
+  }
   return formatSuccess(`File: ${scriptPath}\n\n${content}`)
 }
 
@@ -200,10 +210,16 @@ async function attachScript(args: Record<string, unknown>, resolvePath: (path: s
   }
 
   const sceneFullPath = resolvePath(scenePath)
-  if (!(await pathExists(sceneFullPath)))
-    throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
-
-  const content = await readFile(sceneFullPath, 'utf-8')
+  let content: string
+  try {
+    // ⚡ Bolt: Using try-to-perform instead of pathExists to reduce redundant I/O calls
+    content = await readFile(sceneFullPath, 'utf-8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new GodotMCPError(`Scene not found: ${scenePath}`, 'SCENE_ERROR', 'Create the scene first.')
+    }
+    throw error
+  }
   // ⚡ Bolt: Using replaceAll('\\', '/') avoids RegExp allocation overhead
   const resPath = `res://${scriptPath.replaceAll('\\', '/')}`
 
@@ -255,10 +271,15 @@ async function deleteScript(args: Record<string, unknown>, resolvePath: (path: s
   if (!scriptPath) throw new GodotMCPError('No script_path specified', 'INVALID_ARGS', 'Provide script_path to delete.')
 
   const fullPath = resolvePath(scriptPath)
-  if (!(await pathExists(fullPath)))
-    throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
-
-  await unlink(fullPath)
+  try {
+    // ⚡ Bolt: Using try-to-perform instead of pathExists to reduce redundant I/O calls
+    await unlink(fullPath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new GodotMCPError(`Script not found: ${scriptPath}`, 'SCRIPT_ERROR', 'Check the file path.')
+    }
+    throw error
+  }
   return formatSuccess(`Deleted script: ${scriptPath}`)
 }
 


### PR DESCRIPTION
💡 **What**: Replaced sequential `pathExists` and I/O operations in `src/tools/composite/scripts.ts` with direct I/O execution wrapped in `try...catch` blocks (EAFP pattern) and using the `wx` flag for `writeFile`.
🎯 **Why**: Checking if a file exists before interacting with it introduces redundant file system `stat` calls and a potential Time-of-Check to Time-of-Use (TOCTOU) race condition. Using native `fs` error codes (`ENOENT`, `EEXIST`) is faster and safer.
📊 **Impact**: Eliminates one filesystem syscall per operation on the happy path, improving overall I/O performance when creating, reading, attaching, or deleting GDScript files.
🔬 **Measurement**: Verified by running `bun run test tests/composite/scripts.test.ts` to ensure no changes to functionality and that the exact same GodotMCPError messages are returned. All tests pass successfully.

---
*PR created automatically by Jules for task [15651999648434951612](https://jules.google.com/task/15651999648434951612) started by @n24q02m*