### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix prototype pollution in tool registry

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,7 @@
 **Vulnerability:** Inadequate PID validation could lead to argument injection or errors when interacting with system processes.
 **Learning:** Checking only for type 'number' is insufficient as it includes NaN, Infinity, and non-integers. Godot process management requires safe, positive integers.
 **Prevention:** Use `Number.isSafeInteger(pid) && pid > 0` and verify the type is strictly `number` to ensure system stability and security.
+## 2024-10-24 - Prototype Pollution in Tool Registry
+**Vulnerability:** The central `TOOL_HANDLERS` object mapping in `src/tools/registry.ts` accessed handler objects using plain object lookup (`const handler = TOOL_HANDLERS[name]`).
+**Learning:** Plain property accesses on objects expose them to prototype pollution attacks, where input representing an action or tool matching an `Object.prototype` key (like `toString` or `constructor`) can result in the lookup successfully returning a built-in method rather than throwing an unknown tool error. This bypasses validation logic and may lead to crashes if the runtime attempts to invoke `toString` as if it were a tool handler function.
+**Prevention:** Always wrap key lookups on unverified user input against plain object maps using `Object.hasOwn(obj, key)` before accessing and invoking values as functions.

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -604,7 +604,7 @@ export function registerTools(server: Server, config: GodotConfig): void {
           args as Record<string, unknown>,
         )
       } else {
-        const handler = TOOL_HANDLERS[name]
+        const handler = Object.hasOwn(TOOL_HANDLERS, name) ? TOOL_HANDLERS[name] : undefined
         if (!handler) {
           const validTools = TOOLS.map((t) => t.name)
           const closest = findClosestMatch(name, validTools)

--- a/tests/registry-security.test.ts
+++ b/tests/registry-security.test.ts
@@ -144,6 +144,19 @@ describe('registerTools security integration', () => {
     expect(result.content[0].text).not.toContain('<untrusted_godot_content>')
   })
 
+  it('should reject Object.prototype properties as unknown tools', async () => {
+    const maliciousNames = ['toString', 'valueOf', 'constructor', '__proto__']
+    for (const name of maliciousNames) {
+      const result = (await callToolHandler?.({
+        params: { name, arguments: {} },
+      })) as { isError: boolean; content: Array<{ text: string }> }
+
+      expect(result.isError).toBe(true)
+      expect(result.content[0].text).toContain(`Unknown tool: ${name}`)
+      expect(result.content[0].text).not.toContain('<untrusted_godot_content>')
+    }
+  })
+
   it('should suggest closest match for unknown tool', async () => {
     const result = (await callToolHandler?.({
       params: { name: 'scrip', arguments: {} },


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The central tool dispatcher in `src/tools/registry.ts` accessed `TOOL_HANDLERS` using a direct object lookup `TOOL_HANDLERS[name]`. If a user requested a tool named after an `Object.prototype` property (e.g., `"toString"` or `"constructor"`), the server would resolve the built-in function, bypassing the `!handler` check, and attempt to invoke it as a tool.
🎯 Impact: This could lead to a crash or unexpected application state if the prototype function was executed as a tool handler, which presents a denial of service or application logical bypass vector.
🔧 Fix: Used `Object.hasOwn(TOOL_HANDLERS, name)` to strictly enforce that the requested tool name is an explicitly registered, own property of the registry map, gracefully rejecting malicious strings with an "Unknown tool" error.
✅ Verification: Added security integration tests inside `tests/registry-security.test.ts` to assert that `Object.prototype` strings like `"toString"`, `"valueOf"`, and `"__proto__"` are safely caught and return standard "Unknown tool" error responses. Run `bun run test` to verify.

---
*PR created automatically by Jules for task [12968658484227379799](https://jules.google.com/task/12968658484227379799) started by @n24q02m*