### PR TITLE
⚡ Bolt: Optimize pathExists checks in scenes composite tool

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,7 @@ This ensures that "create" matches "create" even if "create_node" appears earlie
 ## 2025-06-25 - [Optimize scene info extraction]
 **Learning:** Using `scene.nodes.map` constructs an intermediate array dynamically, triggering repeated memory allocations when parsing scenes with tens of thousands of nodes. This adds significant garbage collection overhead compared to pre-allocating an array.
 **Action:** Replace `scene.nodes.map(...)` in `src/tools/composite/scenes.ts` with a direct loop over a pre-allocated array (`new Array(scene.nodes.length)`). This avoids intermediary allocation overhead and significantly speeds up scene info extraction.
+
+## 2025-06-25 - [Optimize redundant pathExists checks in scenes tool]
+**Learning:** Sequential `pathExists` followed by I/O operations like `writeFile` or `copyFile` causes redundant filesystem calls, which can impact performance. Additionally, checking `pathExists` before creating or copying a file is not thread-safe/atomic.
+**Action:** Replaced `pathExists` + `writeFile` with `writeFile` using `flag: 'wx'` to atomically check for existence and create the file, catching `EEXIST`. Replaced `pathExists` + `copyFile` with `copyFile` using `constants.COPYFILE_EXCL` flag from `node:fs` to atomically check for existence and copy the file, catching `EEXIST`. Applied in `src/tools/composite/scenes.ts`.

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -3,6 +3,7 @@
  * Actions: create | list | info | delete | duplicate | set_main
  */
 
+import { constants } from 'node:fs'
 import { copyFile, mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/promises'
 import { basename, dirname, join } from 'node:path'
 import type { GodotConfig, SceneInfo } from '../../godot/types.js'
@@ -106,17 +107,21 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       }
 
       const fullPath = safeResolve(projectPath as string, scenePath)
-      if (await pathExists(fullPath)) {
-        throw new GodotMCPError(
-          `Scene already exists: ${scenePath}`,
-          'SCENE_ERROR',
-          'Use a different path or delete the existing scene first.',
-        )
-      }
-
       const content = generateTscnContent(rootName, rootType)
       await mkdir(dirname(fullPath), { recursive: true })
-      await writeFile(fullPath, content, 'utf-8')
+      try {
+        // ⚡ Bolt: Using 'wx' flag to atomically check for existence and create file, reducing redundant I/O calls
+        await writeFile(fullPath, content, { encoding: 'utf-8', flag: 'wx' })
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+          throw new GodotMCPError(
+            `Scene already exists: ${scenePath}`,
+            'SCENE_ERROR',
+            'Use a different path or delete the existing scene first.',
+          )
+        }
+        throw error
+      }
 
       return formatSuccess(`Created scene: ${scenePath}\nRoot: ${rootName} (${rootType})`)
     }
@@ -206,18 +211,18 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       const srcFull = resolvePath(projectPath, scenePath)
       const dstFull = resolvePath(projectPath, newPath as string)
 
-      if (await pathExists(dstFull)) {
-        throw new GodotMCPError(
-          `Destination already exists: ${newPath}`,
-          'SCENE_ERROR',
-          'Choose a different destination.',
-        )
-      }
-
       await mkdir(dirname(dstFull), { recursive: true })
       try {
-        await copyFile(srcFull, dstFull)
+        // ⚡ Bolt: Using constants.COPYFILE_EXCL flag to atomically check for existence and copy file, reducing redundant I/O calls
+        await copyFile(srcFull, dstFull, constants.COPYFILE_EXCL)
       } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+          throw new GodotMCPError(
+            `Destination already exists: ${newPath}`,
+            'SCENE_ERROR',
+            'Choose a different destination.',
+          )
+        }
         if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
           throw new GodotMCPError(`Source scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the source path.')
         }

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -8,7 +8,7 @@ import { copyFile, mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/p
 import { basename, dirname, join } from 'node:path'
 import type { GodotConfig, SceneInfo } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { pathExists, safeResolve } from '../helpers/paths.js'
+import { safeResolve } from '../helpers/paths.js'
 import { setSettingInContent } from '../helpers/project-settings.js'
 import { parseSceneContent } from '../helpers/scene-parser.js'
 


### PR DESCRIPTION
💡 What: Replaced non-atomic and redundant `pathExists` checks followed by I/O operations (`writeFile`, `copyFile`) with direct atomic operations using the `wx` flag and `constants.COPYFILE_EXCL`. Caught `EEXIST` errors to return the appropriate Godot MCP errors.
🎯 Why: Calling `pathExists` prior to creating or copying a file creates a Time-of-Check to Time-of-Use (TOCTOU) race condition and introduces a redundant I/O filesystem call. Using atomic create/copy operations is inherently faster and safer.
📊 Impact: Reduces filesystem calls by half for successful creations and duplicates. Avoids race conditions.
🔬 Measurement: Run tests using `bun run test`. Ensure all tests in `tests/composite/scenes.test.ts` pass, specifically the tests concerning path already existing.

---
*PR created automatically by Jules for task [6146655842281476862](https://jules.google.com/task/6146655842281476862) started by @n24q02m*