### PR TITLE
⚡ Bolt: Optimize redundant pathExists checks in scenes tool

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,7 @@ This ensures that "create" matches "create" even if "create_node" appears earlie
 ## 2025-06-25 - [Optimize scene info extraction]
 **Learning:** Using `scene.nodes.map` constructs an intermediate array dynamically, triggering repeated memory allocations when parsing scenes with tens of thousands of nodes. This adds significant garbage collection overhead compared to pre-allocating an array.
 **Action:** Replace `scene.nodes.map(...)` in `src/tools/composite/scenes.ts` with a direct loop over a pre-allocated array (`new Array(scene.nodes.length)`). This avoids intermediary allocation overhead and significantly speeds up scene info extraction.
+
+## 2025-06-25 - [Optimization] Redundant pathExists checks in scenes tool
+**Learning:** Sequential `pathExists` and `writeFile`/`copyFile` operations result in redundant filesystem calls and introduce TOCTOU (Time-of-Check to Time-of-Use) race conditions. Direct execution with `try-catch` handling for `EEXIST` (using `wx` flag for writes and `COPYFILE_EXCL` for copies) is more efficient and thread-safe.
+**Action:** Replaced `pathExists` followed by I/O operations in `handleScenes` with direct calls and `NodeJS.ErrnoException` code checks.

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -3,6 +3,7 @@
  * Actions: create | list | info | delete | duplicate | set_main
  */
 
+import { constants } from 'node:fs'
 import { copyFile, mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/promises'
 import { basename, dirname, join } from 'node:path'
 import type { GodotConfig, SceneInfo } from '../../godot/types.js'
@@ -106,17 +107,24 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       }
 
       const fullPath = safeResolve(projectPath as string, scenePath)
-      if (await pathExists(fullPath)) {
-        throw new GodotMCPError(
-          `Scene already exists: ${scenePath}`,
-          'SCENE_ERROR',
-          'Use a different path or delete the existing scene first.',
-        )
-      }
 
       const content = generateTscnContent(rootName, rootType)
       await mkdir(dirname(fullPath), { recursive: true })
-      await writeFile(fullPath, content, 'utf-8')
+
+      // ⚡ Bolt: Using try-to-perform instead of pathExists to reduce redundant I/O calls
+      // Use 'wx' flag to fail atomically if the file already exists
+      try {
+        await writeFile(fullPath, content, { encoding: 'utf-8', flag: 'wx' })
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+          throw new GodotMCPError(
+            `Scene already exists: ${scenePath}`,
+            'SCENE_ERROR',
+            'Use a different path or delete the existing scene first.',
+          )
+        }
+        throw error
+      }
 
       return formatSuccess(`Created scene: ${scenePath}\nRoot: ${rootName} (${rootType})`)
     }
@@ -206,18 +214,20 @@ export async function handleScenes(action: string, args: Record<string, unknown>
       const srcFull = resolvePath(projectPath, scenePath)
       const dstFull = resolvePath(projectPath, newPath as string)
 
-      if (await pathExists(dstFull)) {
-        throw new GodotMCPError(
-          `Destination already exists: ${newPath}`,
-          'SCENE_ERROR',
-          'Choose a different destination.',
-        )
-      }
-
       await mkdir(dirname(dstFull), { recursive: true })
+
+      // ⚡ Bolt: Using try-to-perform instead of pathExists to reduce redundant I/O calls
+      // Use COPYFILE_EXCL to fail atomically if the destination already exists
       try {
-        await copyFile(srcFull, dstFull)
+        await copyFile(srcFull, dstFull, constants.COPYFILE_EXCL)
       } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+          throw new GodotMCPError(
+            `Destination already exists: ${newPath}`,
+            'SCENE_ERROR',
+            'Choose a different destination.',
+          )
+        }
         if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
           throw new GodotMCPError(`Source scene not found: ${scenePath}`, 'SCENE_ERROR', 'Check the source path.')
         }

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -8,7 +8,7 @@ import { copyFile, mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/p
 import { basename, dirname, join } from 'node:path'
 import type { GodotConfig, SceneInfo } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { pathExists, safeResolve } from '../helpers/paths.js'
+import { safeResolve } from '../helpers/paths.js'
 import { setSettingInContent } from '../helpers/project-settings.js'
 import { parseSceneContent } from '../helpers/scene-parser.js'
 


### PR DESCRIPTION
💡 What: Replaced sequential `pathExists` + I/O operations with direct, atomic I/O operations in `handleScenes` ('create' and 'duplicate' actions).
🎯 Why: Removes redundant file system syscalls to improve performance and resolves a Time-of-Check to Time-of-Use (TOCTOU) race condition, making file creation/duplication thread-safe.
📊 Impact: Minor speedup on file operations and guaranteed file operation atomicity.
🔬 Measurement: Run the test suite (`bun run test`) to verify functionality matches previous behavior.

---
*PR created automatically by Jules for task [6394461827823695549](https://jules.google.com/task/6394461827823695549) started by @n24q02m*