### PR TITLE
fix: add explicit node types to tsconfig for TypeScript 7 compat

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "ES2024",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "types": ["node"],
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Unblocks the pending typescript@^7.0.2 Renovate bump (#993), which currently fails CI on all 3 OS with:

    error TS2503: Cannot find namespace 'NodeJS'.
    error TS2591: Cannot find name 'node:fs/promises'...

Root cause: TypeScript 7's native compiler no longer implicitly includes ambient `@types/*` packages when `compilerOptions.types` is omitted from tsconfig.json, unlike 5.x. mcp-core and better-email-mcp already declare `"types": ["node"]`; better-godot-mcp did not.

Fix: add the missing field. No behavior change for the current TypeScript 5.9 toolchain — this is additive/defensive.