### PR TITLE
feat: add detect and doctor cli subcommands

### DIFF
--- a/scripts/start-server.ts
+++ b/scripts/start-server.ts
@@ -21,4 +21,13 @@ async function startServer() {
   }
 }
 
-startServer()
+async function main() {
+  const sub = process.argv[2]
+  if (sub === 'detect' || sub === 'doctor') {
+    const { runGodotCli } = await import('../src/godot-cli.js')
+    process.exit(await runGodotCli(sub))
+  }
+  await startServer()
+}
+
+main()

--- a/src/godot-cli.ts
+++ b/src/godot-cli.ts
@@ -1,0 +1,63 @@
+/**
+ * CLI subcommands: `detect` and `doctor`
+ *
+ * Invoked from scripts/start-server.ts when argv[2] matches; reuses the same
+ * detection/project-check logic as the `config` composite tool's
+ * `detect_godot`/`check` actions, but prints plain stdout/stderr for a CLI
+ * rather than an MCP tool response.
+ */
+
+import { join, resolve } from 'node:path'
+import { detectGodot } from './godot/detector.js'
+import { pathExists } from './tools/helpers/paths.js'
+
+async function runDetect(): Promise<number> {
+  const result = detectGodot()
+
+  console.log(
+    JSON.stringify(
+      {
+        found: result !== null,
+        path: result?.path ?? null,
+        version: result?.version ?? null,
+        source: result?.source ?? null,
+      },
+      null,
+      2,
+    ),
+  )
+
+  if (!result) {
+    console.error('Godot not found. Set the GODOT_PATH environment variable to your Godot binary.')
+    return 1
+  }
+  return 0
+}
+
+async function runDoctor(): Promise<number> {
+  const detection = detectGodot()
+
+  if (detection) {
+    console.log(`[ok] godot binary: ${detection.path} (source: ${detection.source})`)
+    console.log(`[ok] godot version: ${detection.version.raw}`)
+  } else {
+    console.log('[fail] godot binary: not found')
+    console.log('[fail] godot version: unknown (set GODOT_PATH or install Godot)')
+  }
+
+  const projectPath = process.env.GODOT_PROJECT_PATH || process.cwd()
+  const hasProject = await pathExists(join(projectPath, 'project.godot'))
+  if (hasProject) {
+    console.log(`[ok] project: ${resolve(projectPath)}`)
+  } else {
+    console.log(`[warn] project: no project.godot found at ${resolve(projectPath)} (set GODOT_PROJECT_PATH)`)
+  }
+
+  // Godot binary is the only hard requirement; a missing/invalid project is a warning.
+  return detection ? 0 : 1
+}
+
+export async function runGodotCli(cmd: 'detect' | 'doctor'): Promise<number> {
+  if (cmd === 'detect') return runDetect()
+  return runDoctor()
+}

--- a/tests/godot-cli.test.ts
+++ b/tests/godot-cli.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for CLI subcommands (detect, doctor)
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as detectorModule from '../src/godot/detector.js'
+import type * as pathsModule from '../src/tools/helpers/paths.js'
+
+vi.mock('../src/godot/detector.js', async () => {
+  const actual = await vi.importActual<typeof detectorModule>('../src/godot/detector.js')
+  return {
+    ...actual,
+    detectGodot: vi.fn(),
+  }
+})
+
+vi.mock('../src/tools/helpers/paths.js', async () => {
+  const actual = await vi.importActual<typeof pathsModule>('../src/tools/helpers/paths.js')
+  return {
+    ...actual,
+    pathExists: vi.fn(),
+  }
+})
+
+import * as detector from '../src/godot/detector.js'
+import { runGodotCli } from '../src/godot-cli.js'
+import * as paths from '../src/tools/helpers/paths.js'
+
+const FOUND = {
+  path: '/usr/bin/godot',
+  version: { major: 4, minor: 3, patch: 0, label: 'stable', raw: 'Godot Engine v4.3.stable.official' },
+  source: 'path' as const,
+}
+
+describe('godot-cli', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('detect', () => {
+    it('prints found JSON and returns 0 when Godot is detected', async () => {
+      vi.mocked(detector.detectGodot).mockReturnValue(FOUND)
+
+      const rc = await runGodotCli('detect')
+
+      expect(rc).toBe(0)
+      const printed = JSON.parse(logSpy.mock.calls[0][0] as string)
+      expect(printed).toEqual({ found: true, path: FOUND.path, version: FOUND.version, source: FOUND.source })
+      expect(errorSpy).not.toHaveBeenCalled()
+    })
+
+    it('prints not-found JSON, hints GODOT_PATH on stderr, and returns 1 when not detected', async () => {
+      vi.mocked(detector.detectGodot).mockReturnValue(null)
+
+      const rc = await runGodotCli('detect')
+
+      expect(rc).toBe(1)
+      const printed = JSON.parse(logSpy.mock.calls[0][0] as string)
+      expect(printed).toEqual({ found: false, path: null, version: null, source: null })
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('GODOT_PATH'))
+    })
+  })
+
+  describe('doctor', () => {
+    it('reports [ok] for godot and project, returns 0 when both are found', async () => {
+      vi.mocked(detector.detectGodot).mockReturnValue(FOUND)
+      vi.mocked(paths.pathExists).mockResolvedValue(true)
+
+      const rc = await runGodotCli('doctor')
+
+      expect(rc).toBe(0)
+      const lines = logSpy.mock.calls.map((c) => c[0] as string)
+      expect(lines.some((l) => l.startsWith('[ok]') && l.includes('godot binary'))).toBe(true)
+      expect(lines.some((l) => l.startsWith('[ok]') && l.includes('godot version'))).toBe(true)
+      expect(lines.some((l) => l.startsWith('[ok]') && l.includes('project'))).toBe(true)
+    })
+
+    it('reports [warn] for a missing project but still returns 0 when Godot is found', async () => {
+      vi.mocked(detector.detectGodot).mockReturnValue(FOUND)
+      vi.mocked(paths.pathExists).mockResolvedValue(false)
+
+      const rc = await runGodotCli('doctor')
+
+      expect(rc).toBe(0)
+      const lines = logSpy.mock.calls.map((c) => c[0] as string)
+      expect(lines.some((l) => l.startsWith('[warn]') && l.includes('project'))).toBe(true)
+    })
+
+    it('reports [fail] for godot and returns 1 when Godot is not detected', async () => {
+      vi.mocked(detector.detectGodot).mockReturnValue(null)
+      vi.mocked(paths.pathExists).mockResolvedValue(false)
+
+      const rc = await runGodotCli('doctor')
+
+      expect(rc).toBe(1)
+      const lines = logSpy.mock.calls.map((c) => c[0] as string)
+      expect(lines.some((l) => l.startsWith('[fail]') && l.includes('godot binary'))).toBe(true)
+      expect(lines.some((l) => l.startsWith('[fail]') && l.includes('godot version'))).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
## S6 / WS-B4 (godot half)

Hand-rolled argv dispatch following the better-email-mcp `auth` precedent (no Python build_cli — TS server):
- `better-godot-mcp detect` — reuses `detectGodot()` (env → PATH → system paths), JSON `{found, path, version, source}` on stdout, rc 0/1 + GODOT_PATH hint on stderr.
- `better-godot-mcp doctor` — `[ok]/[warn]/[fail]` lines: binary + version via detectGodot, project check (`GODOT_PROJECT_PATH` or cwd) as warn-only. rc keyed on binary presence.
- Bare launch and `--http` fall through to `initServer()` byte-identically; CLI module is dynamic-imported only on the two subcommands (bundling into bin/cli.mjs verified — no src/ dependency at runtime).

Evidence: bun check/test 927 passed (5 new CLI tests, mocked detection), real built-artifact smoke on this machine (Scoop Godot found; doctor ok/ok/warn; --http unaffected). Task-reviewed: Approved.