### PR TITLE
fix: capture project run output, add project logs, and stop leaking the process

### DIFF
--- a/src/docs/project.md
+++ b/src/docs/project.md
@@ -1,7 +1,7 @@
 # Project Tool - Full Documentation
 
 ## Overview
-Project lifecycle management: info, settings, run, stop.
+Project lifecycle management: info, settings, run, logs, stop.
 
 ## Actions
 
@@ -18,9 +18,17 @@ Get installed Godot Engine version.
 ```
 
 ### run
-Run the Godot project.
+Run the Godot project. stdout/stderr are captured into a 400-line ring buffer per PID -- use `logs` to read them.
 ```json
 {"action": "run", "project_path": "/path/to/godot/project"}
+```
+
+### logs
+Read the last captured stdout/stderr lines from a run started with `run`. Works right after a crash too (logs for
+the last 10 exited processes are kept). Defaults to the most recently started PID if `pid` is omitted.
+```json
+{"action": "logs"}
+{"action": "logs", "pid": 12345}
 ```
 
 ### stop
@@ -49,6 +57,7 @@ Export the project using a preset.
 
 ## Parameters
 - `project_path` - Path to Godot project directory (optional, uses config default)
+- `pid` - PID to read logs for (for logs; optional, defaults to the most recently started PID)
 - `key` - Settings key in section/key format (for settings_get/set)
 - `value` - Settings value (for settings_set)
 - `preset` - Export preset name (for export)

--- a/src/godot/headless.ts
+++ b/src/godot/headless.ts
@@ -155,6 +155,10 @@ export function spawnCaptured(bin: string, args: string[]): { pid: number | unde
 
   if (child.pid !== undefined) {
     const pid = child.pid
+    // The OS can reuse a pid: if a stale exited-bookkeeping entry for this same pid is
+    // still pending eviction, drop it now so it can never evict *this* live process's logs.
+    const staleIdx = exitedPidOrder.indexOf(pid)
+    if (staleIdx !== -1) exitedPidOrder.splice(staleIdx, 1)
     projectLogs.set(pid, { lines: [], dropped: false })
     liveProcessPids.add(pid)
     child.stdout?.on('data', (chunk: Buffer) => pushLog(pid, chunk))

--- a/src/godot/headless.ts
+++ b/src/godot/headless.ts
@@ -7,8 +7,15 @@ import { promisify } from 'node:util'
 import type { HeadlessResult } from './types.js'
 
 const DEFAULT_TIMEOUT_MS = 30_000
+const RING_MAX = 400
 
 const execFileAsync = promisify(execFile)
+
+/** Last RING_MAX stdout/stderr lines per spawned PID, for the `project logs` action. */
+const projectLogs = new Map<number, string[]>()
+
+/** child.stdout/stderr are typed as plain `Readable`, but the underlying pipe handle exposes `unref()`. */
+type UnrefableStream = { unref?: () => void }
 
 /**
  * Execute a Godot command and capture output
@@ -90,6 +97,45 @@ export async function execGodotAsync(
   }
 }
 
+function pushLog(pid: number, chunk: Buffer): void {
+  const lines = projectLogs.get(pid)
+  if (!lines) return
+  for (const line of chunk.toString('utf8').split(/\r?\n/)) {
+    if (line === '') continue
+    lines.push(line)
+    if (lines.length > RING_MAX) lines.shift()
+  }
+}
+
+/**
+ * Spawn a detached, non-blocking process and capture its stdout/stderr into a
+ * per-pid ring buffer (see getProjectLogs). Shared by runGodotProject; exported
+ * separately so it can be unit-tested without a real Godot binary.
+ */
+export function spawnCaptured(bin: string, args: string[]): { pid: number | undefined } {
+  const child = spawn(bin, args, {
+    detached: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  if (child.pid !== undefined) {
+    const pid = child.pid
+    projectLogs.set(pid, [])
+    child.stdout?.on('data', (chunk: Buffer) => pushLog(pid, chunk))
+    child.stderr?.on('data', (chunk: Buffer) => pushLog(pid, chunk))
+    // child.unref() alone does not release the event loop: the piped stdout/stderr
+    // handles stay ref'd for as long as the (detached) child keeps running, which
+    // would keep this server process alive too. Unref them explicitly. The `Readable`
+    // type doesn't declare `unref` but the underlying pipe handle supports it at runtime.
+    ;(child.stdout as UnrefableStream | null)?.unref?.()
+    ;(child.stderr as UnrefableStream | null)?.unref?.()
+  }
+
+  child.unref()
+
+  return { pid: child.pid }
+}
+
 /**
  * Run Godot project (non-blocking)
  */
@@ -103,14 +149,24 @@ export function runGodotProject(
     args.push(scenePath)
   }
 
-  const child = spawn(godotPath, args, {
-    detached: true,
-    stdio: 'ignore',
-  })
+  return spawnCaptured(godotPath, args)
+}
 
-  child.unref()
+/** Last captured output lines for a PID started via runGodotProject/spawnCaptured. */
+export function getProjectLogs(pid: number): { lines: string[]; truncated: boolean } | undefined {
+  const lines = projectLogs.get(pid)
+  if (!lines) return undefined
+  return { lines: [...lines], truncated: lines.length >= RING_MAX }
+}
 
-  return { pid: child.pid }
+/** Drop the ring buffer entry for a PID (call once the process is no longer tracked). */
+export function clearProjectLogs(pid: number): void {
+  projectLogs.delete(pid)
+}
+
+/** PIDs with a live ring buffer entry, i.e. spawned and not yet cleared. Used for best-effort cleanup on shutdown. */
+export function getTrackedPids(): number[] {
+  return [...projectLogs.keys()]
 }
 
 /**

--- a/src/godot/headless.ts
+++ b/src/godot/headless.ts
@@ -2,17 +2,31 @@
  * Run Godot in headless mode for CLI operations
  */
 
-import { execFile, spawn, spawnSync } from 'node:child_process'
+import { execFile, execFileSync, spawn, spawnSync } from 'node:child_process'
 import { promisify } from 'node:util'
 import type { HeadlessResult } from './types.js'
 
 const DEFAULT_TIMEOUT_MS = 30_000
 const RING_MAX = 400
+/** Cap on how many *exited* processes' logs are retained (bounds memory). Live processes are never evicted. */
+const MAX_EXITED_LOGS = 10
 
 const execFileAsync = promisify(execFile)
 
+interface LogBuffer {
+  lines: string[]
+  /** True once at least one line was dropped from the front of the ring buffer. */
+  dropped: boolean
+}
+
 /** Last RING_MAX stdout/stderr lines per spawned PID, for the `project logs` action. */
-const projectLogs = new Map<number, string[]>()
+const projectLogs = new Map<number, LogBuffer>()
+
+/** Pids with a process currently running -- added at spawn, removed on exit or explicit clear. */
+const liveProcessPids = new Set<number>()
+
+/** FIFO of exited pids whose logs are still retained (oldest first); bounds `projectLogs` for finished/crashed runs. */
+const exitedPidOrder: number[] = []
 
 /** child.stdout/stderr are typed as plain `Readable`, but the underlying pipe handle exposes `unref()`. */
 type UnrefableStream = { unref?: () => void }
@@ -98,12 +112,33 @@ export async function execGodotAsync(
 }
 
 function pushLog(pid: number, chunk: Buffer): void {
-  const lines = projectLogs.get(pid)
-  if (!lines) return
+  const buf = projectLogs.get(pid)
+  if (!buf) return
   for (const line of chunk.toString('utf8').split(/\r?\n/)) {
     if (line === '') continue
-    lines.push(line)
-    if (lines.length > RING_MAX) lines.shift()
+    buf.lines.push(line)
+    if (buf.lines.length > RING_MAX) {
+      buf.lines.shift()
+      buf.dropped = true
+    }
+  }
+}
+
+/**
+ * Called once a spawned process exits. Moves the pid from "live" to "exited" bookkeeping
+ * and, if that pushes the exited-with-retained-logs count over MAX_EXITED_LOGS, evicts the
+ * oldest exited pid's logs. Logs are kept (not dropped) on exit so `project logs` still
+ * works right after a crash -- only capped in count, and only for pids no longer live.
+ */
+function handleProcessExit(pid: number): void {
+  // If clearProjectLogs already ran for this pid (e.g. `project stop`), there is
+  // nothing left to retain or evict -- avoid resurrecting stale bookkeeping.
+  if (!liveProcessPids.delete(pid)) return
+
+  exitedPidOrder.push(pid)
+  if (exitedPidOrder.length > MAX_EXITED_LOGS) {
+    const oldest = exitedPidOrder.shift()
+    if (oldest !== undefined) projectLogs.delete(oldest)
   }
 }
 
@@ -120,9 +155,11 @@ export function spawnCaptured(bin: string, args: string[]): { pid: number | unde
 
   if (child.pid !== undefined) {
     const pid = child.pid
-    projectLogs.set(pid, [])
+    projectLogs.set(pid, { lines: [], dropped: false })
+    liveProcessPids.add(pid)
     child.stdout?.on('data', (chunk: Buffer) => pushLog(pid, chunk))
     child.stderr?.on('data', (chunk: Buffer) => pushLog(pid, chunk))
+    child.once('exit', () => handleProcessExit(pid))
     // child.unref() alone does not release the event loop: the piped stdout/stderr
     // handles stay ref'd for as long as the (detached) child keeps running, which
     // would keep this server process alive too. Unref them explicitly. The `Readable`
@@ -152,21 +189,53 @@ export function runGodotProject(
   return spawnCaptured(godotPath, args)
 }
 
-/** Last captured output lines for a PID started via runGodotProject/spawnCaptured. */
+/**
+ * Last captured output lines for a PID started via runGodotProject/spawnCaptured.
+ * Works for both live and recently-exited processes (see MAX_EXITED_LOGS), so
+ * `project logs` still works right after a crash.
+ */
 export function getProjectLogs(pid: number): { lines: string[]; truncated: boolean } | undefined {
-  const lines = projectLogs.get(pid)
-  if (!lines) return undefined
-  return { lines: [...lines], truncated: lines.length >= RING_MAX }
+  const buf = projectLogs.get(pid)
+  if (!buf) return undefined
+  return { lines: [...buf.lines], truncated: buf.dropped }
 }
 
-/** Drop the ring buffer entry for a PID (call once the process is no longer tracked). */
+/** Drop the ring buffer entry for a PID (call once the process is no longer tracked, e.g. by `project stop`). */
 export function clearProjectLogs(pid: number): void {
   projectLogs.delete(pid)
+  liveProcessPids.delete(pid)
+  const idx = exitedPidOrder.indexOf(pid)
+  if (idx !== -1) exitedPidOrder.splice(idx, 1)
 }
 
-/** PIDs with a live ring buffer entry, i.e. spawned and not yet cleared. Used for best-effort cleanup on shutdown. */
+/** PIDs with a currently-running process (spawned, not yet exited or explicitly cleared). Used for best-effort cleanup on shutdown. */
 export function getTrackedPids(): number[] {
-  return [...projectLogs.keys()]
+  return [...liveProcessPids]
+}
+
+/**
+ * Best-effort kill of a process, tree-killing on Windows (plain SIGTERM there leaves
+ * children of the target process running -- the exact orphan this module exists to fix).
+ * Shared by `project stop` and the server shutdown handler. Never throws.
+ * Returns true if a kill was actually issued (the process appeared alive), false if it
+ * was already gone.
+ */
+export function killProcessTree(pid: number): boolean {
+  try {
+    if (process.platform === 'win32') {
+      try {
+        process.kill(pid, 0) // liveness probe; throws if the process doesn't exist
+      } catch {
+        return false
+      }
+      execFileSync('taskkill', ['/F', '/PID', pid.toString(), '/T'], { stdio: 'pipe' })
+    } else {
+      process.kill(pid, 'SIGTERM')
+    }
+    return true
+  } catch {
+    return false
+  }
 }
 
 /**

--- a/src/init-server.ts
+++ b/src/init-server.ts
@@ -14,6 +14,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import pkg from '../package.json' with { type: 'json' }
 import { detectGodot } from './godot/detector.js'
+import { getTrackedPids } from './godot/headless.js'
 import type { GodotConfig } from './godot/types.js'
 import { logger } from './tools/helpers/logger.js'
 import { registerTools } from './tools/registry.js'
@@ -96,6 +97,15 @@ export async function initServer(): Promise<void> {
       // Keep process alive until SIGINT/SIGTERM.
       await new Promise<void>((resolve) => {
         const shutdown = async (): Promise<void> => {
+          // Godot processes started via `project run` are detached; without this,
+          // they outlive the server on shutdown (see spec: "highest-value item").
+          for (const pid of getTrackedPids()) {
+            try {
+              process.kill(pid)
+            } catch {
+              // Already exited or inaccessible; best-effort cleanup only.
+            }
+          }
           await handle.close()
           resolve()
         }

--- a/src/init-server.ts
+++ b/src/init-server.ts
@@ -14,7 +14,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import pkg from '../package.json' with { type: 'json' }
 import { detectGodot } from './godot/detector.js'
-import { getTrackedPids } from './godot/headless.js'
+import { getTrackedPids, killProcessTree } from './godot/headless.js'
 import type { GodotConfig } from './godot/types.js'
 import { logger } from './tools/helpers/logger.js'
 import { registerTools } from './tools/registry.js'
@@ -99,9 +99,12 @@ export async function initServer(): Promise<void> {
         const shutdown = async (): Promise<void> => {
           // Godot processes started via `project run` are detached; without this,
           // they outlive the server on shutdown (see spec: "highest-value item").
+          // killProcessTree tree-kills on Windows (matches `project stop`) and is
+          // itself best-effort, but wrap it anyway in case a mocked/future
+          // implementation throws -- a stale pid must never block handle.close().
           for (const pid of getTrackedPids()) {
             try {
-              process.kill(pid)
+              killProcessTree(pid)
             } catch {
               // Already exited or inaccessible; best-effort cleanup only.
             }

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -3,10 +3,15 @@
  * Actions: info | version | run | stop | settings_get | settings_set | export
  */
 
-import { execFileSync } from 'node:child_process'
 import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { clearProjectLogs, execGodotAsync, getProjectLogs, runGodotProject } from '../../godot/headless.js'
+import {
+  clearProjectLogs,
+  execGodotAsync,
+  getProjectLogs,
+  killProcessTree,
+  runGodotProject,
+} from '../../godot/headless.js'
 import type { GodotConfig, ProjectInfo } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
@@ -195,23 +200,8 @@ export async function handleProject(action: string, args: Record<string, unknown
         if (!isValidPid(pid)) {
           continue
         }
-
-        try {
-          if (process.platform === 'win32') {
-            // Check if process exists before attempting to kill
-            try {
-              process.kill(pid, 0)
-              execFileSync('taskkill', ['/F', '/PID', pid.toString(), '/T'], { stdio: 'pipe' })
-            } catch {
-              // Process already dead
-              continue
-            }
-          } else {
-            process.kill(pid, 'SIGTERM')
-          }
+        if (killProcessTree(pid)) {
           stoppedCount++
-        } catch {
-          // Process might have already terminated
         }
       }
 
@@ -331,7 +321,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       throw new GodotMCPError(
         `Unknown action: ${action}`,
         'INVALID_ACTION',
-        'Valid actions: info, version, run, stop, settings_get, settings_set, export. Use help tool for full docs.',
+        'Valid actions: info, version, run, logs, stop, settings_get, settings_set, export. Use help tool for full docs.',
       )
   }
 }

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -6,7 +6,7 @@
 import { execFileSync } from 'node:child_process'
 import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { execGodotAsync, runGodotProject } from '../../godot/headless.js'
+import { clearProjectLogs, execGodotAsync, getProjectLogs, runGodotProject } from '../../godot/headless.js'
 import type { GodotConfig, ProjectInfo } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
@@ -149,7 +149,39 @@ export async function handleProject(action: string, args: Record<string, unknown
         validatePid(pid)
         config.activePids.push(pid)
       }
-      return formatSuccess(`Godot project started (PID: ${pid})${scenePath ? ` for scene ${scenePath}` : ''}`)
+      return formatSuccess(
+        `Godot project started (PID: ${pid})${scenePath ? ` for scene ${scenePath}` : ''}. ` +
+          'Use project logs to see output, project stop to terminate.',
+      )
+    }
+
+    case 'logs': {
+      let pid: number | undefined
+      if (args.pid !== undefined) {
+        if (typeof args.pid !== 'number' || !isValidPid(args.pid)) {
+          throw new GodotMCPError('Invalid PID', 'INVALID_ARGS', 'pid must be a positive integer.')
+        }
+        pid = args.pid
+      } else {
+        pid = config.activePids[config.activePids.length - 1]
+      }
+
+      if (pid === undefined) {
+        throw new GodotMCPError('No running project', 'PROCESS_NOT_FOUND', 'Use project run first.')
+      }
+
+      const logs = getProjectLogs(pid)
+      if (!logs) {
+        throw new GodotMCPError(
+          `No logs for PID ${pid}`,
+          'PROCESS_NOT_FOUND',
+          'This process was not started by this server, or its logs were already cleared by project stop.',
+        )
+      }
+
+      return formatSuccess(
+        `Last ${logs.lines.length} line(s)${logs.truncated ? ' (older lines dropped)' : ''}:\n${logs.lines.join('\n')}`,
+      )
     }
 
     case 'stop': {
@@ -183,6 +215,9 @@ export async function handleProject(action: string, args: Record<string, unknown
         }
       }
 
+      for (const pid of config.activePids) {
+        clearProjectLogs(pid)
+      }
       config.activePids = []
       return formatSuccess(`Godot processes stopped (Stopped ${stoppedCount} tracked processes)`)
     }

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -6,6 +6,7 @@ export type GodotMCPErrorCode =
   | 'GODOT_NOT_FOUND'
   | 'VERSION_MISMATCH'
   | 'PROJECT_NOT_FOUND'
+  | 'PROCESS_NOT_FOUND'
   | 'SCENE_ERROR'
   | 'SCRIPT_ERROR'
   | 'NODE_ERROR'

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -64,6 +64,7 @@ const P0_TOOLS = [
       '- info (-> project_path): project metadata',
       '- version: Godot engine version',
       '- run (-> scene_path, project_path): launch game',
+      '- logs (-> pid): last captured stdout/stderr lines from a run (default: most recently started)',
       '- stop: stop running game',
       '- settings_get (key -> project_path): read project setting',
       '- settings_set (key, value -> project_path): write project setting',
@@ -75,11 +76,12 @@ const P0_TOOLS = [
       properties: {
         action: {
           type: 'string',
-          enum: ['info', 'version', 'run', 'stop', 'settings_get', 'settings_set', 'export'],
+          enum: ['info', 'version', 'run', 'logs', 'stop', 'settings_get', 'settings_set', 'export'],
           description: 'Action to perform',
         },
         project_path: { type: 'string', description: 'Path to Godot project directory' },
         scene_path: { type: 'string', description: 'Path to a specific scene to run (optional)' },
+        pid: { type: 'number', description: 'PID to read logs for (for logs; default: most recently started)' },
         key: { type: 'string', description: 'Settings key (for settings_get/set)' },
         value: { type: 'string', description: 'Settings value (for settings_set)' },
         preset: { type: 'string', description: 'Export preset name (for export)' },

--- a/tests/composite/help-docs.test.ts
+++ b/tests/composite/help-docs.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Real (unmocked) doc-content coverage -- catches the tool surface (registry.ts action
+ * enum) drifting from src/docs/*.md. See help.test.ts for the (mocked) loading mechanism.
+ */
+import { describe, expect, it } from 'vitest'
+import { handleHelp } from '../../src/tools/composite/help.js'
+
+describe('help(project) doc content', () => {
+  it('documents the logs action and its pid param', async () => {
+    const result = await handleHelp('project', {})
+    const text = result.content[0].text
+
+    expect(text).toContain('### logs')
+    expect(text).toContain('pid')
+  })
+})

--- a/tests/composite/project.test.ts
+++ b/tests/composite/project.test.ts
@@ -2,12 +2,12 @@
  * Tests for Project tool
  */
 
-import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { GodotConfig } from '../../src/godot/types.js'
 import { handleProject } from '../../src/tools/composite/project.js'
+import type { GodotMCPError } from '../../src/tools/helpers/errors.js'
 import { createTmpProject, makeConfig } from '../fixtures.js'
 
 // Mock headless execution
@@ -17,14 +17,16 @@ vi.mock('../../src/godot/headless.js', () => ({
   runGodotProject: vi.fn(),
   getProjectLogs: vi.fn(),
   clearProjectLogs: vi.fn(),
+  killProcessTree: vi.fn(),
 }))
 
-// Mock child_process for stop command
-vi.mock('node:child_process', () => ({
-  execFileSync: vi.fn(),
-}))
-
-import { clearProjectLogs, execGodotAsync, getProjectLogs, runGodotProject } from '../../src/godot/headless.js'
+import {
+  clearProjectLogs,
+  execGodotAsync,
+  getProjectLogs,
+  killProcessTree,
+  runGodotProject,
+} from '../../src/godot/headless.js'
 
 describe('project', () => {
   let projectPath: string
@@ -139,62 +141,54 @@ describe('project', () => {
   describe('stop', () => {
     it('should stop godot processes', async () => {
       config.activePids = [1234]
-      const processKillSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      vi.mocked(killProcessTree).mockReturnValue(true)
 
       const result = await handleProject('stop', {}, config)
-      expect(result.content[0].text).toContain('Godot processes stopped')
-      if (process.platform === 'win32') {
-        expect(execFileSync).toHaveBeenCalled()
-      } else {
-        expect(processKillSpy).toHaveBeenCalledWith(1234, 'SIGTERM')
-      }
+      expect(result.content[0].text).toContain('Godot processes stopped (Stopped 1 tracked processes)')
+      expect(killProcessTree).toHaveBeenCalledWith(1234)
       expect(config.activePids).toHaveLength(0)
-
-      processKillSpy.mockRestore()
     })
 
     it('should clear ring-buffered logs for every tracked pid', async () => {
       config.activePids = [1234, 5678]
-      const processKillSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      vi.mocked(killProcessTree).mockReturnValue(true)
 
       await handleProject('stop', {}, config)
 
       expect(clearProjectLogs).toHaveBeenCalledWith(1234)
       expect(clearProjectLogs).toHaveBeenCalledWith(5678)
-
-      processKillSpy.mockRestore()
     })
 
     it('should handle no running processes gracefully', async () => {
       const result = await handleProject('stop', {}, config)
       expect(result.content[0].text).toContain('No running Godot processes found (tracked by this server)')
       expect(clearProjectLogs).not.toHaveBeenCalled()
+      expect(killProcessTree).not.toHaveBeenCalled()
     })
 
-    it('should continue if process is already dead on win32', async () => {
-      const originalPlatform = process.platform
-      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
-
+    it('should not count an already-dead pid toward stoppedCount, but should still count a live one', async () => {
       config.activePids = [1234, 5678]
-
-      const processKillSpy = vi.spyOn(process, 'kill').mockImplementation((pid, signal) => {
-        if (pid === 1234 && (signal === 0 || signal === '0')) {
-          throw new Error('Process already dead')
-        }
-        return true
-      })
+      // killProcessTree itself owns the platform-specific (win32 tree-kill vs SIGTERM) and
+      // already-dead detection -- see headless.test.ts for that behavior. Here we only need
+      // to prove `stop` sums its per-pid boolean return correctly.
+      vi.mocked(killProcessTree).mockImplementation((pid) => pid !== 1234)
 
       const result = await handleProject('stop', {}, config)
       expect(result.content[0].text).toContain('Stopped 1 tracked processes')
-
-      // Should NOT call taskkill for 1234, but SHOULD for 5678
-      expect(execFileSync).not.toHaveBeenCalledWith('taskkill', expect.arrayContaining(['1234']), expect.anything())
-      expect(execFileSync).toHaveBeenCalledWith('taskkill', expect.arrayContaining(['5678']), expect.anything())
-
+      expect(killProcessTree).toHaveBeenCalledWith(1234)
+      expect(killProcessTree).toHaveBeenCalledWith(5678)
       expect(config.activePids).toHaveLength(0)
+    })
 
-      processKillSpy.mockRestore()
-      Object.defineProperty(process, 'platform', { value: originalPlatform })
+    it('should skip invalid pids without calling killProcessTree', async () => {
+      config.activePids = [-1, 1.5, 5678]
+      vi.mocked(killProcessTree).mockReturnValue(true)
+
+      await handleProject('stop', {}, config)
+
+      expect(killProcessTree).not.toHaveBeenCalledWith(-1)
+      expect(killProcessTree).not.toHaveBeenCalledWith(1.5)
+      expect(killProcessTree).toHaveBeenCalledWith(5678)
     })
   })
 
@@ -398,5 +392,19 @@ describe('project', () => {
   // ==========================================
   it('should throw for unknown action', async () => {
     await expect(handleProject('invalid', {}, config)).rejects.toThrow('Unknown action')
+  })
+
+  it('should list every real action, including logs, as a suggestion for an unknown action', async () => {
+    const realActions = ['info', 'version', 'run', 'logs', 'stop', 'settings_get', 'settings_set', 'export']
+
+    try {
+      await handleProject('invalid', {}, config)
+      throw new Error('expected handleProject to reject')
+    } catch (err) {
+      const suggestion = (err as GodotMCPError).suggestion ?? ''
+      for (const action of realActions) {
+        expect(suggestion).toContain(action)
+      }
+    }
   })
 })

--- a/tests/composite/project.test.ts
+++ b/tests/composite/project.test.ts
@@ -15,6 +15,8 @@ vi.mock('../../src/godot/headless.js', () => ({
   execGodotAsync: vi.fn().mockResolvedValue({ success: true, stdout: '', stderr: '', exitCode: 0 }),
   execGodotSync: vi.fn(),
   runGodotProject: vi.fn(),
+  getProjectLogs: vi.fn(),
+  clearProjectLogs: vi.fn(),
 }))
 
 // Mock child_process for stop command
@@ -22,7 +24,7 @@ vi.mock('node:child_process', () => ({
   execFileSync: vi.fn(),
 }))
 
-import { execGodotAsync, runGodotProject } from '../../src/godot/headless.js'
+import { clearProjectLogs, execGodotAsync, getProjectLogs, runGodotProject } from '../../src/godot/headless.js'
 
 describe('project', () => {
   let projectPath: string
@@ -122,6 +124,13 @@ describe('project', () => {
       const noProjectConfig = makeConfig({ godotPath: '/usr/bin/godot' })
       await expect(handleProject('run', {}, noProjectConfig)).rejects.toThrow('No project path specified')
     })
+
+    it('should include a hint to use logs/stop after starting', async () => {
+      vi.mocked(runGodotProject).mockReturnValue({ pid: 12345 })
+
+      const result = await handleProject('run', { project_path: projectPath }, config)
+      expect(result.content[0].text).toContain('Use project logs to see output, project stop to terminate.')
+    })
   })
 
   // ==========================================
@@ -144,9 +153,22 @@ describe('project', () => {
       processKillSpy.mockRestore()
     })
 
+    it('should clear ring-buffered logs for every tracked pid', async () => {
+      config.activePids = [1234, 5678]
+      const processKillSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+
+      await handleProject('stop', {}, config)
+
+      expect(clearProjectLogs).toHaveBeenCalledWith(1234)
+      expect(clearProjectLogs).toHaveBeenCalledWith(5678)
+
+      processKillSpy.mockRestore()
+    })
+
     it('should handle no running processes gracefully', async () => {
       const result = await handleProject('stop', {}, config)
       expect(result.content[0].text).toContain('No running Godot processes found (tracked by this server)')
+      expect(clearProjectLogs).not.toHaveBeenCalled()
     })
 
     it('should continue if process is already dead on win32', async () => {
@@ -173,6 +195,53 @@ describe('project', () => {
 
       processKillSpy.mockRestore()
       Object.defineProperty(process, 'platform', { value: originalPlatform })
+    })
+  })
+
+  // ==========================================
+  // logs
+  // ==========================================
+  describe('logs', () => {
+    it('should throw when no project has been started', async () => {
+      await expect(handleProject('logs', {}, config)).rejects.toThrow('No running project')
+    })
+
+    it('should throw for an explicit pid that was never tracked', async () => {
+      vi.mocked(getProjectLogs).mockReturnValue(undefined)
+      await expect(handleProject('logs', { pid: 999 }, config)).rejects.toThrow('No logs for PID 999')
+    })
+
+    it('should throw for a non-positive-integer pid', async () => {
+      await expect(handleProject('logs', { pid: -1 }, config)).rejects.toThrow('Invalid PID')
+      await expect(handleProject('logs', { pid: 'nope' }, config)).rejects.toThrow('Invalid PID')
+    })
+
+    it('should default to the most recently started pid when none is given', async () => {
+      config.activePids = [111, 222]
+      vi.mocked(getProjectLogs).mockReturnValue({ lines: ['hello'], truncated: false })
+
+      const result = await handleProject('logs', {}, config)
+
+      expect(getProjectLogs).toHaveBeenCalledWith(222)
+      expect(result.content[0].text).toContain('hello')
+    })
+
+    it('should return the ring-buffered lines for an explicit pid', async () => {
+      vi.mocked(getProjectLogs).mockReturnValue({ lines: ['line1', 'line2'], truncated: false })
+
+      const result = await handleProject('logs', { pid: 42 }, config)
+
+      expect(getProjectLogs).toHaveBeenCalledWith(42)
+      expect(result.content[0].text).toContain('Last 2 line(s):')
+      expect(result.content[0].text).toContain('line1\nline2')
+    })
+
+    it('should note when older lines were dropped due to truncation', async () => {
+      vi.mocked(getProjectLogs).mockReturnValue({ lines: Array(400).fill('x'), truncated: true })
+
+      const result = await handleProject('logs', { pid: 42 }, config)
+
+      expect(result.content[0].text).toContain('Last 400 line(s) (older lines dropped):')
     })
   })
 

--- a/tests/godot/headless-real-spawn.test.ts
+++ b/tests/godot/headless-real-spawn.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Integration test for spawnCaptured using a real (unmocked) child process.
+ * Verifies stdout/stderr are actually captured end-to-end, not just that the
+ * mocked spawn call was wired correctly (see headless.test.ts for the mocked unit tests).
+ *
+ * Uses spawnCaptured directly with the current runtime binary as the fake "godot" -- not
+ * runGodotProject with a test-only extra parameter, which would change its public signature.
+ */
+import { describe, expect, it } from 'vitest'
+import { clearProjectLogs, getProjectLogs, spawnCaptured } from '../../src/godot/headless.js'
+
+describe('spawnCaptured (real child process)', () => {
+  it('captures real stdout and stderr output from a spawned process', async () => {
+    const { pid } = spawnCaptured(process.execPath, [
+      '-e',
+      "console.log('line1'); console.error('line2'); console.log('line3')",
+    ])
+    expect(pid).toBeDefined()
+
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    const logs = getProjectLogs(pid as number)
+    expect(logs?.lines.join('\n')).toContain('line1')
+    expect(logs?.lines.join('\n')).toContain('line2')
+    expect(logs?.lines.join('\n')).toContain('line3')
+
+    clearProjectLogs(pid as number)
+  })
+})

--- a/tests/godot/headless.test.ts
+++ b/tests/godot/headless.test.ts
@@ -4,13 +4,14 @@
 
 import * as child_process from 'node:child_process'
 import { EventEmitter } from 'node:events'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   clearProjectLogs,
   execGodotAsync,
   execGodotSync,
   getProjectLogs,
   getTrackedPids,
+  killProcessTree,
   launchGodotEditor,
   runGodotProject,
   spawnCaptured,
@@ -32,6 +33,7 @@ vi.mock('node:child_process', async () => {
     spawnSync: vi.fn(),
     spawn: vi.fn(),
     execFile: execFileMock,
+    execFileSync: vi.fn(),
   }
 })
 
@@ -288,7 +290,7 @@ describe('headless', () => {
   // ==========================================
   describe('runGodotProject', () => {
     it('should spawn Godot with correct arguments', () => {
-      const mockChild = { unref: vi.fn(), pid: 42 }
+      const mockChild = { unref: vi.fn(), once: vi.fn(), pid: 42 }
       vi.mocked(child_process.spawn).mockReturnValue(mockChild as never)
 
       const result = runGodotProject('/usr/bin/godot', '/tmp/project')
@@ -301,7 +303,7 @@ describe('headless', () => {
     })
 
     it('should include scenePath in arguments when provided', () => {
-      const mockChild = { unref: vi.fn(), pid: 43 }
+      const mockChild = { unref: vi.fn(), once: vi.fn(), pid: 43 }
       vi.mocked(child_process.spawn).mockReturnValue(mockChild as never)
 
       const result = runGodotProject('/usr/bin/godot', '/tmp/project', 'res://main.tscn')
@@ -403,6 +405,21 @@ describe('headless', () => {
       expect(logs?.truncated).toBe(true)
     })
 
+    it('does not report truncated when exactly 400 lines were captured (no lines actually dropped)', () => {
+      const { stdout } = mockChildWithStreams(150)
+
+      spawnCaptured('/usr/bin/godot', ['--path', '/tmp/project'])
+      for (let i = 0; i < 400; i++) {
+        stdout.emit('data', Buffer.from(`line${i}\n`))
+      }
+
+      const logs = getProjectLogs(150)
+      expect(logs?.lines).toHaveLength(400)
+      expect(logs?.truncated).toBe(false)
+
+      clearProjectLogs(150)
+    })
+
     it('does not register a ring buffer entry when spawn fails to assign a pid', () => {
       mockChildWithStreams(undefined)
 
@@ -434,7 +451,7 @@ describe('headless', () => {
       expect(getProjectLogs(106)?.lines).toEqual(['hello from game'])
     })
 
-    it('getTrackedPids reflects pids currently registered in the ring buffer', () => {
+    it('getTrackedPids reflects currently-live spawned pids', () => {
       mockChildWithStreams(201)
       spawnCaptured('/usr/bin/godot', ['--path', '/tmp/project'])
       mockChildWithStreams(202)
@@ -446,6 +463,132 @@ describe('headless', () => {
 
       clearProjectLogs(201)
       clearProjectLogs(202)
+    })
+
+    it('removes an exited pid from getTrackedPids, but keeps its logs available for post-crash debugging', () => {
+      const { child, stdout } = mockChildWithStreams(301)
+      spawnCaptured('/usr/bin/godot', ['--path', '/tmp/project'])
+      stdout.emit('data', Buffer.from('dying words\n'))
+      expect(getTrackedPids()).toContain(301)
+
+      child.emit('exit', 1, null)
+
+      expect(getTrackedPids()).not.toContain(301)
+      expect(getProjectLogs(301)?.lines).toEqual(['dying words'])
+
+      clearProjectLogs(301)
+    })
+
+    it('evicts the oldest exited pid once more than 10 exited processes have logs retained', () => {
+      const pids = Array.from({ length: 11 }, (_, i) => 400 + i)
+      for (const pid of pids) {
+        const { child } = mockChildWithStreams(pid)
+        spawnCaptured('/usr/bin/godot', ['--path', '/tmp/project'])
+        child.emit('exit', 0, null)
+      }
+
+      // oldest exited pid's logs were evicted to bound memory
+      expect(getProjectLogs(pids[0])).toBeUndefined()
+      // the most recent 10 exited pids are still retained
+      for (const pid of pids.slice(1)) {
+        expect(getProjectLogs(pid)).toBeDefined()
+      }
+
+      for (const pid of pids.slice(1)) clearProjectLogs(pid)
+    })
+
+    it('never evicts a still-live pid, even after 11 other processes have exited', () => {
+      const { stdout } = mockChildWithStreams(500)
+      spawnCaptured('/usr/bin/godot', ['--path', '/tmp/project'])
+      stdout.emit('data', Buffer.from('still running\n'))
+
+      for (let i = 0; i < 11; i++) {
+        const { child } = mockChildWithStreams(600 + i)
+        spawnCaptured('/usr/bin/godot', ['--path', '/tmp/project'])
+        child.emit('exit', 0, null)
+      }
+
+      expect(getProjectLogs(500)?.lines).toEqual(['still running'])
+      expect(getTrackedPids()).toContain(500)
+
+      clearProjectLogs(500)
+      for (let i = 0; i < 11; i++) clearProjectLogs(600 + i)
+    })
+
+    it('does not resurrect eviction bookkeeping for a pid whose logs were already cleared before it exited', () => {
+      const { child, stdout } = mockChildWithStreams(700)
+      spawnCaptured('/usr/bin/godot', ['--path', '/tmp/project'])
+      stdout.emit('data', Buffer.from('line\n'))
+
+      clearProjectLogs(700) // e.g. `project stop` already ran
+      child.emit('exit', 0, null) // async exit event arrives afterward
+
+      expect(getProjectLogs(700)).toBeUndefined()
+      expect(getTrackedPids()).not.toContain(700)
+    })
+  })
+
+  // ==========================================
+  // killProcessTree
+  // ==========================================
+  describe('killProcessTree', () => {
+    const originalPlatform = process.platform
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+    })
+
+    it('sends SIGTERM on non-win32 platforms and reports the process was alive', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+
+      expect(killProcessTree(1234)).toBe(true)
+      expect(killSpy).toHaveBeenCalledWith(1234, 'SIGTERM')
+      killSpy.mockRestore()
+    })
+
+    it('returns false on non-win32 when the process is already dead', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+        throw new Error('ESRCH')
+      })
+
+      expect(killProcessTree(1234)).toBe(false)
+      killSpy.mockRestore()
+    })
+
+    it('tree-kills via taskkill on win32 when the liveness probe succeeds', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+
+      expect(killProcessTree(4321)).toBe(true)
+      expect(killSpy).toHaveBeenCalledWith(4321, 0)
+      expect(child_process.execFileSync).toHaveBeenCalledWith('taskkill', ['/F', '/PID', '4321', '/T'], {
+        stdio: 'pipe',
+      })
+      killSpy.mockRestore()
+    })
+
+    it('skips taskkill on win32 when the liveness probe fails (already dead)', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+        throw new Error('already dead')
+      })
+
+      expect(killProcessTree(4321)).toBe(false)
+      expect(child_process.execFileSync).not.toHaveBeenCalled()
+      killSpy.mockRestore()
+    })
+
+    it('returns false and does not throw if taskkill itself throws on win32', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      vi.mocked(child_process.execFileSync).mockImplementationOnce(() => {
+        throw new Error('taskkill failed')
+      })
+
+      expect(killProcessTree(4321)).toBe(false)
+      killSpy.mockRestore()
     })
   })
 

--- a/tests/godot/headless.test.ts
+++ b/tests/godot/headless.test.ts
@@ -3,8 +3,18 @@
  */
 
 import * as child_process from 'node:child_process'
+import { EventEmitter } from 'node:events'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { execGodotAsync, execGodotSync, launchGodotEditor, runGodotProject } from '../../src/godot/headless.js'
+import {
+  clearProjectLogs,
+  execGodotAsync,
+  execGodotSync,
+  getProjectLogs,
+  getTrackedPids,
+  launchGodotEditor,
+  runGodotProject,
+  spawnCaptured,
+} from '../../src/godot/headless.js'
 
 // execFileAsyncMock is hoisted so it is available inside the vi.mock factory.
 // We attach it as [promisify.custom] on execFile so that promisify(execFile)
@@ -285,7 +295,7 @@ describe('headless', () => {
       expect(result.pid).toBe(42)
       expect(child_process.spawn).toHaveBeenCalledWith('/usr/bin/godot', ['--path', '/tmp/project'], {
         detached: true,
-        stdio: 'ignore',
+        stdio: ['ignore', 'pipe', 'pipe'],
       })
       expect(mockChild.unref).toHaveBeenCalled()
     })
@@ -301,7 +311,7 @@ describe('headless', () => {
         ['--path', '/tmp/project', 'res://main.tscn'],
         {
           detached: true,
-          stdio: 'ignore',
+          stdio: ['ignore', 'pipe', 'pipe'],
         },
       )
     })
@@ -320,6 +330,122 @@ describe('headless', () => {
       })
 
       expect(() => runGodotProject('/usr/bin/godot', '/tmp/project')).toThrow('Spawn failed')
+    })
+  })
+
+  // ==========================================
+  // spawnCaptured / project logs ring buffer
+  // ==========================================
+  describe('spawnCaptured', () => {
+    function mockChildWithStreams(pid: number | undefined) {
+      const stdout = Object.assign(new EventEmitter(), { unref: vi.fn() })
+      const stderr = Object.assign(new EventEmitter(), { unref: vi.fn() })
+      const child = Object.assign(new EventEmitter(), { unref: vi.fn(), pid, stdout, stderr })
+      vi.mocked(child_process.spawn).mockReturnValue(child as never)
+      return { child, stdout, stderr }
+    }
+
+    it('spawns with piped stdio (not ignore) so output can be captured', () => {
+      const { child } = mockChildWithStreams(100)
+
+      spawnCaptured('/usr/bin/godot', ['--path', '/tmp/project'])
+
+      expect(child_process.spawn).toHaveBeenCalledWith('/usr/bin/godot', ['--path', '/tmp/project'], {
+        detached: true,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+      expect(child.unref).toHaveBeenCalled()
+    })
+
+    it('captures stdout and stderr chunks into the per-pid ring buffer', () => {
+      const { stdout, stderr } = mockChildWithStreams(101)
+
+      spawnCaptured('/usr/bin/godot', ['--path', '/tmp/project'])
+      stdout.emit('data', Buffer.from('line1\n'))
+      stderr.emit('data', Buffer.from('line2\n'))
+      stdout.emit('data', Buffer.from('line3'))
+
+      const logs = getProjectLogs(101)
+      expect(logs?.lines).toEqual(['line1', 'line2', 'line3'])
+      expect(logs?.truncated).toBe(false)
+    })
+
+    it('unrefs the stdout/stderr streams so a live child does not block process exit', () => {
+      const { stdout, stderr } = mockChildWithStreams(102)
+
+      spawnCaptured('/usr/bin/godot', ['--path', '/tmp/project'])
+
+      expect(stdout.unref).toHaveBeenCalled()
+      expect(stderr.unref).toHaveBeenCalled()
+    })
+
+    it('drops empty lines produced by trailing newlines', () => {
+      const { stdout } = mockChildWithStreams(103)
+
+      spawnCaptured('/usr/bin/godot', ['--path', '/tmp/project'])
+      stdout.emit('data', Buffer.from('only\n\n'))
+
+      expect(getProjectLogs(103)?.lines).toEqual(['only'])
+    })
+
+    it('keeps only the last 400 lines and marks the buffer truncated', () => {
+      const { stdout } = mockChildWithStreams(104)
+
+      spawnCaptured('/usr/bin/godot', ['--path', '/tmp/project'])
+      for (let i = 0; i < 410; i++) {
+        stdout.emit('data', Buffer.from(`line${i}\n`))
+      }
+
+      const logs = getProjectLogs(104)
+      expect(logs?.lines).toHaveLength(400)
+      expect(logs?.lines[0]).toBe('line10')
+      expect(logs?.lines[399]).toBe('line409')
+      expect(logs?.truncated).toBe(true)
+    })
+
+    it('does not register a ring buffer entry when spawn fails to assign a pid', () => {
+      mockChildWithStreams(undefined)
+
+      const result = spawnCaptured('/usr/bin/godot', ['--path', '/tmp/project'])
+
+      expect(result.pid).toBeUndefined()
+    })
+
+    it('getProjectLogs returns undefined for an unknown pid', () => {
+      expect(getProjectLogs(999999)).toBeUndefined()
+    })
+
+    it('clearProjectLogs removes the ring buffer entry for a pid', () => {
+      mockChildWithStreams(105)
+      spawnCaptured('/usr/bin/godot', ['--path', '/tmp/project'])
+      expect(getProjectLogs(105)).toBeDefined()
+
+      clearProjectLogs(105)
+
+      expect(getProjectLogs(105)).toBeUndefined()
+    })
+
+    it('runGodotProject output flows through the same ring buffer as spawnCaptured', () => {
+      const { stdout } = mockChildWithStreams(106)
+
+      runGodotProject('/usr/bin/godot', '/tmp/project')
+      stdout.emit('data', Buffer.from('hello from game\n'))
+
+      expect(getProjectLogs(106)?.lines).toEqual(['hello from game'])
+    })
+
+    it('getTrackedPids reflects pids currently registered in the ring buffer', () => {
+      mockChildWithStreams(201)
+      spawnCaptured('/usr/bin/godot', ['--path', '/tmp/project'])
+      mockChildWithStreams(202)
+      spawnCaptured('/usr/bin/godot', ['--path', '/tmp/project'])
+
+      const tracked = getTrackedPids()
+      expect(tracked).toContain(201)
+      expect(tracked).toContain(202)
+
+      clearProjectLogs(201)
+      clearProjectLogs(202)
     })
   })
 

--- a/tests/godot/headless.test.ts
+++ b/tests/godot/headless.test.ts
@@ -497,6 +497,39 @@ describe('headless', () => {
       for (const pid of pids.slice(1)) clearProjectLogs(pid)
     })
 
+    it('does not let a reused PID stale exited-entry evict a currently-live process with the same PID', () => {
+      const pid = 800
+
+      // First instance of this PID runs and exits -- its stale bookkeeping entry lands
+      // in the exited-pid FIFO (as the oldest entry).
+      const first = mockChildWithStreams(pid)
+      spawnCaptured('/usr/bin/godot', ['--path', '/tmp/project'])
+      first.child.emit('exit', 0, null)
+      expect(getProjectLogs(pid)).toBeDefined()
+
+      // The OS reuses the same PID for a brand-new, currently-live process.
+      const { stdout } = mockChildWithStreams(pid)
+      spawnCaptured('/usr/bin/godot', ['--path', '/tmp/project'])
+      stdout.emit('data', Buffer.from('reused pid output\n'))
+      expect(getTrackedPids()).toContain(pid)
+
+      // Drive 10 unrelated exits -- enough to trigger eviction of the FIFO's oldest entry
+      // if the stale entry for `pid` from the first instance was not de-duplicated on respawn.
+      const otherPids = Array.from({ length: 10 }, (_, i) => 900 + i)
+      for (const otherPid of otherPids) {
+        const { child } = mockChildWithStreams(otherPid)
+        spawnCaptured('/usr/bin/godot', ['--path', '/tmp/project'])
+        child.emit('exit', 0, null)
+      }
+
+      // The reused PID's currently-live process must still have its output -- not silently
+      // wiped out by eviction of the first (exited) instance's stale FIFO entry.
+      expect(getProjectLogs(pid)?.lines).toEqual(['reused pid output'])
+
+      clearProjectLogs(pid)
+      for (const otherPid of otherPids) clearProjectLogs(otherPid)
+    })
+
     it('never evicts a still-live pid, even after 11 other processes have exited', () => {
       const { stdout } = mockChildWithStreams(500)
       spawnCaptured('/usr/bin/godot', ['--path', '/tmp/project'])

--- a/tests/init-server.test.ts
+++ b/tests/init-server.test.ts
@@ -42,6 +42,7 @@ vi.mock('../src/godot/detector.js', () => ({
 
 vi.mock('../src/godot/headless.js', () => ({
   getTrackedPids: vi.fn().mockReturnValue([]),
+  killProcessTree: vi.fn().mockReturnValue(false),
 }))
 
 vi.mock('../src/tools/registry.js', () => ({
@@ -218,32 +219,31 @@ describe('initServer', () => {
   })
 
   describe('HTTP shutdown process cleanup', () => {
-    it('kills tracked Godot pids before closing the HTTP handle on SIGINT', async () => {
+    it('tree-kills tracked Godot pids before closing the HTTP handle on SIGINT', async () => {
       const { detectGodot } = await import('../src/godot/detector.js')
       vi.mocked(detectGodot).mockReturnValue(null)
       process.env.MCP_TRANSPORT = 'http'
 
-      const { getTrackedPids } = await import('../src/godot/headless.js')
+      const { getTrackedPids, killProcessTree } = await import('../src/godot/headless.js')
       vi.mocked(getTrackedPids).mockReturnValue([111, 222])
-      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      vi.mocked(killProcessTree).mockReturnValue(true)
 
       const { initServer } = await import('../src/init-server.js')
       await runHttpInit(initServer)
 
-      expect(killSpy).toHaveBeenCalledWith(111)
-      expect(killSpy).toHaveBeenCalledWith(222)
-      killSpy.mockRestore()
+      expect(killProcessTree).toHaveBeenCalledWith(111)
+      expect(killProcessTree).toHaveBeenCalledWith(222)
     })
 
-    it('closes the HTTP handle even if killing a stale pid throws', async () => {
+    it('closes the HTTP handle even if killProcessTree throws unexpectedly', async () => {
       const { detectGodot } = await import('../src/godot/detector.js')
       vi.mocked(detectGodot).mockReturnValue(null)
       process.env.MCP_TRANSPORT = 'http'
 
-      const { getTrackedPids } = await import('../src/godot/headless.js')
+      const { getTrackedPids, killProcessTree } = await import('../src/godot/headless.js')
       vi.mocked(getTrackedPids).mockReturnValue([333])
-      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
-        throw new Error('ESRCH: no such process')
+      vi.mocked(killProcessTree).mockImplementation(() => {
+        throw new Error('unexpected')
       })
 
       const closeSpy = vi.fn().mockResolvedValue(undefined)
@@ -253,7 +253,6 @@ describe('initServer', () => {
       await expect(runHttpInit(initServer)).resolves.not.toThrow()
 
       expect(closeSpy).toHaveBeenCalledOnce()
-      killSpy.mockRestore()
     })
   })
 

--- a/tests/init-server.test.ts
+++ b/tests/init-server.test.ts
@@ -40,6 +40,10 @@ vi.mock('../src/godot/detector.js', () => ({
   detectGodot: vi.fn(),
 }))
 
+vi.mock('../src/godot/headless.js', () => ({
+  getTrackedPids: vi.fn().mockReturnValue([]),
+}))
+
 vi.mock('../src/tools/registry.js', () => ({
   registerTools: vi.fn(),
 }))
@@ -210,6 +214,46 @@ describe('initServer', () => {
           },
         },
       )
+    })
+  })
+
+  describe('HTTP shutdown process cleanup', () => {
+    it('kills tracked Godot pids before closing the HTTP handle on SIGINT', async () => {
+      const { detectGodot } = await import('../src/godot/detector.js')
+      vi.mocked(detectGodot).mockReturnValue(null)
+      process.env.MCP_TRANSPORT = 'http'
+
+      const { getTrackedPids } = await import('../src/godot/headless.js')
+      vi.mocked(getTrackedPids).mockReturnValue([111, 222])
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+
+      const { initServer } = await import('../src/init-server.js')
+      await runHttpInit(initServer)
+
+      expect(killSpy).toHaveBeenCalledWith(111)
+      expect(killSpy).toHaveBeenCalledWith(222)
+      killSpy.mockRestore()
+    })
+
+    it('closes the HTTP handle even if killing a stale pid throws', async () => {
+      const { detectGodot } = await import('../src/godot/detector.js')
+      vi.mocked(detectGodot).mockReturnValue(null)
+      process.env.MCP_TRANSPORT = 'http'
+
+      const { getTrackedPids } = await import('../src/godot/headless.js')
+      vi.mocked(getTrackedPids).mockReturnValue([333])
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+        throw new Error('ESRCH: no such process')
+      })
+
+      const closeSpy = vi.fn().mockResolvedValue(undefined)
+      mockStartHttp.mockResolvedValue({ host: '127.0.0.1', port: 12345, close: closeSpy })
+
+      const { initServer } = await import('../src/init-server.js')
+      await expect(runHttpInit(initServer)).resolves.not.toThrow()
+
+      expect(closeSpy).toHaveBeenCalledOnce()
+      killSpy.mockRestore()
     })
   })
 


### PR DESCRIPTION
## Bug (S14 Task 1, Wave 1) — the highest-value item in the godot feature report

`project run` spawned Godot with `stdio: 'ignore'` — all game output was discarded, the tool returned only a PID, there was no timeout, and shutdown never killed spawned children, so forgetting `project stop` left Godot orphaned indefinitely.

## Fix

- **Capture output**: `spawnCaptured` pipes stdout/stderr into a bounded per-pid ring buffer (400 lines). The streams are `.unref()`'d so they can't keep the server's event loop alive.
- **New `project logs` action**: returns the captured output (optional `pid`), with an accurate `truncated` flag (set only when a line is actually dropped).
- **Stop-safety**: a shared `killProcessTree(pid)` (win32 → `taskkill /F /PID <pid> /T`, else SIGTERM, best-effort) is called by both `stop` and a new SIGINT/SIGTERM shutdown handler, so shutdown no longer leaks child processes on Windows.
- **PID lifecycle**: the shutdown-kill set holds only *live* pids (pruned on child exit), so a reused PID of an exited process can't be killed; logs are retained after exit for post-crash debugging, capped at the last 10 exited processes; a reused PID splices its stale exited-bookkeeping entry so it can never evict the live buffer.

Deviation (verified necessary): shutdown uses a module-level live-pid registry, not `config.activePids` — mcp-core builds the server factory once per HTTP session, so no `config` is in scope for the shutdown handler.

## Tests

976 passed. New coverage: real output capture (unmocked child), the logs action, killProcessTree's win32/SIGTERM/dead-pid branches, live-vs-exited pid separation + capped eviction + the reused-PID-doesn't-wipe-live-logs edge (verified to fail before the fix), the exact-400 truncated boundary, and help doc `### logs`/`pid` served by the real handleHelp.

Reviewed (adversarial, two rounds): SPEC + QUALITY pass; 4 Important + 2 Minor from round 1 all resolved; one round-2 PID-reuse edge fixed. In-repo help doc updated; claude-plugins tools.md is a separate post-merge docs step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)