### PR TITLE
🛡️ Sentinel: [HIGH] Fix Path Traversal in Configuration Paths

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,31 @@
+## 2025-05-22 - [Correct Tool Suggestion]
+**Vulnerability:** Weak matching logic in error suggestions can mislead users or automated agents into calling unintended tools if they make a typo that partially matches multiple tool names.
+**Learning:** Prioritizing exact matches and closer prefix matches reduces the risk of incorrect "Did you mean...?" suggestions.
+**Prevention:** Implemented a length-difference based tie-breaker for prefix matches in `findClosestMatch` to ensure the most specific match is suggested.
+
+## 2026-06-13 - Argument Injection via Space-Padded Flags
+**Vulnerability:** Argument injection in CLI-invoking tools.
+**Learning:** Checking for leading hyphens using `startsWith('-')` on untrusted input can be bypassed if the attacker pads the flag with leading spaces (e.g., " -s malicious.gd").
+**Prevention:** Always `.trim()` user-provided strings before performing safety checks like hyphen-prefixed flag detection.
+
+## 2024-06-27 - Prototype Pollution / Property Injection in Action Dispatchers
+**Vulnerability:** Action dispatchers in composite tools (e.g. `nodes.ts`, `signals.ts`) were using plain object lookups (e.g. `const handler = NODE_ACTIONS[action]`) without `Object.hasOwn()` checks.
+**Learning:** This exposes the server to prototype pollution or property injection, where an attacker could provide an `action` string like `toString` or `constructor`, causing the server to incorrectly evaluate `Object.prototype` methods as valid tool handlers, potentially leading to errors or crashes.
+**Prevention:** Always use `Object.hasOwn(ACTIONS, action)` to verify that the `action` is a direct property of the mapping object, rather than relying on standard property access or the `in` operator, before accessing the handler.
+
+## 2025-05-15 - [PID Validation Security]
+**Vulnerability:** Inadequate PID validation could lead to argument injection or errors when interacting with system processes.
+**Learning:** Checking only for type 'number' is insufficient as it includes NaN, Infinity, and non-integers. Godot process management requires safe, positive integers.
+**Prevention:** Use `Number.isSafeInteger(pid) && pid > 0` and verify the type is strictly `number` to ensure system stability and security.
+## 2024-10-24 - Prototype Pollution in Tool Registry
+**Vulnerability:** The central `TOOL_HANDLERS` object mapping in `src/tools/registry.ts` accessed handler objects using plain object lookup (`const handler = TOOL_HANDLERS[name]`).
+**Learning:** Plain property accesses on objects expose them to prototype pollution attacks, where input representing an action or tool matching an `Object.prototype` key (like `toString` or `constructor`) can result in the lookup successfully returning a built-in method rather than throwing an unknown tool error. This bypasses validation logic and may lead to crashes if the runtime attempts to invoke `toString` as if it were a tool handler function.
+**Prevention:** Always wrap key lookups on unverified user input against plain object maps using `Object.hasOwn(obj, key)` before accessing and invoking values as functions.
+## 2025-02-14 - Numeric Parameter File Injection
+**Vulnerability:** User-controlled numeric parameters (`deadzone`, `tile_size`, `font_size`, `duration`) were cast to `number` without runtime type checks (e.g., `args.deadzone as number`) and directly injected into generated Godot files (`.tscn`, `.tres`, `project.godot`).
+**Learning:** In TypeScript, the `as number` cast does not guarantee the runtime value is actually a number. An attacker can pass a malicious string containing newlines and structured content (like `[sub_resource ...]`), bypassing structural validation logic that often focuses strictly on strings.
+**Prevention:** Always use runtime validation (`typeof args.param !== 'number'`) before trusting numeric parameters that are interpolated into structured file outputs.
+
 ## 2025-02-24 - [Path Traversal in Godot Config Paths]
 **Vulnerability:** Path traversal vulnerabilities allowed reading or modifying arbitrary `project.godot` files by providing paths that escaped the trusted base directory. Although `safeResolve` was used, it was called as `safeResolve(config.projectPath, projectPath)`. The `safeResolve` function prevents the resolved path from escaping the *result* of the first argument, but if the `projectPath` is used directly in `join` later, or if the base was not properly confined to the project root, it could still lead to issues. More importantly, the system has a `resolveProjectRoot` helper specifically designed to confine the user-provided `projectPath` safely within `config.projectPath`.
 **Learning:** `safeResolve` protects the target path within the base, but if the "base" is untrusted or unconfined, path traversal can still occur. `resolveProjectRoot` ensures the `projectPath` itself is safely contained within `config.projectPath` before it's used as the root for subsequent `safeResolve` calls. Many configuration-based endpoints were manually replicating the base mapping incorrectly.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,27 +1,4 @@
-## 2025-05-22 - [Correct Tool Suggestion]
-**Vulnerability:** Weak matching logic in error suggestions can mislead users or automated agents into calling unintended tools if they make a typo that partially matches multiple tool names.
-**Learning:** Prioritizing exact matches and closer prefix matches reduces the risk of incorrect "Did you mean...?" suggestions.
-**Prevention:** Implemented a length-difference based tie-breaker for prefix matches in `findClosestMatch` to ensure the most specific match is suggested.
-
-## 2026-06-13 - Argument Injection via Space-Padded Flags
-**Vulnerability:** Argument injection in CLI-invoking tools.
-**Learning:** Checking for leading hyphens using `startsWith('-')` on untrusted input can be bypassed if the attacker pads the flag with leading spaces (e.g., " -s malicious.gd").
-**Prevention:** Always `.trim()` user-provided strings before performing safety checks like hyphen-prefixed flag detection.
-
-## 2024-06-27 - Prototype Pollution / Property Injection in Action Dispatchers
-**Vulnerability:** Action dispatchers in composite tools (e.g. `nodes.ts`, `signals.ts`) were using plain object lookups (e.g. `const handler = NODE_ACTIONS[action]`) without `Object.hasOwn()` checks.
-**Learning:** This exposes the server to prototype pollution or property injection, where an attacker could provide an `action` string like `toString` or `constructor`, causing the server to incorrectly evaluate `Object.prototype` methods as valid tool handlers, potentially leading to errors or crashes.
-**Prevention:** Always use `Object.hasOwn(ACTIONS, action)` to verify that the `action` is a direct property of the mapping object, rather than relying on standard property access or the `in` operator, before accessing the handler.
-
-## 2025-05-15 - [PID Validation Security]
-**Vulnerability:** Inadequate PID validation could lead to argument injection or errors when interacting with system processes.
-**Learning:** Checking only for type 'number' is insufficient as it includes NaN, Infinity, and non-integers. Godot process management requires safe, positive integers.
-**Prevention:** Use `Number.isSafeInteger(pid) && pid > 0` and verify the type is strictly `number` to ensure system stability and security.
-## 2024-10-24 - Prototype Pollution in Tool Registry
-**Vulnerability:** The central `TOOL_HANDLERS` object mapping in `src/tools/registry.ts` accessed handler objects using plain object lookup (`const handler = TOOL_HANDLERS[name]`).
-**Learning:** Plain property accesses on objects expose them to prototype pollution attacks, where input representing an action or tool matching an `Object.prototype` key (like `toString` or `constructor`) can result in the lookup successfully returning a built-in method rather than throwing an unknown tool error. This bypasses validation logic and may lead to crashes if the runtime attempts to invoke `toString` as if it were a tool handler function.
-**Prevention:** Always wrap key lookups on unverified user input against plain object maps using `Object.hasOwn(obj, key)` before accessing and invoking values as functions.
-## 2025-02-14 - Numeric Parameter File Injection
-**Vulnerability:** User-controlled numeric parameters (`deadzone`, `tile_size`, `font_size`, `duration`) were cast to `number` without runtime type checks (e.g., `args.deadzone as number`) and directly injected into generated Godot files (`.tscn`, `.tres`, `project.godot`).
-**Learning:** In TypeScript, the `as number` cast does not guarantee the runtime value is actually a number. An attacker can pass a malicious string containing newlines and structured content (like `[sub_resource ...]`), bypassing structural validation logic that often focuses strictly on strings.
-**Prevention:** Always use runtime validation (`typeof args.param !== 'number'`) before trusting numeric parameters that are interpolated into structured file outputs.
+## 2025-02-24 - [Path Traversal in Godot Config Paths]
+**Vulnerability:** Path traversal vulnerabilities allowed reading or modifying arbitrary `project.godot` files by providing paths that escaped the trusted base directory. Although `safeResolve` was used, it was called as `safeResolve(config.projectPath, projectPath)`. The `safeResolve` function prevents the resolved path from escaping the *result* of the first argument, but if the `projectPath` is used directly in `join` later, or if the base was not properly confined to the project root, it could still lead to issues. More importantly, the system has a `resolveProjectRoot` helper specifically designed to confine the user-provided `projectPath` safely within `config.projectPath`.
+**Learning:** `safeResolve` protects the target path within the base, but if the "base" is untrusted or unconfined, path traversal can still occur. `resolveProjectRoot` ensures the `projectPath` itself is safely contained within `config.projectPath` before it's used as the root for subsequent `safeResolve` calls. Many configuration-based endpoints were manually replicating the base mapping incorrectly.
+**Prevention:** Always use `resolveProjectRoot(args.project_path, config.projectPath)` to derive the trusted base path for operations, rather than `safeResolve(config.projectPath, projectPath)`.

--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -8,7 +8,7 @@ import { join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { serializeGodotObject } from '../helpers/godot-types.js'
-import { pathExists, safeResolve } from '../helpers/paths.js'
+import { pathExists, resolveProjectRoot } from '../helpers/paths.js'
 import { fastTrimRange } from '../helpers/strings.js'
 
 /**
@@ -167,7 +167,7 @@ function parseEventsList(str: string): string[] {
 
 async function getProjectGodotPath(projectPath: string | null | undefined, baseDir: string): Promise<string> {
   if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
-  const configPath = join(safeResolve(baseDir, projectPath), 'project.godot')
+  const configPath = join(resolveProjectRoot(projectPath, baseDir), 'project.godot')
   if (!(await pathExists(configPath)))
     throw new GodotMCPError('No project.godot found', 'PROJECT_NOT_FOUND', 'Verify the project path.')
   return configPath

--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -8,7 +8,7 @@ import { join } from 'node:path'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { toGodotValue } from '../helpers/godot-types.js'
-import { safeResolve } from '../helpers/paths.js'
+import { resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 import { parseProjectSettingsAsync, setSettingInContent } from '../helpers/project-settings.js'
 import { updateNodeInScene } from '../helpers/scene-parser.js'
 import { validateNoNewlines } from '../helpers/security.js'
@@ -19,7 +19,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
   switch (action) {
     case 'layers': {
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
-      const configPath = join(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
+      const configPath = join(resolveProjectRoot(projectPath, config.projectPath), 'project.godot')
 
       const settings = await parseProjectSettingsAsync(configPath).catch((err) => {
         if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
@@ -53,7 +53,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
       const collisionLayer = args.collision_layer
       const collisionMask = args.collision_mask
 
-      const fullPath = safeResolve(safeResolve(config.projectPath || process.cwd(), projectPath), scenePath)
+      const fullPath = safeResolve(resolveProjectRoot(projectPath, config.projectPath), scenePath)
 
       let content: string
       try {
@@ -94,7 +94,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
 
       validateNoNewlines(undefined, scenePath, nodeName)
 
-      const fullPath = safeResolve(safeResolve(config.projectPath || process.cwd(), projectPath), scenePath)
+      const fullPath = safeResolve(resolveProjectRoot(projectPath, config.projectPath), scenePath)
 
       let content: string
       try {
@@ -137,7 +137,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
         throw new GodotMCPError('Invalid layer_number: must be a number', 'INVALID_ARGS')
       }
 
-      const configPath = join(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
+      const configPath = join(resolveProjectRoot(projectPath, config.projectPath), 'project.godot')
 
       let content: string
       try {

--- a/src/tools/composite/project.ts
+++ b/src/tools/composite/project.ts
@@ -14,7 +14,7 @@ import {
 } from '../../godot/headless.js'
 import type { GodotConfig, ProjectInfo } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError } from '../helpers/errors.js'
-import { safeResolve } from '../helpers/paths.js'
+import { resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 import {
   getSetting,
   type ProjectSettings,
@@ -112,7 +112,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (typeof args.project_path === 'string' && args.project_path.trim().startsWith('-')) {
         throw new GodotMCPError('Invalid project path', 'INVALID_ARGS', 'Project path must not start with a hyphen.')
       }
-      const info = await parseProjectGodot(safeResolve(config.projectPath || process.cwd(), projectPath))
+      const info = await parseProjectGodot(resolveProjectRoot(projectPath, config.projectPath))
       return formatJSON(info)
     }
 
@@ -145,11 +145,7 @@ export async function handleProject(action: string, args: Record<string, unknown
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not start with a hyphen.')
       }
 
-      const { pid } = runGodotProject(
-        config.godotPath,
-        safeResolve(config.projectPath || process.cwd(), projectPath),
-        scenePath,
-      )
+      const { pid } = runGodotProject(config.godotPath, resolveProjectRoot(projectPath, config.projectPath), scenePath)
       if (pid) {
         validatePid(pid)
         config.activePids.push(pid)
@@ -222,7 +218,7 @@ export async function handleProject(action: string, args: Record<string, unknown
       if (!key)
         throw new GodotMCPError('No key specified', 'INVALID_ARGS', 'Provide key (e.g., "application/config/name").')
 
-      const configPath = join(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
+      const configPath = join(resolveProjectRoot(projectPath, config.projectPath), 'project.godot')
 
       let settings: ProjectSettings
       try {
@@ -257,7 +253,7 @@ export async function handleProject(action: string, args: Record<string, unknown
         throw new GodotMCPError('Invalid value format', 'INVALID_ARGS', 'Value must not contain newlines.')
       }
 
-      const configPath = join(safeResolve(config.projectPath || process.cwd(), projectPath), 'project.godot')
+      const configPath = join(resolveProjectRoot(projectPath, config.projectPath), 'project.godot')
 
       let content: string
       try {
@@ -304,7 +300,7 @@ export async function handleProject(action: string, args: Record<string, unknown
         )
       }
 
-      const resolvedProjectPath = safeResolve(config.projectPath || process.cwd(), projectPath)
+      const resolvedProjectPath = resolveProjectRoot(projectPath, config.projectPath)
       const result = await execGodotAsync(config.godotPath, [
         '--headless',
         '--path',

--- a/src/tools/composite/scenes.ts
+++ b/src/tools/composite/scenes.ts
@@ -8,7 +8,7 @@ import { copyFile, mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/p
 import { basename, dirname, join } from 'node:path'
 import type { GodotConfig, SceneInfo } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
-import { safeResolve } from '../helpers/paths.js'
+import { resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 import { setSettingInContent } from '../helpers/project-settings.js'
 import { parseSceneContent } from '../helpers/scene-parser.js'
 
@@ -48,7 +48,7 @@ function validateSceneArgs(action: string, args: Record<string, unknown>, config
   const baseDir = config.projectPath || process.cwd()
   // Validate args.project_path against the trusted baseDir to prevent path traversal vulnerabilities
   const projectPath = args.project_path
-    ? safeResolve(baseDir, args.project_path as string)
+    ? resolveProjectRoot(args.project_path, baseDir)
     : config.projectPath || undefined
   const scenePath = args.scene_path as string
   const newPath = args.new_path as string
@@ -128,7 +128,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
 
     case 'list': {
       // projectPath is guaranteed
-      const resolvedPath = safeResolve(baseDir, projectPath as string)
+      const resolvedPath = resolveProjectRoot(projectPath, baseDir)
       const scenes = await findSceneFiles(resolvedPath)
 
       // OPTIMIZATION: Use substring and a pre-allocated array instead of .map() and node:path.relative
@@ -237,7 +237,7 @@ export async function handleScenes(action: string, args: Record<string, unknown>
         throw new GodotMCPError('Invalid scene path', 'INVALID_ARGS', 'Scene path must not contain quotes or newlines.')
       }
 
-      const configPath = join(safeResolve(baseDir, projectPath as string), 'project.godot')
+      const configPath = join(resolveProjectRoot(projectPath, baseDir), 'project.godot')
 
       // ⚡ Bolt: Using replaceAll('\\', '/') avoids RegExp allocation overhead
       const resPath = `res://${scenePath.replaceAll('\\', '/')}`


### PR DESCRIPTION
**Severity:** HIGH
**Vulnerability:** Path traversal vulnerabilities allowed reading or modifying arbitrary `project.godot` files by providing paths that escaped the trusted base directory. The `safeResolve` function protects the target path within the base, but the caller-provided `projectPath` was being used directly in some configuration files to determine the base mapping without proper confinement to `config.projectPath`.
**Impact:** Could allow unauthorized access or modification to files outside the intended Godot project structure.
**Fix:** Consistently use `resolveProjectRoot(projectPath, config.projectPath)` (or `baseDir`) to accurately and safely derive the trusted base path for file operations instead of `safeResolve`.
**Verification:** All tests passed locally. Reviewed the affected usages in `physics.ts`, `project.ts`, `scenes.ts`, and `input-map.ts`.

---
*PR created automatically by Jules for task [3349000905123793757](https://jules.google.com/task/3349000905123793757) started by @n24q02m*