### PR TITLE
⚡ Bolt: pre-compile RegExps and use .exec() in hot paths

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -72,3 +72,7 @@ This ensures that "create" matches "create" even if "create_node" appears earlie
 ## 2025-03-10 - [Pre-allocate arrays for node listing]
 **Learning:** Dynamically growing arrays using `.push()` inside an O(N) traversal (like listing all nodes in a scene) causes resizing overhead in the V8 engine, which accumulates heavily in scenes with tens of thousands of nodes.
 **Action:** Always use a pre-allocated array (`new Array(scene.nodes.length)`) for 1:1 mapping operations during O(N) loops, avoiding V8 array resizing penalties.
+
+## 2026-07-14 - Pre-compile inline regular expressions
+**Learning:** Initializing regular expressions inline inside parsing hot paths (e.g., inside loops iterating over files like `project.godot`) forces the JS engine to recreate the RegExp object or check cache continually. While modern engines cache regex literals, making them module-level constants definitively avoids potential recreation overhead. Furthermore, `.exec()` avoids the minor overhead of `String.prototype.match()` while providing identical capture group output for non-global regexes.
+**Action:** Extract non-global inline regexes (like `/"events":\s*\[([^\]]*)\]/`) into module-level constants (e.g., `EVENTS_REGEX`) and replace `.match()` calls with `.exec()` in high-frequency parsing paths.

--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -12,11 +12,10 @@ import { pathExists, safeResolve } from '../helpers/paths.js'
 import { fastTrimRange } from '../helpers/strings.js'
 
 // ⚡ Bolt: Pre-compile regular expressions to avoid recreation in hot paths
-const EVENTS_REGEX = /"events":\s*\[([^\]]*)\]/;
-const SINGLE_LINE_ACTION_REGEX = /^(\w+)=\{(.+)\}$/;
-const MULTI_LINE_ACTION_START_REGEX = /^(\w+)=\{(.*)$/;
-const EVENTS_TRANSFORM_REGEX = /("events":\s*\[)([^\]]*)\]/;
-
+const EVENTS_REGEX = /"events":\s*\[([^\]]*)\]/
+const SINGLE_LINE_ACTION_REGEX = /^(\w+)=\{(.+)\}$/
+const MULTI_LINE_ACTION_START_REGEX = /^(\w+)=\{(.*)$/
+const EVENTS_TRANSFORM_REGEX = /("events":\s*\[)([^\]]*)\]/
 
 /**
  * Godot 4.x Key enum numeric values (@GlobalScope.Key)

--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -11,6 +11,13 @@ import { serializeGodotObject } from '../helpers/godot-types.js'
 import { pathExists, safeResolve } from '../helpers/paths.js'
 import { fastTrimRange } from '../helpers/strings.js'
 
+// ⚡ Bolt: Pre-compile regular expressions to avoid recreation in hot paths
+const EVENTS_REGEX = /"events":\s*\[([^\]]*)\]/;
+const SINGLE_LINE_ACTION_REGEX = /^(\w+)=\{(.+)\}$/;
+const MULTI_LINE_ACTION_START_REGEX = /^(\w+)=\{(.*)$/;
+const EVENTS_TRANSFORM_REGEX = /("events":\s*\[)([^\]]*)\]/;
+
+
 /**
  * Godot 4.x Key enum numeric values (@GlobalScope.Key)
  * Letters are ASCII codes, special keys use the 4194304+ range (2^22 bit set)
@@ -200,7 +207,7 @@ function parseInputActions(content: string): Map<string, string[]> {
         currentActionAccumulator += trimmed
         if (trimmed.endsWith('}')) {
           // End of multi-line action
-          const eventsMatch = currentActionAccumulator.match(/"events":\s*\[([^\]]*)\]/)
+          const eventsMatch = EVENTS_REGEX.exec(currentActionAccumulator)
           const events = eventsMatch ? parseEventsList(eventsMatch[1]) : []
           actions.set(currentActionName, events)
           currentActionName = null
@@ -215,10 +222,10 @@ function parseInputActions(content: string): Map<string, string[]> {
           break
         } else if (inInputSection) {
           // Single-line format: action_name={...}
-          const match = trimmed.match(/^(\w+)=\{(.+)\}$/)
+          const match = SINGLE_LINE_ACTION_REGEX.exec(trimmed)
           if (match) {
             const actionName = match[1]
-            const eventsMatch = match[2].match(/"events":\s*\[([^\]]*)\]/)
+            const eventsMatch = EVENTS_REGEX.exec(match[2])
             const events = eventsMatch ? parseEventsList(eventsMatch[1]) : []
             actions.set(actionName, events)
           } else {
@@ -226,7 +233,7 @@ function parseInputActions(content: string): Map<string, string[]> {
             //   "deadzone": 0.2,
             //   "events": [...]
             // }
-            const startMatch = trimmed.match(/^(\w+)=\{(.*)$/)
+            const startMatch = MULTI_LINE_ACTION_START_REGEX.exec(trimmed)
             if (startMatch) {
               currentActionName = startMatch[1]
               currentActionAccumulator = startMatch[2]
@@ -491,13 +498,12 @@ export async function handleInputMap(action: string, args: Record<string, unknow
 
       // Find existing events array and append using transformInputMap
       const { updated, found } = transformInputMap(content, actionName, (block) => {
-        const eventsRegex = /("events":\s*\[)([^\]]*)\]/
-        const match = block.match(eventsRegex)
+        const match = EVENTS_TRANSFORM_REGEX.exec(block)
         if (!match) return block // Should not happen with valid Godot files
 
         const existingEvents = match[2].trim()
         const newEvents = existingEvents ? `${existingEvents}, ${eventObj}` : eventObj
-        return block.replace(eventsRegex, (_, p1) => `${p1}${newEvents}]`)
+        return block.replace(EVENTS_TRANSFORM_REGEX, (_, p1) => `${p1}${newEvents}]`)
       })
 
       if (!found) {

--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -7,6 +7,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { safeResolve } from '../helpers/paths.js'
+
 import {
   getNodeProperty,
   parseSceneContent,
@@ -14,6 +15,9 @@ import {
   renameNodeInContent,
   setNodePropertyInContent,
 } from '../helpers/scene-parser.js'
+
+// ⚡ Bolt: Pre-compile regular expressions to avoid recreation in hot paths
+const ROOT_PATH_REGEX = /^\/?root\/(.+)$/i;
 
 function resolveScenePath(projectPath: string, scenePath: string): string {
   return safeResolve(projectPath, scenePath)
@@ -45,7 +49,7 @@ function normalizeNodePath(path: string): { path: string; corrected: boolean } {
 
   // Case-insensitive check for /root/ or root/ prefix
   // These are common LLM mistakes when they try to use absolute paths.
-  const rootMatch = normalized.match(/^\/?root\/(.+)$/i)
+  const rootMatch = ROOT_PATH_REGEX.exec(normalized)
   if (rootMatch) {
     const afterRoot = rootMatch[1]
     const segments = afterRoot.split('/').filter(Boolean)

--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -17,7 +17,7 @@ import {
 } from '../helpers/scene-parser.js'
 
 // ⚡ Bolt: Pre-compile regular expressions to avoid recreation in hot paths
-const ROOT_PATH_REGEX = /^\/?root\/(.+)$/i;
+const ROOT_PATH_REGEX = /^\/?root\/(.+)$/i
 
 function resolveScenePath(projectPath: string, scenePath: string): string {
   return safeResolve(projectPath, scenePath)


### PR DESCRIPTION
💡 What: Extracted inline regular expressions into module-level constants and replaced `.match()` with `.exec()` in parsing hot paths (`input-map.ts` and `nodes.ts`).
🎯 Why: Initializing regex literals within tight loops theoretically forces engine evaluation/cache checks. Pre-compiling them guarantees zero recreation overhead. `.exec()` is also slightly faster than `.match()` for non-global regexes while maintaining identical capture group outputs.
📊 Impact: Reduces garbage collection pressure and CPU overhead during bulk parsing operations (e.g. `list` actions).
🔬 Measurement: Run `bun run test` to verify parser functionality remains completely identical.

---
*PR created automatically by Jules for task [10595091693018281870](https://jules.google.com/task/10595091693018281870) started by @n24q02m*