### PR TITLE
feat: add PR-title conventional-commit gate + no-bump release warning

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -83,6 +83,28 @@ jobs:
           prerelease_token: beta
           no_operation_mode: true
 
+      # PSR silently no-ops when it can't find a fix:/feat: commit since the last
+      # tag -- e.g. a bot PR squash-merged with a non-conventional subject (the
+      # commit-title no-bump trap the pr-title CI check guards at merge time; this
+      # step is the release-time backstop for anything that slipped past it, or a
+      # repo predating that check). released=false alone is not an error (it is
+      # the normal outcome of a docs-only/chore-only window), so this only warns.
+      - name: Warn if commits exist since last tag but PSR computed no release
+        if: steps.dryrun.outputs.released != 'true'
+        run: |
+          set -uo pipefail
+          highest_tag="$(git tag -l 'v*' | sort -V | tail -1)"
+          if [ -z "$highest_tag" ]; then
+            echo "No existing tags -- nothing to compare."
+            exit 0
+          fi
+          commit_count="$(git rev-list "${highest_tag}..HEAD" --count)"
+          if [ "$commit_count" -gt 0 ]; then
+            echo "::warning::PSR computed no release (released=false) but ${commit_count} commit(s) exist since ${highest_tag}. This is expected if they are all chore/docs-only, but if one of them should have bumped the version (e.g. a bot-authored fix squashed with a non-conventional subject), inspect 'git log ${highest_tag}..HEAD --oneline' before assuming there is nothing to release."
+          else
+            echo "OK: no commits since ${highest_tag} -- released=false is expected."
+          fi
+
       # Fail early and loudly if the version PSR intends to publish already exists on
       # npm. npm never allows reusing a version number, so a hit here means the git
       # history has diverged from the registry. Catching it here converts two nasty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,45 @@ permissions:
   pull-requests: write
 
 jobs:
+  # ============================================================================
+  # PR Title Lint (Conventional Commits subset)
+  # ============================================================================
+  # Squash-merge uses the PR title as the commit subject and bypasses the
+  # local enforce-commit pre-commit commit-msg hook (bot PRs never run local
+  # git hooks). Without a server-side check, a bot title like
+  # "Sentinel: [HIGH] Fix ..." squash-merges with a non-conventional subject
+  # -> PSR's commit parser silently ignores it -> no version bump, even for a
+  # security fix. This job only surfaces a red check; it does not block
+  # merge (no required-status-check rule), so the person merging still must
+  # retype the squash-commit subject to start with fix:/feat: when this is red.
+  pr-title:
+    name: Validate PR title (Conventional Commits subset)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        with:
+          egress-policy: audit
+
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Repo rule: only feat: and fix: (feedback_commit_prefix.md). This is
+          # narrower than PSR's own default allowed_tags (which also treats
+          # perf: as patch-worthy) -- we enforce the project convention here,
+          # not just what PSR itself would accept.
+          types: |
+            fix
+            feat
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject must not start with an uppercase character.
+
   lint-and-test:
     name: Lint, Test & Build (${{ matrix.os }})
     if: github.event_name == 'pull_request' || github.event_name == 'push'


### PR DESCRIPTION
## Why

Bot-authored PRs (Sentinel/Bolt/Jules) squash-merge with a non-conventional title (e.g. emoji-prefixed, no `fix:`/`feat:` token). Squash-merge uses the PR title as the commit subject and bypasses the local `enforce-commit` pre-commit `commit-msg` hook (bot PRs never run local git hooks), so a title like `Sentinel: [HIGH] Fix ...` lands on `main` as a commit PSR's parser cannot recognize -> no version bump, even for a security fix. This already happened and required a controller to manually retype the squash-commit subject at merge time (imagine-mcp#452, the only repo in the 12-repo MCP stack that already had this gate).

## What

Rolled out from the spike verified on `web-core` (PR #643, both directions confirmed with real CI runs: conventional title passes, non-conventional bot-style title fails):

1. **`ci.yml`: `pr-title` job** -- `amannn/action-semantic-pull-request` validates the PR title matches `fix:`/`feat:` at PR-open/sync time. Not a required status check (no branch-ruleset change here), so it does not block merge -- it surfaces a red X that forces whoever runs the squash-merge to notice and retype the subject. Restricted to `types: [fix, feat]` only (this repo's own PSR config has no `commit_parser_options` override, so PSR's built-in default `allowed_tags` also treats `perf:` as patch-worthy -- the gate deliberately enforces the narrower project policy, feedback_commit_prefix.md, not just what PSR itself would accept).
2. **`cd.yml`: release-time backstop** -- right after the existing PSR dry-run step, warn (`::warning::`, non-blocking) if `released=false` but commits exist since the last tag. Catches anything that slipped past (1).

## Verify

- `actionlint .github/workflows/ci.yml .github/workflows/cd.yml` -- clean.
- This PR's own title is conventional (`feat:`), so the new `pr-title` check on this very PR is a live run of the accept path.