### PR TITLE
fix: make live tests self-contained

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,9 +109,6 @@ jobs:
         with:
           files: coverage/lcov.info
 
-      - name: Build project
-        run: bun run build
-
       - name: Run live MCP protocol test (stdio handshake + tools/list)
         run: bun run test:live
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "lint": "biome check .",
     "format": "biome format --write .",
     "check": "biome check . && tsc --noEmit",
-    "test:full": "vitest run --config vitest.full.config.ts",
-    "test:live": "vitest run --config vitest.live.config.ts",
+    "test:full": "bun run build && vitest run --config vitest.full.config.ts",
+    "test:live": "bun run build && vitest run --config vitest.live.config.ts",
     "check:fix": "biome check --fix .",
     "clean": "rm -rf build bin",
     "prepublishOnly": "bun run build"


### PR DESCRIPTION
## Summary
- build the CLI before the full Godot and live MCP suites
- make both live test commands work from a clean checkout without a pre-existing ignored `bin/cli.mjs`

## Verification
- `bun run check`
- `bun run test` — 64 files, 1,012 passed, 2 skipped
- clean checkout `bun run test:full` — 37 passed
- clean checkout `bun run test:live` — 21 passed