### PR TITLE
feat: validate Godot engine compatibility and help contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,70 @@ jobs:
       - name: Run live MCP protocol test (stdio handshake + tools/list)
         run: bun run test:live
 
+  engine-compatibility:
+    name: Engine compatibility (Godot 4.7.1 stable)
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install pinned Godot 4.7.1 stable
+        env:
+          GODOT_ASSET_NAME: Godot_v4.7.1-stable_linux.x86_64.zip
+          GODOT_ASSET_URL: https://github.com/godotengine/godot-builds/releases/download/4.7.1-stable/Godot_v4.7.1-stable_linux.x86_64.zip
+          GODOT_SHA256: c7ff14fd28472c8d4f193043de30278dcf7e5241a1dcf7566b02e27addaa33ba
+        run: |
+          set -euo pipefail
+          godot_root="$RUNNER_TEMP/godot"
+          godot_archive="$godot_root/$GODOT_ASSET_NAME"
+          godot_extract="$godot_root/extracted"
+          godot_bin="$godot_root/bin"
+
+          mkdir -p "$godot_extract" "$godot_bin"
+          curl --fail --location --retry 3 --output "$godot_archive" "$GODOT_ASSET_URL"
+          printf '%s  %s\n' "$GODOT_SHA256" "$godot_archive" | sha256sum --check --strict
+          unzip -q "$godot_archive" -d "$godot_extract"
+
+          godot_binary="$godot_extract/Godot_v4.7.1-stable_linux.x86_64"
+          test -f "$godot_binary"
+          install -m 0755 "$godot_binary" "$godot_bin/godot"
+          echo "$godot_bin" >> "$GITHUB_PATH"
+          echo "GODOT_PATH=$godot_bin/godot" >> "$GITHUB_ENV"
+
+      - name: Verify pinned Godot version
+        run: |
+          set -euo pipefail
+          godot_version="$(godot --headless --version)"
+          printf 'Godot version: %s\n' "$godot_version"
+          case "$godot_version" in
+            4.7.1.stable.official*) ;;
+            *) echo "Unexpected Godot version: $godot_version" >&2; exit 1 ;;
+          esac
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Setup Node.js 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build MCP binary
+        run: bun run build
+
+      - name: Run full MCP engine scenario
+        run: bun run test:full
+
   dependency-review:
     name: Dependency Review
     if: github.event_name == 'pull_request'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 <!-- version list -->
 
+## Unreleased
+
+### Breaking Changes
+
+| Legacy argument | Current argument |
+| --- | --- |
+| `help.tool_name` | `help.topic` |
+
+`topic` is optional; omitting it returns the overview.
+
 ## v1.21.0 (2026-07-18)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ mcp-name: io.github.n24q02m/better-godot-mcp
 
 ## Install
 
-Runs over **stdio** by default. No credentials, no account, no relay -- the server reads and writes your local Godot project files directly. Godot 4.x is optional (only `run`/`stop`/`export` and `editor` actions need the binary).
+Runs over **stdio** by default. No credentials, no account, no relay -- the server reads and writes your local Godot project files directly. Godot 4.x is optional for file operations; only `run`/`stop`/`export` and `editor` actions need a Godot binary. The detector accepts Godot >=4.1. Live engine compatibility is currently verified with Godot 4.7.1 stable; this does not claim that every future minor release has been verified.
 
 ### Via npx (recommended)
 
@@ -194,7 +194,7 @@ The server runs over stdio by default. To serve over Streamable HTTP instead, pa
 
 ### Limitations
 
-- Requires Godot 4.x project structure
+- Requires a Godot 4.x project structure; a Godot binary is optional for file operations
 - Scene files (`.tscn`) are parsed/modified via text manipulation, not Godot's internal API
 - `run`/`stop`/`export` actions require Godot binary to be installed
 - Docker mode has limited filesystem access (mount your project directory)
@@ -220,10 +220,10 @@ npx -y @n24q02m/better-godot-mcp detect
   "path": "/path/to/godot",
   "version": {
     "major": 4,
-    "minor": 6,
-    "patch": 3,
+    "minor": 7,
+    "patch": 1,
     "label": "stable.official",
-    "raw": "4.6.3.stable.official"
+    "raw": "4.7.1.stable.official"
   },
   "source": "system"
 }
@@ -236,7 +236,7 @@ npx -y @n24q02m/better-godot-mcp doctor
 
 ```text
 [ok] godot binary: /path/to/godot (source: system)
-[ok] godot version: 4.6.3.stable.official
+[ok] godot version: 4.7.1.stable.official
 [warn] project: no project.godot found at /path/to/cwd (set GODOT_PROJECT_PATH)
 ```
 

--- a/scripts/start-server.test.ts
+++ b/scripts/start-server.test.ts
@@ -45,7 +45,7 @@ describe('start-server (buildCli wiring)', () => {
 
     expect(initServer).not.toHaveBeenCalled()
     expect(process.exit).toHaveBeenCalledWith(0)
-  })
+  }, 30_000)
 
   it('routes "detect" to the Godot-specific handler', async () => {
     process.argv.push('detect')
@@ -56,7 +56,7 @@ describe('start-server (buildCli wiring)', () => {
 
     expect(initServer).not.toHaveBeenCalled()
     expect(process.exit).toHaveBeenCalledWith(0)
-  })
+  }, 30_000)
 
   it('propagates the Godot doctor exit code (1 when Godot is not found)', async () => {
     process.argv.push('doctor')
@@ -66,7 +66,7 @@ describe('start-server (buildCli wiring)', () => {
     await vi.waitFor(() => expect(process.exit).toHaveBeenCalled())
 
     expect(process.exit).toHaveBeenCalledWith(1)
-  })
+  }, 30_000)
 
   it('exposes the core doctor (node runtime / storage / relay / mode) under "core-doctor"', async () => {
     process.argv.push('core-doctor')
@@ -86,7 +86,7 @@ describe('start-server (buildCli wiring)', () => {
     expect(runGodotCli).not.toHaveBeenCalled()
     expect(initServer).not.toHaveBeenCalled()
     logSpy.mockRestore()
-  })
+  }, 30_000)
 
   it('prints version and exits 0 without starting the server', async () => {
     process.argv.push('--version')
@@ -99,7 +99,7 @@ describe('start-server (buildCli wiring)', () => {
     expect(process.exit).toHaveBeenCalledWith(0)
     expect(initServer).not.toHaveBeenCalled()
     logSpy.mockRestore()
-  })
+  }, 30_000)
 
   it('lists doctor/detect/core-doctor as subcommands in -h', async () => {
     process.argv.push('-h')
@@ -113,7 +113,7 @@ describe('start-server (buildCli wiring)', () => {
     expect(subcommandsLine).toContain('detect')
     expect(subcommandsLine).toContain('core-doctor')
     logSpy.mockRestore()
-  })
+  }, 30_000)
 
   it('starts the server and registers SIGINT/SIGTERM when no subcommand is given', async () => {
     vi.mocked(initServer).mockResolvedValue(undefined)
@@ -124,7 +124,7 @@ describe('start-server (buildCli wiring)', () => {
     expect(runGodotCli).not.toHaveBeenCalled()
     expect(onceSpy).toHaveBeenCalledWith('SIGINT', expect.any(Function))
     expect(onceSpy).toHaveBeenCalledWith('SIGTERM', expect.any(Function))
-  })
+  }, 30_000)
 
   it('does not exit right after initServer resolves (stdio must stay alive until shutdown)', async () => {
     // Regression guard: Server.connect() (inside initServer) resolves once
@@ -139,7 +139,7 @@ describe('start-server (buildCli wiring)', () => {
     await new Promise((resolve) => setTimeout(resolve, 20))
 
     expect(process.exit).not.toHaveBeenCalled()
-  })
+  }, 30_000)
 
   it('exits 0 once SIGINT fires after the server starts', async () => {
     vi.mocked(initServer).mockResolvedValue(undefined)
@@ -156,7 +156,7 @@ describe('start-server (buildCli wiring)', () => {
 
     sigintHandler?.()
     await vi.waitFor(() => expect(process.exit).toHaveBeenCalledWith(0))
-  })
+  }, 30_000)
 
   it('exits with 1 if initServer throws', async () => {
     const error = new Error('Init failed')
@@ -165,7 +165,7 @@ describe('start-server (buildCli wiring)', () => {
     await import('./start-server.js')
     await vi.waitFor(() => expect(initServer).toHaveBeenCalled())
     await vi.waitFor(() => expect(process.exit).toHaveBeenCalledWith(1))
-  })
+  }, 30_000)
 
   it('does not add a redundant SIGINT wait for --http (initServer already blocks until its own shutdown)', async () => {
     process.argv.push('--http')
@@ -176,5 +176,5 @@ describe('start-server (buildCli wiring)', () => {
     await vi.waitFor(() => expect(process.exit).toHaveBeenCalledWith(0))
 
     expect(onceSpy).not.toHaveBeenCalled()
-  })
+  }, 30_000)
 })

--- a/src/docs/help.md
+++ b/src/docs/help.md
@@ -1,14 +1,32 @@
 # Help Tool - Full Documentation
 
 ## Overview
-Get full documentation for any tool.
+Get markdown documentation for the server tools. The `topic` property is optional.
 
 ## Usage
 ```json
-{"tool_name": "scenes"}
+{"topic": "scenes"}
 ```
 
+Omit `topic` to return the server overview from `overview.md`.
+
 ## Available Topics
-project, scenes, nodes, scripts, editor, config, help,
-resources, input_map, signals, animation, tilemap, shader,
-physics, audio, navigation, ui
+- `animation`
+- `audio`
+- `editor`
+- `input_map`
+- `navigation`
+- `nodes`
+- `physics`
+- `project`
+- `resources`
+- `scenes`
+- `scripts`
+- `shader`
+- `signals`
+- `tilemap`
+- `ui`
+- `config`
+- `overview`
+
+`help` is the tool name, not a valid documentation topic.

--- a/src/docs/overview.md
+++ b/src/docs/overview.md
@@ -1,0 +1,26 @@
+# Better Godot MCP Documentation
+
+## Overview
+
+Use the `help` tool to read the full markdown documentation for any supported topic. Call it with no arguments for this overview.
+
+## Available Topics
+
+- `animation` - AnimationPlayer and animation resource operations.
+- `audio` - Audio buses, effects, and stream players.
+- `editor` - Godot editor launch and status operations.
+- `input_map` - Project input action management.
+- `navigation` - Navigation regions, agents, and obstacles.
+- `nodes` - Scene node operations.
+- `physics` - Collision layers and physics body configuration.
+- `project` - Project metadata, settings, running, logs, and exports.
+- `resources` - Resource browsing and import configuration.
+- `scenes` - Scene file CRUD and main-scene management.
+- `scripts` - GDScript file CRUD and scene attachment.
+- `shader` - Godot shader file management.
+- `signals` - Scene signal connection management.
+- `tilemap` - TileSet and TileMap operations.
+- `ui` - Control nodes, layouts, and themes.
+- `config` - Server configuration and environment detection.
+
+For detailed usage, call `help` with one of these topics. The `help` tool itself is not a topic.

--- a/src/tools/composite/help.ts
+++ b/src/tools/composite/help.ts
@@ -8,26 +8,26 @@ import { join } from 'node:path'
 import { GodotMCPError } from '../helpers/errors.js'
 import { pathExists } from '../helpers/paths.js'
 
-const VALID_TOPICS = [
-  'project',
-  'scenes',
-  'nodes',
-  'scripts',
-  'editor',
-  'config',
-  'help',
-  'resources',
-  'input_map',
-  'signals',
+export const VALID_HELP_TOPICS = [
   'animation',
-  'tilemap',
-  'shader',
-  'physics',
   'audio',
+  'editor',
+  'input_map',
   'navigation',
+  'nodes',
+  'physics',
+  'project',
+  'resources',
+  'scenes',
+  'scripts',
+  'shader',
+  'signals',
+  'tilemap',
   'ui',
+  'config',
+  'overview',
 ] as const
-type TopicName = (typeof VALID_TOPICS)[number]
+type HelpTopic = (typeof VALID_HELP_TOPICS)[number]
 
 let cachedDocsDir: string | null = null
 
@@ -63,7 +63,7 @@ async function getDocsDir(): Promise<string> {
 }
 
 /**
- * Load documentation for a specific tool
+ * Load documentation for a specific help topic.
  */
 async function loadDoc(topic: string): Promise<string> {
   const docsDir = await getDocsDir()
@@ -81,14 +81,18 @@ async function loadDoc(topic: string): Promise<string> {
   }
 }
 
-export async function handleHelp(action: string, args: Record<string, unknown>) {
-  const toolName = (args.tool_name as string) || action
+export async function handleHelp(topic?: string) {
+  const resolvedTopic = topic === undefined ? 'overview' : topic
 
-  if (!VALID_TOPICS.includes(toolName as TopicName)) {
-    throw new GodotMCPError(`Unknown tool: ${toolName}`, 'INVALID_ARGS', `Valid topics: ${VALID_TOPICS.join(', ')}`)
+  if (!VALID_HELP_TOPICS.includes(resolvedTopic as HelpTopic)) {
+    throw new GodotMCPError(
+      `Unknown topic: ${resolvedTopic}`,
+      'INVALID_ARGS',
+      `Valid topics: ${VALID_HELP_TOPICS.join(', ')}`,
+    )
   }
 
-  const doc = await loadDoc(toolName)
+  const doc = await loadDoc(resolvedTopic)
   // help stays markdown-only by design (no outputSchema) -- do not route through
   // formatSuccess, which now always emits structuredContent for domain tools.
   return { content: [{ type: 'text', text: doc }] }

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -14,7 +14,7 @@ import { handleAnimation } from './composite/animation.js'
 import { handleAudio } from './composite/audio.js'
 import { handleConfig } from './composite/config.js'
 import { handleEditor } from './composite/editor.js'
-import { handleHelp } from './composite/help.js'
+import { handleHelp, VALID_HELP_TOPICS } from './composite/help.js'
 import { handleInputMap } from './composite/input-map.js'
 import { handleNavigation } from './composite/navigation.js'
 import { handleNodes } from './composite/nodes.js'
@@ -249,36 +249,18 @@ const P0_TOOLS = [
   },
   {
     name: 'help',
-    description: 'Full documentation for a tool. Use when compressed descriptions are insufficient.',
+    description:
+      'Full documentation. Omit topic for the overview; use a topic when compressed descriptions are insufficient.',
     annotations: createAnnotations('Help', { readOnly: true, idempotent: true }),
     inputSchema: {
       type: 'object' as const,
       properties: {
-        tool_name: {
+        topic: {
           type: 'string',
-          enum: [
-            'project',
-            'scenes',
-            'nodes',
-            'scripts',
-            'editor',
-            'config',
-            'help',
-            'resources',
-            'input_map',
-            'signals',
-            'animation',
-            'tilemap',
-            'shader',
-            'physics',
-            'audio',
-            'navigation',
-            'ui',
-          ],
-          description: 'Tool to get documentation for',
+          enum: [...VALID_HELP_TOPICS],
+          description: 'Documentation topic. Omit to read overview.md.',
         },
       },
-      required: ['tool_name'],
     },
   },
 ]
@@ -616,10 +598,7 @@ export function registerTools(server: Server, config: GodotConfig): void {
         isError?: boolean
       }
       if (name === 'help') {
-        result = await handleHelp(
-          (args.action as string) || (args.tool_name as string),
-          args as Record<string, unknown>,
-        )
+        result = await handleHelp(args.topic as string | undefined)
       } else {
         const handler = Object.hasOwn(TOOL_HANDLERS, name) ? TOOL_HANDLERS[name] : undefined
         if (!handler) {

--- a/tests/composite/help-docs.test.ts
+++ b/tests/composite/help-docs.test.ts
@@ -3,14 +3,29 @@
  * enum) drifting from src/docs/*.md. See help.test.ts for the (mocked) loading mechanism.
  */
 import { describe, expect, it } from 'vitest'
-import { handleHelp } from '../../src/tools/composite/help.js'
+import { handleHelp, VALID_HELP_TOPICS } from '../../src/tools/composite/help.js'
 
-describe('help(project) doc content', () => {
+describe('help documentation contract', () => {
+  it('returns overview.md when no topic is supplied', async () => {
+    const result = await handleHelp()
+    const text = result.content[0].text
+
+    expect(text).toMatch(/^# /)
+    expect(text).toContain('Available Topics')
+  })
+
   it('documents the logs action and its pid param', async () => {
-    const result = await handleHelp('project', {})
+    const result = await handleHelp('project')
     const text = result.content[0].text
 
     expect(text).toContain('### logs')
     expect(text).toContain('pid')
+  })
+
+  it.each(VALID_HELP_TOPICS)('has a markdown document for topic %s', async (topic) => {
+    const result = await handleHelp(topic)
+    const text = result.content[0].text
+
+    expect(text).toMatch(/^# /)
   })
 })

--- a/tests/composite/help.test.ts
+++ b/tests/composite/help.test.ts
@@ -4,6 +4,26 @@ import { handleHelp } from '../../src/tools/composite/help.js'
 import { GodotMCPError } from '../../src/tools/helpers/errors.js'
 import { pathExists } from '../../src/tools/helpers/paths.js'
 
+const VALID_TOPICS = [
+  'animation',
+  'audio',
+  'editor',
+  'input_map',
+  'navigation',
+  'nodes',
+  'physics',
+  'project',
+  'resources',
+  'scenes',
+  'scripts',
+  'shader',
+  'signals',
+  'tilemap',
+  'ui',
+  'config',
+  'overview',
+] as const
+
 // Mock node:fs/promises and paths helper
 vi.mock('node:fs/promises', () => {
   return {
@@ -21,11 +41,21 @@ describe('handleHelp', () => {
     vi.mocked(pathExists).mockResolvedValue(true)
   })
 
-  it('should return documentation for valid topic', async () => {
+  it('should return overview documentation when topic is omitted', async () => {
+    vi.mocked(readFile).mockResolvedValue('# Overview Documentation')
+
+    const result = await handleHelp()
+
+    expect(result.content[0].text).toContain('# Overview Documentation')
+    const calledPath = vi.mocked(readFile).mock.calls[0][0] as string
+    expect(calledPath).toContain('overview.md')
+  })
+
+  it('should return documentation for a valid topic', async () => {
     // Mock valid documentation file
     vi.mocked(readFile).mockResolvedValue('# Test Documentation')
 
-    const result = await handleHelp('project', {})
+    const result = await handleHelp('project')
 
     expect(result.content[0].text).toContain('# Test Documentation')
     expect(readFile).toHaveBeenCalled()
@@ -34,15 +64,15 @@ describe('handleHelp', () => {
   it('should never emit structuredContent -- help stays markdown-only, no outputSchema declared', async () => {
     vi.mocked(readFile).mockResolvedValue('# Test Documentation')
 
-    const result = await handleHelp('project', {})
+    const result = await handleHelp('project')
 
     expect((result as Record<string, unknown>).structuredContent).toBeUndefined()
   })
 
-  it('should use tool_name from arguments if provided', async () => {
+  it('should load the requested topic document', async () => {
     vi.mocked(readFile).mockResolvedValue('# Scenes Documentation')
 
-    const result = await handleHelp('help', { tool_name: 'scenes' })
+    const result = await handleHelp('scenes')
 
     expect(result.content[0].text).toContain('# Scenes Documentation')
     // Verify it looked for scenes.md, not help.md
@@ -51,8 +81,22 @@ describe('handleHelp', () => {
   })
 
   it('should throw error for invalid topic', async () => {
-    await expect(handleHelp('invalid_tool', {})).rejects.toThrow(GodotMCPError)
-    await expect(handleHelp('help', { tool_name: 'invalid_tool' })).rejects.toThrow('Unknown tool: invalid_tool')
+    await expect(handleHelp('invalid_tool')).rejects.toThrow(GodotMCPError)
+    await expect(handleHelp('invalid_tool')).rejects.toThrow('Unknown topic: invalid_tool')
+  })
+
+  it('should list valid topics in stable order and reject help aliases', async () => {
+    const error = await handleHelp('help').catch((caught: unknown) => caught)
+
+    expect(error).toBeInstanceOf(GodotMCPError)
+    expect((error as GodotMCPError).suggestion).toBe(`Valid topics: ${VALID_TOPICS.join(', ')}`)
+    expect(readFile).not.toHaveBeenCalled()
+  })
+
+  it('should reject path traversal without reading outside the docs directory', async () => {
+    await expect(handleHelp('../package.json')).rejects.toThrow('Unknown topic: ../package.json')
+    await expect(handleHelp('..\\package.json')).rejects.toThrow('Unknown topic: ..\\package.json')
+    expect(readFile).not.toHaveBeenCalled()
   })
 
   it('should return fallback message if documentation file is missing (ENOENT)', async () => {
@@ -61,7 +105,7 @@ describe('handleHelp', () => {
     enoent.code = 'ENOENT'
     vi.mocked(readFile).mockRejectedValue(enoent)
 
-    const result = await handleHelp('project', {})
+    const result = await handleHelp('project')
 
     expect(result.content[0].text).toContain('No documentation available for: project')
   })
@@ -72,6 +116,6 @@ describe('handleHelp', () => {
     eacces.code = 'EACCES'
     vi.mocked(readFile).mockRejectedValue(eacces)
 
-    await expect(handleHelp('project', {})).rejects.toThrow('Permission denied')
+    await expect(handleHelp('project')).rejects.toThrow('Permission denied')
   })
 })

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -7,7 +7,7 @@ describe('Better Godot MCP', () => {
       const mod = await import('../src/init-server.js')
       expect(mod.initServer).toBeDefined()
       expect(typeof mod.initServer).toBe('function')
-    })
+    }, 30_000)
   })
 
   describe('detector', () => {
@@ -25,7 +25,7 @@ describe('Better Godot MCP', () => {
       expect(v2?.major).toBe(4)
       expect(v2?.minor).toBe(3)
       expect(v2?.patch).toBe(1)
-    })
+    }, 30_000)
 
     it('should validate minimum version', async () => {
       const { isVersionSupported } = await import('../src/godot/detector.js')
@@ -35,7 +35,7 @@ describe('Better Godot MCP', () => {
       expect(isVersionSupported({ major: 4, minor: 0, patch: 0, label: 'stable', raw: '' })).toBe(false)
       expect(isVersionSupported({ major: 3, minor: 5, patch: 0, label: 'stable', raw: '' })).toBe(false)
       expect(isVersionSupported({ major: 5, minor: 0, patch: 0, label: 'dev', raw: '' })).toBe(true)
-    })
+    }, 30_000)
   })
 
   describe('errors', () => {
@@ -49,7 +49,7 @@ describe('Better Godot MCP', () => {
       expect(result.content[0].text).toContain('GODOT_NOT_FOUND')
       expect(result.content[0].text).toContain('Test error')
       expect(result.content[0].text).toContain('Install Godot')
-    })
+    }, 30_000)
 
     it('should format generic errors', async () => {
       const { formatError } = await import('../src/tools/helpers/errors.js')
@@ -57,6 +57,6 @@ describe('Better Godot MCP', () => {
       const result = formatError(new Error('generic'))
       expect(result.isError).toBe(true)
       expect(result.content[0].text).toContain('generic')
-    })
+    }, 30_000)
   })
 })

--- a/tests/e2e_mcp_http_test.py
+++ b/tests/e2e_mcp_http_test.py
@@ -67,7 +67,7 @@ async def main() -> int:
         ("config", "status", {"action": "status"}),
         ("config", "detect_godot", {"action": "detect_godot"}),
         ("config", "check", {"action": "check"}),
-        ("help", "help_config", {"tool_name": "config"}),
+        ("help", "help_config", {"topic": "config"}),
         ("project", "info", {"action": "info", "project_path": PROJECT_PATH}),
         ("project", "version", {"action": "version", "project_path": PROJECT_PATH}),
         ("project", "settings_get", {"action": "settings_get", "key": "application/config/name", "project_path": PROJECT_PATH}),

--- a/tests/e2e_mcp_protocol_test.py
+++ b/tests/e2e_mcp_protocol_test.py
@@ -30,8 +30,8 @@ CALL_PLANS: dict[str, list[tuple[str, dict]]] = {
         ("set", {"action": "set", "key": "project_path", "value": PROJECT_PATH}),
     ],
     "help": [
-        ("help_project", {"tool_name": "project"}),
-        ("help_scenes", {"tool_name": "scenes"}),
+        ("help_project", {"topic": "project"}),
+        ("help_scenes", {"topic": "scenes"}),
     ],
     "project": [
         ("version", {"action": "version"}),

--- a/tests/live/mcp-protocol.live.test.ts
+++ b/tests/live/mcp-protocol.live.test.ts
@@ -90,14 +90,16 @@ describe('MCP Protocol - Live', () => {
     }
   })
 
-  it('every tool has inputSchema with required action field', async () => {
+  it('every tool has the expected inputSchema contract', async () => {
     const result = await client.listTools()
     // All tools except 'help' require 'action'
     for (const tool of result.tools) {
       const schema = tool.inputSchema as Record<string, unknown>
       expect(schema.type).toBe('object')
       if (tool.name === 'help') {
-        expect((schema.required as string[]) ?? []).toContain('tool_name')
+        expect((schema.required as string[]) ?? []).toEqual([])
+        expect(schema.properties).toMatchObject({ topic: { type: 'string' } })
+        expect(JSON.stringify(schema)).not.toContain('tool_name')
       } else {
         expect((schema.required as string[]) ?? []).toContain('action')
       }
@@ -107,8 +109,16 @@ describe('MCP Protocol - Live', () => {
   // -------------------------------------------------------
   // 3. help tool works and returns useful content
   // -------------------------------------------------------
+  it('help tool returns overview documentation when topic is omitted', async () => {
+    const result = await client.callTool({ name: 'help', arguments: {} })
+    const text = getText(result)
+
+    expect(result.isError).toBeFalsy()
+    expect(text).toContain('Available Topics')
+  })
+
   it('help tool returns documentation for project', async () => {
-    const result = await client.callTool({ name: 'help', arguments: { tool_name: 'project' } })
+    const result = await client.callTool({ name: 'help', arguments: { topic: 'project' } })
     const text = getText(result)
 
     expect(result.isError).toBeFalsy()
@@ -117,7 +127,7 @@ describe('MCP Protocol - Live', () => {
   })
 
   it('help tool rejects unknown topics', async () => {
-    const result = await client.callTool({ name: 'help', arguments: { tool_name: 'nonexistent' } })
+    const result = await client.callTool({ name: 'help', arguments: { topic: 'nonexistent' } })
 
     expect(result.isError).toBe(true)
     const text = getText(result)
@@ -125,21 +135,10 @@ describe('MCP Protocol - Live', () => {
   })
 
   it('help tool works for all P0+P1 tools', async () => {
-    const p0p1Tools = [
-      'project',
-      'scenes',
-      'nodes',
-      'scripts',
-      'editor',
-      'config',
-      'help',
-      'resources',
-      'input_map',
-      'signals',
-    ]
+    const p0p1Tools = ['project', 'scenes', 'nodes', 'scripts', 'editor', 'config', 'resources', 'input_map', 'signals']
 
     for (const toolName of p0p1Tools) {
-      const result = await client.callTool({ name: 'help', arguments: { tool_name: toolName } })
+      const result = await client.callTool({ name: 'help', arguments: { topic: toolName } })
       expect(result.isError, `help for "${toolName}" returned error`).toBeFalsy()
       const text = getText(result)
       expect(text.length, `help for "${toolName}" should return content`).toBeGreaterThan(10)

--- a/tests/live/task2-engine-compat.full.test.ts
+++ b/tests/live/task2-engine-compat.full.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Task 2 live compatibility regression.
+ *
+ * Spawns the built CLI through the MCP SDK, uses one temporary Godot project,
+ * and checks a compact representative-operation matrix. The version case is
+ * explicitly skipped when the real Godot executable is unavailable; it never
+ * substitutes a mock engine.
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createTmpProject, createTmpScene, createTmpScript } from '../fixtures.js'
+
+type JsonObject = Record<string, unknown>
+
+interface CompatibilityOperation {
+  id: string
+  request: {
+    name: string
+    arguments: Record<string, unknown>
+  }
+  jsonKeys?: readonly string[]
+  arrayField?: string
+  arrayIncludes?: string
+  arrayObjectPath?: string
+  arrayMinLength?: number
+  expectedText?: RegExp
+  requiresGodot?: boolean
+}
+
+const COMPATIBILITY_OPERATIONS: CompatibilityOperation[] = [
+  {
+    id: 'project.info',
+    request: { name: 'project', arguments: { action: 'info' } },
+    jsonKeys: ['name', 'mainScene', 'configVersion'],
+  },
+  {
+    id: 'project.version',
+    request: { name: 'project', arguments: { action: 'version' } },
+    expectedText: /godot/i,
+    requiresGodot: true,
+  },
+  {
+    id: 'scenes.list',
+    request: { name: 'scenes', arguments: { action: 'list' } },
+    jsonKeys: ['count', 'scenes'],
+    arrayField: 'scenes',
+    arrayIncludes: 'scenes/main.tscn',
+  },
+  {
+    id: 'nodes.list',
+    request: { name: 'nodes', arguments: { action: 'list', scene_path: 'scenes/main.tscn' } },
+    jsonKeys: ['nodeCount', 'nodes'],
+    arrayField: 'nodes',
+    arrayMinLength: 1,
+  },
+  {
+    id: 'scripts.list',
+    request: { name: 'scripts', arguments: { action: 'list' } },
+    jsonKeys: ['count', 'scripts'],
+    arrayField: 'scripts',
+    arrayIncludes: 'scripts/player.gd',
+  },
+  {
+    id: 'resources.list',
+    request: { name: 'resources', arguments: { action: 'list' } },
+    jsonKeys: ['count', 'resources'],
+    arrayField: 'resources',
+    arrayObjectPath: 'resources/theme.tres',
+  },
+  {
+    id: 'project.settings_get',
+    request: {
+      name: 'project',
+      arguments: { action: 'settings_get', key: 'application/config/name' },
+    },
+    jsonKeys: ['key', 'value'],
+  },
+  {
+    id: 'config.status',
+    request: { name: 'config', arguments: { action: 'status' } },
+    jsonKeys: ['godot_path', 'godot_version', 'project_path', 'runtime_overrides'],
+  },
+]
+
+/** Extract the first text content item and remove the server's security wrapper. */
+function getText(result: Awaited<ReturnType<Client['callTool']>>, operationId: string): string {
+  expect(result.isError ?? false, `${operationId} returned an MCP error`).toBe(false)
+  expect(result.content.length, `${operationId} returned no content`).toBeGreaterThan(0)
+
+  const first = result.content[0]
+  expect(first?.type, `${operationId} returned a non-text content item`).toBe('text')
+  if (first?.type !== 'text') {
+    throw new Error(`${operationId} returned an unexpected MCP content shape`)
+  }
+  expect(first.text.length, `${operationId} returned empty text content`).toBeGreaterThan(0)
+
+  const match = first.text.match(/<untrusted_godot_content>\n([\s\S]*?)\n<\/untrusted_godot_content>/)
+  return match?.[1] ?? first.text
+}
+
+/** Parse a JSON tool response after asserting its MCP content shape. */
+function getJson(result: Awaited<ReturnType<Client['callTool']>>, operationId: string): JsonObject {
+  const text = getText(result, operationId)
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch (error) {
+    throw new Error(`${operationId} returned non-JSON content: ${text}`, { cause: error })
+  }
+  expect(parsed, `${operationId} returned a non-object JSON payload`).toEqual(expect.any(Object))
+  return parsed as JsonObject
+}
+
+describe('Task 2: current Godot engine compatibility - live', () => {
+  let client: Client
+  let cleanup = () => {}
+  let godotAvailable = false
+  let godotUnavailableReason = ''
+
+  beforeAll(async () => {
+    const fixture = createTmpProject()
+    cleanup = fixture.cleanup
+    createTmpScene(fixture.projectPath, 'scenes/main.tscn')
+    createTmpScript(fixture.projectPath, 'scripts/player.gd', 'extends Node\n')
+    createTmpScript(
+      fixture.projectPath,
+      'resources/theme.tres',
+      '[gd_resource type="Theme" format=3]\n\n[resource]\ndefault_font_size = 16\n',
+    )
+
+    const transport = new StdioClientTransport({
+      command: 'node',
+      args: ['bin/cli.mjs', '--stdio'],
+      cwd: process.cwd(),
+      env: { ...process.env, MCP_TRANSPORT: 'stdio' } as Record<string, string>,
+    })
+    client = new Client({ name: 'task2-engine-compat', version: '1.0.0' })
+    await client.connect(transport)
+
+    const detection = await client.callTool({
+      name: 'config',
+      arguments: { action: 'detect_godot' },
+    })
+    const detectionPayload = getJson(detection, 'config.detect_godot')
+    expect(detectionPayload).toHaveProperty('found')
+
+    if (detectionPayload.found === true) {
+      godotAvailable = true
+      expect(detectionPayload).toHaveProperty('path')
+      expect(detectionPayload).toHaveProperty('version')
+    } else {
+      const suggestions = detectionPayload.suggestions
+      godotUnavailableReason = `Godot executable not found; skipped real-engine project.version compatibility check (suggestions: ${JSON.stringify(suggestions)})`
+    }
+
+    const setProject = await client.callTool({
+      name: 'config',
+      arguments: { action: 'set', key: 'project_path', value: fixture.projectPath },
+    })
+    getText(setProject, 'config.set(project_path)')
+  }, 30_000)
+
+  afterAll(async () => {
+    await client?.close()
+    cleanup()
+  })
+
+  it('initializes the built CLI and lists the current 17-tool surface', async () => {
+    expect(client.getServerVersion()?.name).toBe('better-godot-mcp')
+    expect(client.getServerCapabilities()).toBeDefined()
+
+    const result = await client.listTools()
+    const names = result.tools.map((tool) => tool.name)
+
+    expect(result.tools).toHaveLength(17)
+    expect(names).toEqual(expect.arrayContaining(['project', 'scenes', 'nodes', 'scripts', 'resources', 'config']))
+    for (const tool of result.tools) {
+      expect(tool.name.length, 'tools/list returned a tool without a name').toBeGreaterThan(0)
+      expect(tool.inputSchema, `tool ${tool.name} is missing inputSchema`).toBeDefined()
+    }
+  })
+
+  it.each(COMPATIBILITY_OPERATIONS)('$id returns a usable live MCP result', async (operation, context) => {
+    if (operation.requiresGodot && !godotAvailable) {
+      context.skip(godotUnavailableReason)
+      return
+    }
+
+    const result = await client.callTool(operation.request)
+    if (operation.expectedText) {
+      const text = getText(result, operation.id)
+      expect(text).toMatch(operation.expectedText)
+      return
+    }
+
+    const payload = getJson(result, operation.id)
+    for (const key of operation.jsonKeys ?? []) {
+      expect(payload, `${operation.id} payload missing ${key}`).toHaveProperty(key)
+    }
+
+    if (operation.arrayField) {
+      const collection = payload[operation.arrayField]
+      expect(Array.isArray(collection), `${operation.id}.${operation.arrayField} is not an array`).toBe(true)
+      const values = collection as unknown[]
+      if (operation.arrayMinLength !== undefined) {
+        expect(values.length, `${operation.id}.${operation.arrayField} is empty`).toBeGreaterThanOrEqual(
+          operation.arrayMinLength,
+        )
+      }
+      if (operation.arrayIncludes !== undefined) {
+        expect(values, `${operation.id}.${operation.arrayField} missed fixture entry`).toContain(
+          operation.arrayIncludes,
+        )
+      }
+      if (operation.arrayObjectPath !== undefined) {
+        expect(values, `${operation.id}.${operation.arrayField} missed fixture entry`).toEqual(
+          expect.arrayContaining([expect.objectContaining({ path: operation.arrayObjectPath })]),
+        )
+      }
+    }
+  })
+})

--- a/tests/registry-coverage.test.ts
+++ b/tests/registry-coverage.test.ts
@@ -7,7 +7,28 @@ import type { GodotConfig } from '../src/godot/types.js'
 import { makeConfig } from './fixtures.js'
 
 // Mock all tool handlers
-vi.mock('../src/tools/composite/help.js', () => ({ handleHelp: vi.fn() }))
+vi.mock('../src/tools/composite/help.js', () => ({
+  VALID_HELP_TOPICS: [
+    'animation',
+    'audio',
+    'editor',
+    'input_map',
+    'navigation',
+    'nodes',
+    'physics',
+    'project',
+    'resources',
+    'scenes',
+    'scripts',
+    'shader',
+    'signals',
+    'tilemap',
+    'ui',
+    'config',
+    'overview',
+  ],
+  handleHelp: vi.fn(),
+}))
 vi.mock('../src/tools/composite/project.js', () => ({
   handleProject: vi.fn(() => ({ content: [{ type: 'text', text: 'project result' }] })),
 }))
@@ -79,12 +100,12 @@ describe('registerTools coverage', () => {
     expect(result.content[0].text).toContain("Did you mean 'project'?")
   })
 
-  it('should route help tool with tool_name if action is missing', async () => {
+  it('should route help tool with topic if action is missing', async () => {
     const { handleHelp } = await import('../src/tools/composite/help.js')
     await callToolHandler?.({
-      params: { name: 'help', arguments: { tool_name: 'project' } },
+      params: { name: 'help', arguments: { topic: 'project' } },
     })
-    expect(handleHelp).toHaveBeenCalledWith('project', expect.anything())
+    expect(handleHelp).toHaveBeenCalledWith('project')
   })
 
   it('should handle errors thrown by handleHelp', async () => {
@@ -92,7 +113,7 @@ describe('registerTools coverage', () => {
     vi.mocked(handleHelp).mockRejectedValueOnce(new Error('help error'))
 
     const result = (await callToolHandler?.({
-      params: { name: 'help', arguments: { action: 'info' } },
+      params: { name: 'help', arguments: { topic: 'config' } },
     })) as { isError: boolean; content: Array<{ text: string }> }
 
     expect(result.isError).toBe(true)

--- a/tests/registry-handler.test.ts
+++ b/tests/registry-handler.test.ts
@@ -26,6 +26,25 @@ vi.mock('../src/tools/composite/config.js', () => ({
   handleConfig: vi.fn(() => ({ content: [{ type: 'text', text: 'config result' }] })),
 }))
 vi.mock('../src/tools/composite/help.js', () => ({
+  VALID_HELP_TOPICS: [
+    'animation',
+    'audio',
+    'editor',
+    'input_map',
+    'navigation',
+    'nodes',
+    'physics',
+    'project',
+    'resources',
+    'scenes',
+    'scripts',
+    'shader',
+    'signals',
+    'tilemap',
+    'ui',
+    'config',
+    'overview',
+  ],
   handleHelp: vi.fn(() => ({ content: [{ type: 'text', text: 'help result' }] })),
 }))
 vi.mock('../src/tools/composite/resources.js', () => ({
@@ -147,9 +166,9 @@ describe('registerTools handler routing', () => {
     })
   }
 
-  it('should route help tool with tool_name argument', async () => {
+  it('should route help tool with topic argument', async () => {
     const result = await callToolHandler?.({
-      params: { name: 'help', arguments: { tool_name: 'project' } },
+      params: { name: 'help', arguments: { topic: 'project' } },
     })
     expect(result).toBeDefined()
   })
@@ -215,7 +234,7 @@ describe('registerTools handler routing', () => {
 
     it('should NOT include structuredContent for help', async () => {
       const result = (await callToolHandler?.({
-        params: { name: 'help', arguments: { tool_name: 'project' } },
+        params: { name: 'help', arguments: { topic: 'project' } },
       })) as { structuredContent?: Record<string, unknown> }
 
       expect(result.structuredContent).toBeUndefined()

--- a/tests/registry-security.test.ts
+++ b/tests/registry-security.test.ts
@@ -10,6 +10,25 @@ vi.mock('../src/tools/composite/config.js', () => ({
   handleConfig: vi.fn(() => ({ content: [{ type: 'text', text: 'config content' }] })),
 }))
 vi.mock('../src/tools/composite/help.js', () => ({
+  VALID_HELP_TOPICS: [
+    'animation',
+    'audio',
+    'editor',
+    'input_map',
+    'navigation',
+    'nodes',
+    'physics',
+    'project',
+    'resources',
+    'scenes',
+    'scripts',
+    'shader',
+    'signals',
+    'tilemap',
+    'ui',
+    'config',
+    'overview',
+  ],
   handleHelp: vi.fn(() => ({ content: [{ type: 'text', text: 'help content' }] })),
 }))
 vi.mock('../src/tools/composite/project.js', () => ({
@@ -98,7 +117,7 @@ describe('registerTools security integration', () => {
 
   it('should NOT wrap results for help tool', async () => {
     const result = (await callToolHandler?.({
-      params: { name: 'help', arguments: { tool_name: 'scripts' } },
+      params: { name: 'help', arguments: { topic: 'scripts' } },
     })) as { content: Array<{ text: string }> }
 
     expect(result.content[0].text).toBe('help content')

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -67,16 +67,17 @@ describe('registry', () => {
       expect(registrySource).toContain('openWorldHint: false')
     })
 
-    it('all tools should have inputSchema with required action', () => {
+    it('all tools should have inputSchema with the correct required fields', () => {
       const inputSchemaCount = (registrySource.match(/inputSchema:\s*\{/g) || []).length
       expect(inputSchemaCount).toBe(EXPECTED_TOOLS.length)
 
-      // help tool requires 'tool_name' instead of 'action'
+      // help has an optional topic; all other tools require action
       const requiredActionCount = (registrySource.match(/required:\s*\['action']/g) || []).length
-      expect(requiredActionCount).toBe(EXPECTED_TOOLS.length - 1) // 17 minus help (uses 'tool_name')
+      expect(requiredActionCount).toBe(EXPECTED_TOOLS.length - 1)
 
-      // help uses 'tool_name' as required
-      expect(registrySource).toContain("required: ['tool_name']")
+      expect(registrySource).toContain('topic:')
+      expect(registrySource).not.toContain('tool_name')
+      expect(registrySource).not.toContain("required: ['topic']")
     })
   })
 
@@ -146,16 +147,9 @@ describe('registry', () => {
   // Schema correctness
   // ==========================================
   describe('schema correctness', () => {
-    it('help tool should list all other tool names in its enum', () => {
-      // Extract the help tool's tool_name enum
-      const helpSection = registrySource.slice(
-        registrySource.indexOf("name: 'help'"),
-        registrySource.indexOf('},\n]', registrySource.indexOf("name: 'help'")),
-      )
-
-      for (const tool of EXPECTED_TOOLS) {
-        expect(helpSection).toContain(`'${tool}'`)
-      }
+    it('help tool should expose the shared optional topic enum', () => {
+      expect(registrySource).toContain('enum: [...VALID_HELP_TOPICS]')
+      expect(registrySource).toContain('import { handleHelp, VALID_HELP_TOPICS }')
     })
 
     it('read-only tools should have readOnlyHint=true', () => {

--- a/tests/test-live-mcp.mjs
+++ b/tests/test-live-mcp.mjs
@@ -11,9 +11,9 @@
  * No env vars required. Godot detection is optional — all tests are offline.
  */
 
+import { fileURLToPath } from 'node:url'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
-import { fileURLToPath } from 'node:url'
 
 const TIMEOUT = { timeout: 15000 }
 

--- a/tests/test-live-mcp.mjs
+++ b/tests/test-live-mcp.mjs
@@ -13,6 +13,7 @@
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { fileURLToPath } from 'node:url'
 
 const TIMEOUT = { timeout: 15000 }
 
@@ -44,7 +45,7 @@ const transport = new StdioClientTransport({
   command: 'node',
   args: ['bin/cli.mjs'],
   env: { PATH: process.env.PATH },
-  cwd: import.meta.dirname || process.cwd(),
+  cwd: fileURLToPath(new URL('../', import.meta.url)),
 })
 
 const client = new Client({ name: 'live-test', version: '1.0.0' })
@@ -92,7 +93,7 @@ const helpTopics = ['project', 'scenes', 'nodes', 'scripts', 'resources', 'edito
 
 for (const topic of helpTopics) {
   try {
-    const r = await client.callTool({ name: 'help', arguments: { tool_name: topic } }, undefined, TIMEOUT)
+    const r = await client.callTool({ name: 'help', arguments: { topic } }, undefined, TIMEOUT)
     const t = parse(r)
     if (t.length >= 50) {
       ok(`help(${topic})`, `${t.length} chars`)
@@ -141,7 +142,7 @@ try {
 
 // help with nonexistent tool
 try {
-  const r = await client.callTool({ name: 'help', arguments: { tool_name: 'nonexistent' } }, undefined, TIMEOUT)
+  const r = await client.callTool({ name: 'help', arguments: { topic: 'nonexistent' } }, undefined, TIMEOUT)
   const t = r.content[0].text.toLowerCase()
   if (
     r.isError ||
@@ -248,7 +249,7 @@ const extendedHelpTopics = [
 
 for (const topic of extendedHelpTopics) {
   try {
-    const r = await client.callTool({ name: 'help', arguments: { tool_name: topic } }, undefined, TIMEOUT)
+    const r = await client.callTool({ name: 'help', arguments: { topic } }, undefined, TIMEOUT)
     const t = parse(r)
     if (t.length >= 50) {
       ok(`help(${topic})`, `${t.length} chars`)
@@ -342,7 +343,7 @@ try {
   const r = await client.callTool(
     {
       name: 'help',
-      arguments: { tool_name: '<script>alert(1)</script>' },
+      arguments: { topic: '<script>alert(1)</script>' },
     },
     undefined,
     TIMEOUT,


### PR DESCRIPTION
## Summary\n- validate the supported Godot 4.x engine contract and fail clearly for incompatible versions\n- align the help surface, registry behavior, and live harness imports with the documented MCP contract\n- add the full Task 2 engine-compatibility/live coverage and keep the local suite green\n\n## Verification\n- bun install --frozen-lockfile\n- bun run build\n- bun run check\n- bun run test\n- bunx vitest run --coverage\n- bun run test:live\n- bun run test:full\n- git diff --check origin/main...HEAD\n\nAll listed local checks passed on the branch before opening this PR.