### PR TITLE
feat: add Godot editor plugin companion

### DIFF
--- a/addons/better_godot_mcp/README.md
+++ b/addons/better_godot_mcp/README.md
@@ -1,0 +1,59 @@
+# Better Godot MCP EditorPlugin
+
+This Godot 4 EditorPlugin adds a small dock that calls a local Better Godot MCP server over
+Streamable HTTP. It is a companion for the server package; it does not replace the server.
+
+## Install locally
+
+Copy this directory into a Godot project as:
+
+```text
+res://addons/better_godot_mcp/
+```
+
+Enable **Better Godot MCP** from **Project > Project Settings > Plugins**.
+
+The package is verified against Godot 4.7.1. The server repository supports Godot 4.x with a
+detector minimum of 4.1; the EditorPlugin verification uses Godot 4.7.1 stable.
+
+## Start the local server
+
+Start the server separately from the Godot Editor. No package installation, process launch, or
+network download is performed by the addon.
+
+```sh
+npx @n24q02m/better-godot-mcp@latest --http
+```
+
+For a deterministic local port, use:
+
+```sh
+MCP_TRANSPORT=http PORT=3000 HOST=127.0.0.1 npx @n24q02m/better-godot-mcp@latest --http
+```
+
+The dock defaults to `http://127.0.0.1:3000/mcp`. Update the endpoint if the server is using a
+different local port or path. The current HTTP mode has **no auth** and is intended for trusted
+local or self-hosted use only.
+
+## Use the dock
+
+1. Enter the MCP endpoint and confirm it is a loopback `http://` URL.
+2. Confirm the project path, which is prefilled from the current project.
+3. Select **Connect**.
+4. Select **Project info** or **List scenes** to issue a real MCP `tools/call` request.
+
+Initialization stores the `Mcp-Session-Id` returned by the server. JSON and
+`text/event-stream` responses are decoded; HTTP, MCP, timeout, and malformed-response errors are
+shown in the dock instead of being reported as successful actions.
+
+## Security boundary
+
+The first package is deliberately local-only. It rejects remote hosts, does not store secrets,
+does not spawn a process, and does not download dependencies. A remote/authenticated transport
+requires a separate security design.
+
+## Godot Asset Library
+
+The addon package is structured for an official Godot Asset Library review: it includes
+`plugin.cfg`, an `@tool` `EditorPlugin`, README, and icon. Submission and listing are separate
+public publication steps and are not performed automatically by this repository.

--- a/addons/better_godot_mcp/better_godot_mcp.gd
+++ b/addons/better_godot_mcp/better_godot_mcp.gd
@@ -1,0 +1,17 @@
+@tool
+extends EditorPlugin
+
+const Dock = preload("res://addons/better_godot_mcp/better_godot_mcp_dock.gd")
+
+var dock: Control
+
+func _enter_tree() -> void:
+	dock = Dock.new()
+	dock.name = "BetterGodotMcpDock"
+	add_control_to_dock(DOCK_SLOT_RIGHT_UL, dock)
+
+func _exit_tree() -> void:
+	if is_instance_valid(dock):
+		remove_control_from_docks(dock)
+		dock.queue_free()
+		dock = null

--- a/addons/better_godot_mcp/better_godot_mcp_dock.gd
+++ b/addons/better_godot_mcp/better_godot_mcp_dock.gd
@@ -1,0 +1,293 @@
+@tool
+extends VBoxContainer
+
+const DEFAULT_ENDPOINT := "http://127.0.0.1:3000/mcp"
+const MCP_PROTOCOL_VERSION := "2025-11-25"
+const CLIENT_NAME := "better-godot-mcp-editor"
+const CLIENT_VERSION := "0.1.0"
+const REQUEST_TIMEOUT_SECONDS := 10.0
+
+var endpoint_edit: LineEdit
+var project_path_edit: LineEdit
+var connect_button: Button
+var project_info_button: Button
+var list_scenes_button: Button
+var status_label: Label
+var result_view: TextEdit
+
+var request_id := 0
+var session_id := ""
+var connected := false
+var busy := false
+
+func _ready() -> void:
+	_build_ui()
+
+func _build_ui() -> void:
+	name = "Better Godot MCP"
+	size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
+	var title := Label.new()
+	title.text = "Better Godot MCP"
+	title.add_theme_font_size_override("font_size", 16)
+	add_child(title)
+
+	var description := Label.new()
+	description.text = "Local MCP actions for the current Godot project."
+	description.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	add_child(description)
+
+	var endpoint_label := Label.new()
+	endpoint_label.text = "MCP endpoint"
+	add_child(endpoint_label)
+
+	endpoint_edit = LineEdit.new()
+	endpoint_edit.text = DEFAULT_ENDPOINT
+	endpoint_edit.placeholder_text = DEFAULT_ENDPOINT
+	endpoint_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	add_child(endpoint_edit)
+
+	var project_label := Label.new()
+	project_label.text = "Project path"
+	add_child(project_label)
+
+	project_path_edit = LineEdit.new()
+	project_path_edit.text = ProjectSettings.globalize_path("res://")
+	project_path_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	add_child(project_path_edit)
+
+	connect_button = Button.new()
+	connect_button.text = "Connect"
+	connect_button.pressed.connect(_on_connect_pressed)
+	add_child(connect_button)
+
+	var actions := HBoxContainer.new()
+	add_child(actions)
+
+	project_info_button = Button.new()
+	project_info_button.text = "Project info"
+	project_info_button.disabled = true
+	project_info_button.pressed.connect(_on_project_info_pressed)
+	actions.add_child(project_info_button)
+
+	list_scenes_button = Button.new()
+	list_scenes_button.text = "List scenes"
+	list_scenes_button.disabled = true
+	list_scenes_button.pressed.connect(_on_list_scenes_pressed)
+	actions.add_child(list_scenes_button)
+
+	status_label = Label.new()
+	status_label.text = "Not connected"
+	status_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	add_child(status_label)
+
+	result_view = TextEdit.new()
+	result_view.editable = false
+	result_view.placeholder_text = "MCP results appear here."
+	result_view.custom_minimum_size = Vector2(0, 220)
+	result_view.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	add_child(result_view)
+
+func _on_connect_pressed() -> void:
+	if busy:
+		return
+
+	busy = true
+	connected = false
+	session_id = ""
+	_refresh_action_buttons()
+	_set_status("Connecting...", false)
+
+	var initialize_response: Dictionary = await _mcp_request(
+		"initialize",
+		{
+			"protocolVersion": MCP_PROTOCOL_VERSION,
+			"capabilities": {},
+			"clientInfo": {"name": CLIENT_NAME, "version": CLIENT_VERSION},
+		},
+		true,
+	)
+	if not initialize_response.get("ok", false):
+		_finish_request(str(initialize_response.get("error", "Initialize failed.")), true)
+		return
+
+	var notification_response: Dictionary = await _mcp_request("notifications/initialized", {}, false)
+	if not notification_response.get("ok", false):
+		_finish_request(str(notification_response.get("error", "Initialization notification failed.")), true)
+		return
+
+	connected = true
+	busy = false
+	_refresh_action_buttons()
+	_set_status("Connected to %s" % endpoint_edit.text.strip_edges(), false)
+
+func _on_project_info_pressed() -> void:
+	_call_tool(
+		"project",
+		{"action": "info", "project_path": project_path_edit.text.strip_edges()},
+		"Project info",
+	)
+
+func _on_list_scenes_pressed() -> void:
+	_call_tool(
+		"scenes",
+		{"action": "list", "project_path": project_path_edit.text.strip_edges()},
+		"Scenes",
+	)
+
+func _call_tool(tool_name: String, arguments: Dictionary, label: String) -> void:
+	if busy:
+		return
+	if not connected:
+		_set_status("Connect before calling %s." % label, true)
+		return
+
+	busy = true
+	_refresh_action_buttons()
+	_set_status("Calling %s..." % label, false)
+	var response: Dictionary = await _mcp_request(
+		"tools/call",
+		{"name": tool_name, "arguments": arguments},
+		true,
+	)
+	if not response.get("ok", false):
+		_finish_request(str(response.get("error", "%s failed." % label)), true)
+		return
+
+	busy = false
+	_refresh_action_buttons()
+	_set_status("%s complete" % label, false)
+	result_view.text = _format_tool_result(response.get("payload", {}))
+
+func _mcp_request(method: String, params: Dictionary, expect_response: bool) -> Dictionary:
+	var endpoint := endpoint_edit.text.strip_edges()
+	if not _is_loopback_endpoint(endpoint):
+		return {"ok": false, "error": "Only an http:// loopback endpoint is allowed."}
+
+	var request := HTTPRequest.new()
+	request.timeout = REQUEST_TIMEOUT_SECONDS
+	add_child(request)
+
+	var headers := PackedStringArray([
+		"Content-Type: application/json",
+		"Accept: application/json, text/event-stream",
+		"MCP-Protocol-Version: %s" % MCP_PROTOCOL_VERSION,
+	])
+	if not session_id.is_empty():
+		headers.append("Mcp-Session-Id: %s" % session_id)
+
+	var message: Dictionary = {"jsonrpc": "2.0", "method": method}
+	if expect_response:
+		request_id += 1
+		message["id"] = request_id
+	if not params.is_empty():
+		message["params"] = params
+
+	var request_error := request.request(endpoint, headers, HTTPClient.METHOD_POST, JSON.stringify(message))
+	if request_error != OK:
+		request.queue_free()
+		return {"ok": false, "error": "Could not start HTTP request: %s" % error_string(request_error)}
+
+	var completion: Array = await request.request_completed
+	var result_code: int = completion[0]
+	var response_code: int = completion[1]
+	var response_headers: PackedStringArray = completion[2]
+	var response_body: PackedByteArray = completion[3]
+	var response_session_id := _find_header(response_headers, "mcp-session-id")
+	if not response_session_id.is_empty():
+		session_id = response_session_id
+	request.queue_free()
+
+	if result_code != HTTPRequest.RESULT_SUCCESS:
+		return {"ok": false, "error": "HTTP request failed: %s" % _http_result_name(result_code)}
+	if response_code < 200 or response_code >= 300:
+		return {"ok": false, "error": "HTTP %d from MCP endpoint." % response_code}
+	if not expect_response and response_body.is_empty():
+		return {"ok": true}
+	if response_body.is_empty():
+		return {"ok": false, "error": "MCP endpoint returned an empty response."}
+
+	var payload: Variant = _decode_payload(response_body, response_headers)
+	if payload == null or not (payload is Dictionary):
+		return {"ok": false, "error": "MCP endpoint returned malformed JSON."}
+	var payload_dictionary: Dictionary = payload
+	if payload_dictionary.has("error"):
+		return {"ok": false, "error": "MCP error: %s" % JSON.stringify(payload_dictionary["error"])}
+	return {"ok": true, "payload": payload_dictionary}
+
+func _decode_payload(body: PackedByteArray, headers: PackedStringArray) -> Variant:
+	var text := body.get_string_from_utf8()
+	var content_type := _find_header(headers, "content-type").to_lower()
+	if content_type.contains("text/event-stream"):
+		var event_payload: Variant = null
+		for event in text.split("\n\n"):
+			for line in event.split("\n"):
+				if not line.begins_with("data:"):
+					continue
+				var candidate := line.trim_prefix("data:").strip_edges()
+				if candidate.is_empty() or candidate == "[DONE]":
+					continue
+				var parsed: Variant = JSON.parse_string(candidate)
+				if parsed != null:
+					event_payload = parsed
+		return event_payload
+	return JSON.parse_string(text)
+
+func _format_tool_result(payload: Dictionary) -> String:
+	var result: Variant = payload.get("result", payload)
+	if result is Dictionary:
+		var content: Variant = result.get("content", [])
+		if content is Array:
+			for item in content:
+				if item is Dictionary and item.has("text"):
+					return str(item["text"])
+	return JSON.stringify(payload, "\t")
+
+func _is_loopback_endpoint(endpoint: String) -> bool:
+	var normalized := endpoint.to_lower()
+	if not normalized.begins_with("http://"):
+		return false
+	var authority := normalized.trim_prefix("http://")
+	var slash := authority.find("/")
+	if slash >= 0:
+		authority = authority.substr(0, slash)
+	if authority.begins_with("[::1]"):
+		return true
+	var colon := authority.find(":")
+	var host := authority if colon < 0 else authority.substr(0, colon)
+	return host == "localhost" or host == "127.0.0.1"
+
+func _find_header(headers: PackedStringArray, name: String) -> String:
+	var wanted := name.to_lower()
+	for header in headers:
+		var separator := header.find(":")
+		if separator < 0:
+			continue
+		if header.substr(0, separator).strip_edges().to_lower() == wanted:
+			return header.substr(separator + 1).strip_edges()
+	return ""
+
+func _http_result_name(result_code: int) -> String:
+	return {
+		HTTPRequest.RESULT_CANT_CONNECT: "cannot connect",
+		HTTPRequest.RESULT_CANT_RESOLVE: "cannot resolve host",
+		HTTPRequest.RESULT_CONNECTION_ERROR: "connection error",
+		HTTPRequest.RESULT_TIMEOUT: "timeout",
+	}.get(result_code, "error code %d" % result_code)
+
+func _finish_request(message: String, is_error: bool) -> void:
+	busy = false
+	connected = false
+	_refresh_action_buttons()
+	_set_status(message, is_error)
+
+func _refresh_action_buttons() -> void:
+	if connect_button == null:
+		return
+	connect_button.disabled = busy
+	project_info_button.disabled = busy or not connected
+	list_scenes_button.disabled = busy or not connected
+
+func _set_status(message: String, is_error: bool) -> void:
+	status_label.text = message
+	status_label.modulate = Color(1.0, 0.45, 0.45) if is_error else Color(0.75, 0.9, 1.0)

--- a/addons/better_godot_mcp/better_godot_mcp_dock.gd
+++ b/addons/better_godot_mcp/better_godot_mcp_dock.gd
@@ -251,11 +251,28 @@ func _is_loopback_endpoint(endpoint: String) -> bool:
 	var slash := authority.find("/")
 	if slash >= 0:
 		authority = authority.substr(0, slash)
+	if authority.is_empty() or authority.contains("@") or authority.contains("\\"):
+		return false
 	if authority.begins_with("[::1]"):
-		return true
+		return _is_valid_port_suffix(authority.substr(5))
 	var colon := authority.find(":")
+	if colon >= 0 and authority.find(":", colon + 1) >= 0:
+		return false
+	if colon >= 0 and not _is_valid_port(authority.substr(colon + 1)):
+		return false
 	var host := authority if colon < 0 else authority.substr(0, colon)
 	return host == "localhost" or host == "127.0.0.1"
+
+func _is_valid_port_suffix(suffix: String) -> bool:
+	if suffix.is_empty():
+		return true
+	return suffix.begins_with(":") and _is_valid_port(suffix.substr(1))
+
+func _is_valid_port(port: String) -> bool:
+	if port.is_empty() or port != port.strip_edges() or not port.is_valid_int():
+		return false
+	var value := port.to_int()
+	return value > 0 and value <= 65535
 
 func _find_header(headers: PackedStringArray, name: String) -> String:
 	var wanted := name.to_lower()

--- a/addons/better_godot_mcp/icon.svg
+++ b/addons/better_godot_mcp/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect x="8" y="8" width="112" height="112" rx="20" fill="#478cbf"/>
+  <path d="M32 40h64v48H32z" fill="#f4f7fb"/>
+  <path d="M40 52h16v8H40zm32 0h16v8H72zM40 68h48v8H40z" fill="#203040"/>
+  <path d="M48 92h32" stroke="#f4f7fb" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/addons/better_godot_mcp/plugin.cfg
+++ b/addons/better_godot_mcp/plugin.cfg
@@ -1,0 +1,8 @@
+[plugin]
+
+name="Better Godot MCP"
+description="Connects the Godot editor to a local Better Godot MCP server over Streamable HTTP."
+author="n24q02m"
+version="0.1.0"
+script="better_godot_mcp.gd"
+icon="icon.svg"

--- a/tests/godot/editor-plugin-package.test.ts
+++ b/tests/godot/editor-plugin-package.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const addonDir = resolve(process.cwd(), 'addons/better_godot_mcp')
+
+function readAddonFile(name: string): string {
+  return readFileSync(resolve(addonDir, name), 'utf8')
+}
+
+describe('Godot EditorPlugin package', () => {
+  it('contains the minimum official plugin package surface', () => {
+    const manifest = readAddonFile('plugin.cfg')
+
+    expect(manifest).toContain('[plugin]')
+    expect(manifest).toContain('name="Better Godot MCP"')
+    expect(manifest).toContain('script="better_godot_mcp.gd"')
+    expect(manifest).toContain('icon="icon.svg"')
+
+    for (const file of ['better_godot_mcp.gd', 'better_godot_mcp_dock.gd', 'README.md', 'icon.svg']) {
+      expect(() => readAddonFile(file)).not.toThrow()
+    }
+  })
+
+  it('implements a real local MCP client contract in the dock', () => {
+    const dock = readAddonFile('better_godot_mcp_dock.gd')
+
+    expect(dock).toContain('@tool')
+    expect(dock).toContain('initialize')
+    expect(dock).toContain('notifications/initialized')
+    expect(dock).toContain('tools/call')
+    expect(dock).toContain('project')
+    expect(dock).toContain('scenes')
+    expect(dock).toContain('Mcp-Session-Id')
+    expect(dock).toContain('text/event-stream')
+    expect(dock).toContain('127.0.0.1')
+    expect(dock).toContain('MCP error')
+  })
+
+  it('documents the explicit local-server and publication boundaries', () => {
+    const readme = readAddonFile('README.md')
+
+    expect(readme).toContain('127.0.0.1')
+    expect(readme).toContain('npx')
+    expect(readme).toContain('Asset Library')
+    expect(readme).toContain('no auth')
+    expect(readme).toContain('Godot 4.7.1')
+  })
+})

--- a/tests/godot/editor-plugin-package.test.ts
+++ b/tests/godot/editor-plugin-package.test.ts
@@ -35,6 +35,8 @@ describe('Godot EditorPlugin package', () => {
     expect(dock).toContain('text/event-stream')
     expect(dock).toContain('127.0.0.1')
     expect(dock).toContain('MCP error')
+    expect(dock).toContain('authority.contains("@")')
+    expect(dock).toContain('_is_valid_port')
   })
 
   it('documents the explicit local-server and publication boundaries', () => {

--- a/tests/godot/fixtures/editor-plugin-project/project.godot
+++ b/tests/godot/fixtures/editor-plugin-project/project.godot
@@ -1,0 +1,17 @@
+; Engine configuration file.
+; Generated for the Better Godot MCP EditorPlugin headless load test.
+
+config_version=5
+
+[application]
+
+config/name="Better Godot MCP EditorPlugin Fixture"
+
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/better_godot_mcp/plugin.cfg")
+
+[rendering]
+
+renderer/rendering_method="gl_compatibility"
+renderer/rendering_method.mobile="gl_compatibility"

--- a/tests/live/editor-plugin-http.live.test.ts
+++ b/tests/live/editor-plugin-http.live.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Live contract test for the Godot EditorPlugin's Streamable HTTP client.
+ *
+ * The server is the built package, not a mocked handler. The request sequence
+ * mirrors the GDScript dock: initialize, initialized notification, then the
+ * project/info and scenes/list tool calls with the issued session header.
+ */
+
+import { type ChildProcess, spawn } from 'node:child_process'
+import { resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+const MCP_PROTOCOL_VERSION = '2025-11-25'
+const FIXTURE_PROJECT = resolve('tests/godot/fixtures/editor-plugin-project')
+
+type JsonObject = Record<string, unknown>
+
+let serverProcess: ChildProcess | undefined
+let endpoint = ''
+let sessionId = ''
+let requestId = 0
+
+function parseMcpPayload(body: string): JsonObject {
+  const eventData = body
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith('data:'))
+    .map((line) => line.slice('data:'.length).trim())
+    .filter((line) => line.length > 0 && line !== '[DONE]')
+    .at(-1)
+
+  return JSON.parse(eventData ?? body) as JsonObject
+}
+
+function stopProcess(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null) return Promise.resolve()
+
+  return new Promise((resolveStop) => {
+    const timer = setTimeout(() => {
+      if (child.exitCode === null) child.kill('SIGKILL')
+      resolveStop()
+    }, 5_000)
+    child.once('exit', () => {
+      clearTimeout(timer)
+      resolveStop()
+    })
+    child.kill('SIGTERM')
+  })
+}
+
+async function startServer(): Promise<void> {
+  const output: string[] = []
+  const child = spawn(process.execPath, ['bin/cli.mjs', '--http'], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      HOST: '127.0.0.1',
+      MCP_TRANSPORT: 'http',
+      NODE_ENV: 'test',
+      PORT: '0',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  serverProcess = child
+
+  await new Promise<void>((resolveReady, rejectReady) => {
+    const timeout = setTimeout(() => {
+      rejectReady(new Error(`HTTP server did not become ready. Output:\n${output.join('')}`))
+    }, 30_000)
+
+    const onData = (chunk: Buffer | string) => {
+      const text = chunk.toString()
+      output.push(text)
+      const match = output.join('').match(/on http:\/\/127\.0\.0\.1:(\d+)\/mcp/)
+      if (!match) return
+      clearTimeout(timeout)
+      endpoint = `http://127.0.0.1:${match[1]}/mcp`
+      resolveReady()
+    }
+
+    child.stdout?.on('data', onData)
+    child.stderr?.on('data', onData)
+    child.once('error', (error) => {
+      clearTimeout(timeout)
+      rejectReady(error)
+    })
+    child.once('exit', (code) => {
+      if (endpoint) return
+      clearTimeout(timeout)
+      rejectReady(new Error(`HTTP server exited before ready with code ${code}. Output:\n${output.join('')}`))
+    })
+  })
+}
+
+async function postMcp(method: string, params: JsonObject, withResponse = true) {
+  const body: JsonObject = { jsonrpc: '2.0', method }
+  if (withResponse) {
+    requestId += 1
+    body.id = requestId
+  }
+  if (Object.keys(params).length > 0) body.params = params
+
+  const headers: Record<string, string> = {
+    Accept: 'application/json, text/event-stream',
+    'Content-Type': 'application/json',
+    'MCP-Protocol-Version': MCP_PROTOCOL_VERSION,
+  }
+  if (sessionId) headers['Mcp-Session-Id'] = sessionId
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  })
+  const text = await response.text()
+  const responseSessionId = response.headers.get('mcp-session-id')
+  if (responseSessionId) sessionId = responseSessionId
+
+  return {
+    payload: text.trim().length > 0 ? parseMcpPayload(text) : null,
+    response,
+    text,
+  }
+}
+
+describe('Godot EditorPlugin live HTTP contract', () => {
+  beforeAll(async () => {
+    await startServer()
+
+    const initialized = await postMcp('initialize', {
+      capabilities: {},
+      clientInfo: { name: 'better-godot-mcp-editor-test', version: '0.1.0' },
+      protocolVersion: MCP_PROTOCOL_VERSION,
+    })
+    expect(initialized.response.status).toBe(200)
+    expect(sessionId).not.toBe('')
+    expect(initialized.payload?.result).toBeDefined()
+
+    const notification = await postMcp('notifications/initialized', {}, false)
+    expect([200, 202, 204]).toContain(notification.response.status)
+  }, 30_000)
+
+  afterAll(async () => {
+    if (serverProcess) await stopProcess(serverProcess)
+  })
+
+  it('calls project/info and scenes/list through the built server', async () => {
+    const project = await postMcp('tools/call', {
+      arguments: { action: 'info', project_path: FIXTURE_PROJECT },
+      name: 'project',
+    })
+    expect(project.response.status).toBe(200)
+    expect(project.payload?.result).toBeDefined()
+    expect(JSON.stringify(project.payload)).toContain('Better Godot MCP EditorPlugin Fixture')
+
+    const scenes = await postMcp('tools/call', {
+      arguments: { action: 'list', project_path: FIXTURE_PROJECT },
+      name: 'scenes',
+    })
+    expect(scenes.response.status).toBe(200)
+    expect(scenes.payload?.result).toBeDefined()
+    expect(JSON.stringify(scenes.payload)).toContain('scenes')
+  })
+
+  it('rejects a request without a session and an unknown session', async () => {
+    const noSession = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        'MCP-Protocol-Version': MCP_PROTOCOL_VERSION,
+      },
+      body: JSON.stringify({ id: 99, jsonrpc: '2.0', method: 'tools/list' }),
+    })
+    expect(noSession.status).toBe(400)
+    expect(await noSession.text()).toContain('no valid session ID')
+
+    const unknownSession = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        'MCP-Protocol-Version': MCP_PROTOCOL_VERSION,
+        'Mcp-Session-Id': 'editor-plugin-missing-session',
+      },
+      body: JSON.stringify({ id: 100, jsonrpc: '2.0', method: 'tools/list' }),
+    })
+    expect(unknownSession.status).toBe(404)
+    expect(await unknownSession.text()).toContain('Session not found')
+  })
+})

--- a/tests/live/full-godot.full.test.ts
+++ b/tests/live/full-godot.full.test.ts
@@ -62,11 +62,11 @@ describe('P0: project tool', () => {
     cleanup = tmp.cleanup
     const setup = await setupClient('full-test-project', projectPath)
     client = setup.client
-  }, 15_000)
+  }, 30_000)
 
   afterAll(async () => {
-    await client.close()
-    cleanup()
+    await client?.close()
+    cleanup?.()
   })
 
   it('info returns project metadata', async () => {
@@ -141,11 +141,11 @@ describe('P0: scenes tool', () => {
     cleanup = tmp.cleanup
     const setup = await setupClient('full-test-scenes', projectPath)
     client = setup.client
-  }, 15_000)
+  }, 30_000)
 
   afterAll(async () => {
-    await client.close()
-    cleanup()
+    await client?.close()
+    cleanup?.()
   })
 
   it('create -> list -> info -> duplicate -> set_main -> delete', async () => {
@@ -234,11 +234,11 @@ describe('P0: nodes tool', () => {
     createTmpScene(projectPath, 'scenes/test.tscn')
     const setup = await setupClient('full-test-nodes', projectPath)
     client = setup.client
-  }, 15_000)
+  }, 30_000)
 
   afterAll(async () => {
-    await client.close()
-    cleanup()
+    await client?.close()
+    cleanup?.()
   })
 
   it('add -> list -> rename -> set_property -> get_property -> remove', async () => {
@@ -334,11 +334,11 @@ describe('P0: scripts tool', () => {
     createTmpScene(projectPath, 'scenes/main.tscn')
     const setup = await setupClient('full-test-scripts', projectPath)
     client = setup.client
-  }, 15_000)
+  }, 30_000)
 
   afterAll(async () => {
-    await client.close()
-    cleanup()
+    await client?.close()
+    cleanup?.()
   })
 
   it('create -> list -> read -> write -> attach -> delete', async () => {
@@ -415,10 +415,10 @@ describe('P0: editor tool', () => {
     })
     client = new Client({ name: 'full-test-editor', version: '1.0.0' })
     await client.connect(transport)
-  }, 15_000)
+  }, 30_000)
 
   afterAll(async () => {
-    await client.close()
+    await client?.close()
   })
 
   it('status returns process info', async () => {
@@ -445,10 +445,10 @@ describe('P0: config tool (detect_godot + check)', () => {
     })
     client = new Client({ name: 'full-test-config-setup', version: '1.0.0' })
     await client.connect(transport)
-  }, 15_000)
+  }, 30_000)
 
   afterAll(async () => {
-    await client.close()
+    await client?.close()
   })
 
   it('detect_godot returns structured detection result', async () => {
@@ -466,7 +466,7 @@ describe('P0: config tool (detect_godot + check)', () => {
     } else {
       expect(json).toHaveProperty('suggestions')
     }
-  })
+  }, 30_000)
 
   it('check returns structured check result', async () => {
     const result = await client.callTool({
@@ -492,10 +492,10 @@ describe('P0: config tool', () => {
     })
     client = new Client({ name: 'full-test-config', version: '1.0.0' })
     await client.connect(transport)
-  }, 15_000)
+  }, 30_000)
 
   afterAll(async () => {
-    await client.close()
+    await client?.close()
   })
 
   it('status returns server configuration', async () => {
@@ -535,11 +535,11 @@ describe('P1: resources tool', () => {
     )
     const setup = await setupClient('full-test-resources', projectPath)
     client = setup.client
-  }, 15_000)
+  }, 30_000)
 
   afterAll(async () => {
-    await client.close()
-    cleanup()
+    await client?.close()
+    cleanup?.()
   })
 
   it('list returns resource files', async () => {
@@ -602,11 +602,11 @@ describe('P1: input_map tool', () => {
     cleanup = tmp.cleanup
     const setup = await setupClient('full-test-input-map', projectPath)
     client = setup.client
-  }, 15_000)
+  }, 30_000)
 
   afterAll(async () => {
-    await client.close()
-    cleanup()
+    await client?.close()
+    cleanup?.()
   })
 
   it('list returns existing input actions', async () => {
@@ -679,11 +679,11 @@ describe('P1: signals tool', () => {
     createTmpScene(projectPath, 'scenes/signals_test.tscn', COMPLEX_TSCN)
     const setup = await setupClient('full-test-signals', projectPath)
     client = setup.client
-  }, 15_000)
+  }, 30_000)
 
   afterAll(async () => {
-    await client.close()
-    cleanup()
+    await client?.close()
+    cleanup?.()
   })
 
   it('list returns existing connections', async () => {
@@ -756,11 +756,11 @@ describe('P2: animation tool', () => {
     createTmpScene(projectPath, 'scenes/anim_test.tscn')
     const setup = await setupClient('full-test-animation', projectPath)
     client = setup.client
-  }, 15_000)
+  }, 30_000)
 
   afterAll(async () => {
-    await client.close()
-    cleanup()
+    await client?.close()
+    cleanup?.()
   })
 
   it('create_player adds AnimationPlayer node', async () => {
@@ -844,11 +844,11 @@ describe('P2: shader tool', () => {
     cleanup = tmp.cleanup
     const setup = await setupClient('full-test-shader', projectPath)
     client = setup.client
-  }, 15_000)
+  }, 30_000)
 
   afterAll(async () => {
-    await client.close()
-    cleanup()
+    await client?.close()
+    cleanup?.()
   })
 
   it('create -> read -> write -> get_params -> list', async () => {
@@ -922,11 +922,11 @@ describe('P2: tilemap tool', () => {
     createTmpScene(projectPath, 'scenes/tilemap_test.tscn')
     const setup = await setupClient('full-test-tilemap', projectPath)
     client = setup.client
-  }, 15_000)
+  }, 30_000)
 
   afterAll(async () => {
-    await client.close()
-    cleanup()
+    await client?.close()
+    cleanup?.()
   })
 
   it('create_tileset creates a .tres tileset resource', async () => {
@@ -966,11 +966,11 @@ describe('P2: physics tool', () => {
     createTmpScene(projectPath, 'scenes/physics_test.tscn', COMPLEX_TSCN)
     const setup = await setupClient('full-test-physics', projectPath)
     client = setup.client
-  }, 15_000)
+  }, 30_000)
 
   afterAll(async () => {
-    await client.close()
-    cleanup()
+    await client?.close()
+    cleanup?.()
   })
 
   it('layers returns physics layer names', async () => {
@@ -1045,11 +1045,11 @@ describe('P3: audio tool', () => {
     cleanup = tmp.cleanup
     const setup = await setupClient('full-test-audio', projectPath)
     client = setup.client
-  }, 15_000)
+  }, 30_000)
 
   afterAll(async () => {
-    await client.close()
-    cleanup()
+    await client?.close()
+    cleanup?.()
   })
 
   it('list_buses returns bus layout', async () => {
@@ -1098,11 +1098,11 @@ describe('P3: navigation tool', () => {
     createTmpScene(projectPath, 'scenes/nav_test.tscn')
     const setup = await setupClient('full-test-navigation', projectPath)
     client = setup.client
-  }, 15_000)
+  }, 30_000)
 
   afterAll(async () => {
-    await client.close()
-    cleanup()
+    await client?.close()
+    cleanup?.()
   })
 
   it('create_region adds a NavigationRegion node', async () => {
@@ -1133,11 +1133,11 @@ describe('P3: ui tool', () => {
     createTmpScene(projectPath, 'scenes/ui_test.tscn')
     const setup = await setupClient('full-test-ui', projectPath)
     client = setup.client
-  }, 15_000)
+  }, 30_000)
 
   afterAll(async () => {
-    await client.close()
-    cleanup()
+    await client?.close()
+    cleanup?.()
   })
 
   it('create_control adds a UI control node', async () => {

--- a/tests/live/stdio-direct.live.test.ts
+++ b/tests/live/stdio-direct.live.test.ts
@@ -11,7 +11,7 @@ import { spawn } from 'node:child_process'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const CLI_PATH = resolve(__dirname, '..', 'bin', 'cli.mjs')
+const CLI_PATH = resolve(process.cwd(), 'bin', 'cli.mjs')
 
 interface JsonRpcResponse {
   jsonrpc: '2.0'

--- a/vitest.full.config.ts
+++ b/vitest.full.config.ts
@@ -4,5 +4,8 @@ export default defineConfig({
   test: {
     include: ['tests/live/*.full.test.ts'],
     exclude: ['build/**', 'node_modules/**', 'bin/**'],
+    // Each suite launches a real Godot-backed MCP process; parallel suites
+    // exhaust the Windows process/startup budget and trip the 15s hook guard.
+    maxWorkers: 1,
   },
 })

--- a/vitest.live.config.ts
+++ b/vitest.live.config.ts
@@ -2,8 +2,9 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: ['tests/live/mcp-protocol.live.test.ts'],
+    include: ['tests/live/*.live.test.ts'],
     exclude: ['build/**', 'node_modules/**', 'bin/**'],
+    maxWorkers: 1,
     testTimeout: 30000,
   },
 })


### PR DESCRIPTION
Adds a local-only Godot 4 EditorPlugin companion with a real Streamable HTTP MCP dock, package contract tests, Godot 4.7.1 headless load coverage, and live built-server HTTP coverage. Also makes the existing full/live Godot harness deterministic on Windows by running real-process suites sequentially and fixes the stdio test path. Verified: bun run test; bun run test:full; bun run test:live; bun run check; Godot 4.7.1 headless editor load. Official Godot Asset Library submission/listing remains a separate public gate.