### PR TITLE
feat: prepare Godot Asset Store package export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -42,10 +42,3 @@ bun.lock text eol=lf -diff linguist-generated
 *.png binary
 *.jpg binary
 *.ico binary
-
-# Godot Asset Store archives contain only the self-contained addon. The package command also
-# selects this path explicitly so a full-repository archive cannot leak server or CI files.
-/** export-ignore
-/addons !export-ignore
-/addons/better_godot_mcp !export-ignore
-/addons/better_godot_mcp/** !export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -42,3 +42,10 @@ bun.lock text eol=lf -diff linguist-generated
 *.png binary
 *.jpg binary
 *.ico binary
+
+# Godot Asset Store archives contain only the self-contained addon. The package command also
+# selects this path explicitly so a full-repository archive cannot leak server or CI files.
+/** export-ignore
+/addons !export-ignore
+/addons/better_godot_mcp !export-ignore
+/addons/better_godot_mcp/** !export-ignore

--- a/addons/better_godot_mcp/README.md
+++ b/addons/better_godot_mcp/README.md
@@ -52,9 +52,22 @@ The first package is deliberately local-only. It rejects remote hosts, does not 
 does not spawn a process, and does not download dependencies. A remote/authenticated transport
 requires a separate security design.
 
-## Godot Asset Library
+## Godot Asset Store
 
-The addon package is structured for an official Godot Asset Library review: it includes
+The addon package is structured for the current official Godot Asset Store: it includes
 `plugin.cfg`, an `@tool` `EditorPlugin`, this README, a copied `LICENSE`, and the square 128x128
-`icon.png` submission icon. Submission and listing are separate public publication steps and are
-not performed automatically by this repository.
+`icon.png` submission icon. After committing the source, create the deterministic upload archive
+with:
+
+```sh
+bun run package:godot-asset-store
+```
+
+The generated ZIP contains only `addons/better_godot_mcp/`; it does not contain the MCP server
+source, lockfiles, CI configuration, or repository metadata. The Asset Store form still requires
+the owner to provide publisher/asset slug, type, supported Godot range, description, license,
+media and AI-usage disclosure, then accept terms and submit for manual review. Upload and listing
+are not performed automatically by this repository.
+
+The former Godot Asset Library is a separate legacy surface and is not a substitute for the
+current Asset Store listing.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint": "biome check .",
     "format": "biome format --write .",
     "check": "biome check . && tsc --noEmit",
+    "package:godot-asset-store": "node scripts/build-godot-asset-store-package.mjs",
     "test:full": "bun run build && vitest run --config vitest.full.config.ts",
     "test:live": "bun run build && vitest run --config vitest.live.config.ts",
     "check:fix": "biome check --fix .",

--- a/scripts/build-godot-asset-store-package.mjs
+++ b/scripts/build-godot-asset-store-package.mjs
@@ -67,19 +67,10 @@ function readAddonVersion() {
 
 function buildArchive(outputPath) {
   mkdirSync(dirname(outputPath), { recursive: true })
-  execFileSync(
-    'git',
-    [
-      'archive',
-      '--format=zip',
-      '--worktree-attributes',
-      '--output',
-      outputPath,
-      'HEAD',
-      addonPath,
-    ],
-    { cwd: repoRoot, stdio: 'pipe' },
-  )
+  execFileSync('git', ['archive', '--format=zip', '--worktree-attributes', '--output', outputPath, 'HEAD', addonPath], {
+    cwd: repoRoot,
+    stdio: 'pipe',
+  })
 
   if (!existsSync(outputPath) || statSync(outputPath).size === 0) {
     throw new Error(`Git produced no archive at ${outputPath}`)

--- a/scripts/build-godot-asset-store-package.mjs
+++ b/scripts/build-godot-asset-store-package.mjs
@@ -1,0 +1,95 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, lstatSync, mkdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(scriptDir, '..')
+const addonPath = 'addons/better_godot_mcp'
+const requiredFiles = [
+  'plugin.cfg',
+  'better_godot_mcp.gd',
+  'better_godot_mcp_dock.gd',
+  'README.md',
+  'LICENSE',
+  'icon.png',
+]
+
+function parseOutputPath(args, version) {
+  const outputIndex = args.indexOf('--output')
+
+  if (outputIndex >= 0) {
+    const output = args[outputIndex + 1]
+    if (!output || output.startsWith('--')) {
+      throw new Error('--output requires a file path')
+    }
+    return resolve(output)
+  }
+
+  const unexpected = args.filter((arg) => arg !== '--output')
+  if (unexpected.length > 0) {
+    throw new Error(`Unexpected argument: ${unexpected[0]}`)
+  }
+
+  return join(repoRoot, 'dist', 'godot-asset-store', `better-godot-mcp-${version}.zip`)
+}
+
+function assertCleanWorktree() {
+  const status = execFileSync('git', ['status', '--porcelain', '--untracked-files=all'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  }).trim()
+
+  if (status) {
+    throw new Error('Asset Store packaging requires a clean worktree; commit the source first')
+  }
+}
+
+function assertRequiredAddonFiles() {
+  for (const file of requiredFiles) {
+    const absolutePath = join(repoRoot, addonPath, file)
+    if (!existsSync(absolutePath) || !lstatSync(absolutePath).isFile()) {
+      throw new Error(`Required addon file is missing or not a regular file: ${addonPath}/${file}`)
+    }
+  }
+}
+
+function readAddonVersion() {
+  const manifest = readFileSync(join(repoRoot, addonPath, 'plugin.cfg'), 'utf8')
+  const match = manifest.match(/^version="([^"]+)"$/m)
+
+  if (!match) {
+    throw new Error('plugin.cfg must declare a quoted version')
+  }
+
+  return match[1]
+}
+
+function buildArchive(outputPath) {
+  mkdirSync(dirname(outputPath), { recursive: true })
+  execFileSync(
+    'git',
+    [
+      'archive',
+      '--format=zip',
+      '--worktree-attributes',
+      '--output',
+      outputPath,
+      'HEAD',
+      addonPath,
+    ],
+    { cwd: repoRoot, stdio: 'pipe' },
+  )
+
+  if (!existsSync(outputPath) || statSync(outputPath).size === 0) {
+    throw new Error(`Git produced no archive at ${outputPath}`)
+  }
+}
+
+const version = readAddonVersion()
+const outputPath = parseOutputPath(process.argv.slice(2), version)
+assertCleanWorktree()
+assertRequiredAddonFiles()
+buildArchive(outputPath)
+
+process.stdout.write(`Godot Asset Store archive: ${relative(repoRoot, outputPath)}\n`)

--- a/tests/godot/asset-store-package.test.ts
+++ b/tests/godot/asset-store-package.test.ts
@@ -76,14 +76,14 @@ describe('Godot Asset Store package', () => {
     expect(entries.some((entry) => entry.startsWith('.github/'))).toBe(false)
   })
 
-  it('marks non-addon repository files export-ignore while retaining addon files', () => {
+  it('keeps the repository archive attribute-neutral because the command scopes its path explicitly', () => {
     const attributes = execFileSync(
       'git',
       ['check-attr', 'export-ignore', '--', 'package.json', 'addons/better_godot_mcp/plugin.cfg'],
       { cwd: repoRoot, encoding: 'utf8' },
     )
 
-    expect(attributes).toContain('package.json: export-ignore: set')
+    expect(attributes).toContain('package.json: export-ignore: unspecified')
     expect(attributes).toContain('addons/better_godot_mcp/plugin.cfg: export-ignore: unspecified')
   })
 })

--- a/tests/godot/asset-store-package.test.ts
+++ b/tests/godot/asset-store-package.test.ts
@@ -54,7 +54,12 @@ describe('Godot Asset Store package', () => {
     const entries = readZipEntries(readFileSync(output))
 
     expect(entries.length).toBeGreaterThan(0)
-    expect(entries.every((entry) => entry.startsWith('addons/better_godot_mcp/'))).toBe(true)
+    const allowedDirectoryEntries = new Set(['addons/', 'addons/better_godot_mcp/'])
+    expect(
+      entries.every(
+        (entry) => allowedDirectoryEntries.has(entry) || entry.startsWith('addons/better_godot_mcp/'),
+      ),
+    ).toBe(true)
 
     for (const required of [
       'addons/better_godot_mcp/plugin.cfg',

--- a/tests/godot/asset-store-package.test.ts
+++ b/tests/godot/asset-store-package.test.ts
@@ -56,9 +56,7 @@ describe('Godot Asset Store package', () => {
     expect(entries.length).toBeGreaterThan(0)
     const allowedDirectoryEntries = new Set(['addons/', 'addons/better_godot_mcp/'])
     expect(
-      entries.every(
-        (entry) => allowedDirectoryEntries.has(entry) || entry.startsWith('addons/better_godot_mcp/'),
-      ),
+      entries.every((entry) => allowedDirectoryEntries.has(entry) || entry.startsWith('addons/better_godot_mcp/')),
     ).toBe(true)
 
     for (const required of [

--- a/tests/godot/asset-store-package.test.ts
+++ b/tests/godot/asset-store-package.test.ts
@@ -1,0 +1,86 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterAll, describe, expect, it } from 'vitest'
+
+const repoRoot = resolve(process.cwd())
+const outputDir = mkdtempSync(join(tmpdir(), 'better-godot-mcp-asset-store-'))
+
+afterAll(() => {
+  rmSync(outputDir, { recursive: true, force: true })
+})
+
+function readZipEntries(archive: Buffer): string[] {
+  const endOfCentralDirectorySignature = Buffer.from([0x50, 0x4b, 0x05, 0x06])
+  const endOfCentralDirectory = archive.lastIndexOf(endOfCentralDirectorySignature)
+
+  if (endOfCentralDirectory < 0) {
+    throw new Error('Asset Store archive has no ZIP end-of-central-directory record')
+  }
+
+  const centralDirectorySize = archive.readUInt32LE(endOfCentralDirectory + 12)
+  const centralDirectoryOffset = archive.readUInt32LE(endOfCentralDirectory + 16)
+  const centralDirectoryEnd = centralDirectoryOffset + centralDirectorySize
+  const entries: string[] = []
+  let cursor = centralDirectoryOffset
+
+  while (cursor < centralDirectoryEnd) {
+    if (archive.readUInt32LE(cursor) !== 0x02014b50) {
+      throw new Error(`Invalid ZIP central-directory entry at offset ${cursor}`)
+    }
+
+    const fileNameLength = archive.readUInt16LE(cursor + 28)
+    const extraFieldLength = archive.readUInt16LE(cursor + 30)
+    const fileCommentLength = archive.readUInt16LE(cursor + 32)
+    const fileNameStart = cursor + 46
+    entries.push(archive.toString('utf8', fileNameStart, fileNameStart + fileNameLength))
+    cursor += 46 + fileNameLength + extraFieldLength + fileCommentLength
+  }
+
+  return entries
+}
+
+describe('Godot Asset Store package', () => {
+  it('builds a deterministic addon-only archive with the required package surface', () => {
+    const output = join(outputDir, 'better-godot-mcp-asset-store.zip')
+
+    execFileSync(process.execPath, ['scripts/build-godot-asset-store-package.mjs', '--output', output], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+
+    expect(existsSync(output)).toBe(true)
+    const entries = readZipEntries(readFileSync(output))
+
+    expect(entries.length).toBeGreaterThan(0)
+    expect(entries.every((entry) => entry.startsWith('addons/better_godot_mcp/'))).toBe(true)
+
+    for (const required of [
+      'addons/better_godot_mcp/plugin.cfg',
+      'addons/better_godot_mcp/better_godot_mcp.gd',
+      'addons/better_godot_mcp/better_godot_mcp_dock.gd',
+      'addons/better_godot_mcp/README.md',
+      'addons/better_godot_mcp/LICENSE',
+      'addons/better_godot_mcp/icon.png',
+    ]) {
+      expect(entries).toContain(required)
+    }
+
+    expect(entries).not.toContain('package.json')
+    expect(entries).not.toContain('bun.lock')
+    expect(entries.some((entry) => entry.startsWith('src/'))).toBe(false)
+    expect(entries.some((entry) => entry.startsWith('.github/'))).toBe(false)
+  })
+
+  it('marks non-addon repository files export-ignore while retaining addon files', () => {
+    const attributes = execFileSync(
+      'git',
+      ['check-attr', 'export-ignore', '--', 'package.json', 'addons/better_godot_mcp/plugin.cfg'],
+      { cwd: repoRoot, encoding: 'utf8' },
+    )
+
+    expect(attributes).toContain('package.json: export-ignore: set')
+    expect(attributes).toContain('addons/better_godot_mcp/plugin.cfg: export-ignore: unspecified')
+  })
+})

--- a/tests/godot/editor-plugin-package.test.ts
+++ b/tests/godot/editor-plugin-package.test.ts
@@ -68,7 +68,9 @@ describe('Godot EditorPlugin package', () => {
 
     expect(readme).toContain('127.0.0.1')
     expect(readme).toContain('npx')
+    expect(readme).toContain('Asset Store')
     expect(readme).toContain('Asset Library')
+    expect(readme).toContain('package:godot-asset-store')
     expect(readme).toContain('icon.png')
     expect(readme).toContain('LICENSE')
     expect(readme).toContain('no auth')


### PR DESCRIPTION
## Summary\n- add a clean-commit, addon-only Godot Asset Store ZIP command\n- add export-ignore rules and package contract coverage\n- document current Asset Store publication requirements and keep legacy Asset Library separate\n\n## Verification\n- bun run check\n- bun run test (1039 passed, 2 skipped)\n- bun run test:live (25 passed)\n- bun run test:full (47 passed)\n- Godot headless plugin test (1 passed)\n- bun run package:godot-asset-store (archive contents inspected)