### PR TITLE
fix: harden repository automation checks

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 5am"],
+    "commitMessageAction": "lock file maintenance",
     "automerge": true,
     "automergeType": "pr"
   },

--- a/scripts/build-godot-asset-store-package.mjs
+++ b/scripts/build-godot-asset-store-package.mjs
@@ -34,14 +34,14 @@ function parseOutputPath(args, version) {
   return join(repoRoot, 'dist', 'godot-asset-store', `better-godot-mcp-${version}.zip`)
 }
 
-function assertCleanWorktree() {
-  const status = execFileSync('git', ['status', '--porcelain', '--untracked-files=all'], {
+function assertCleanAddonTree() {
+  const status = execFileSync('git', ['status', '--porcelain', '--untracked-files=all', '--', addonPath], {
     cwd: repoRoot,
     encoding: 'utf8',
   }).trim()
 
   if (status) {
-    throw new Error('Asset Store packaging requires a clean worktree; commit the source first')
+    throw new Error('Asset Store packaging requires a clean committed addon tree; commit the addon source first')
   }
 }
 
@@ -79,7 +79,7 @@ function buildArchive(outputPath) {
 
 const version = readAddonVersion()
 const outputPath = parseOutputPath(process.argv.slice(2), version)
-assertCleanWorktree()
+assertCleanAddonTree()
 assertRequiredAddonFiles()
 buildArchive(outputPath)
 

--- a/tests/godot/asset-store-package.test.ts
+++ b/tests/godot/asset-store-package.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, describe, expect, it } from 'vitest'
@@ -42,13 +42,25 @@ function readZipEntries(archive: Buffer): string[] {
 }
 
 describe('Godot Asset Store package', () => {
-  it('builds a deterministic addon-only archive with the required package surface', () => {
+  it('builds a deterministic addon-only archive while unrelated worktree files are dirty', () => {
     const output = join(outputDir, 'better-godot-mcp-asset-store.zip')
+    const unrelatedDirtyFile = join(repoRoot, `.asset-store-unrelated-${process.pid}.tmp`)
+    writeFileSync(unrelatedDirtyFile, 'unrelated test fixture\n')
 
-    execFileSync(process.execPath, ['scripts/build-godot-asset-store-package.mjs', '--output', output], {
-      cwd: repoRoot,
-      encoding: 'utf8',
-    })
+    try {
+      const status = execFileSync('git', ['status', '--porcelain', '--', unrelatedDirtyFile], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      })
+      expect(status).toContain(`?? ${unrelatedDirtyFile.slice(repoRoot.length + 1).replaceAll('\\', '/')}`)
+
+      execFileSync(process.execPath, ['scripts/build-godot-asset-store-package.mjs', '--output', output], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      })
+    } finally {
+      rmSync(unrelatedDirtyFile, { force: true })
+    }
 
     expect(existsSync(output)).toBe(true)
     const entries = readZipEntries(readFileSync(output))
@@ -85,5 +97,24 @@ describe('Godot Asset Store package', () => {
 
     expect(attributes).toContain('package.json: export-ignore: unspecified')
     expect(attributes).toContain('addons/better_godot_mcp/plugin.cfg: export-ignore: unspecified')
+  })
+
+  it('rejects packaging when the addon source itself is dirty', () => {
+    const addonReadme = join(repoRoot, 'addons/better_godot_mcp/README.md')
+    const original = readFileSync(addonReadme)
+
+    try {
+      writeFileSync(addonReadme, Buffer.concat([original, Buffer.from('\nasset-store-dirty-fixture\n')]))
+
+      expect(() =>
+        execFileSync(process.execPath, ['scripts/build-godot-asset-store-package.mjs'], {
+          cwd: repoRoot,
+          encoding: 'utf8',
+          stdio: 'pipe',
+        }),
+      ).toThrow(/clean committed addon tree/)
+    } finally {
+      writeFileSync(addonReadme, original)
+    }
   })
 })

--- a/tests/renovate-config.test.ts
+++ b/tests/renovate-config.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+interface RenovateConfig {
+  lockFileMaintenance?: {
+    commitMessageAction?: string
+  }
+}
+
+describe('Renovate configuration', () => {
+  it('keeps lock-file maintenance titles compatible with the lowercase CI rule', () => {
+    const config = JSON.parse(readFileSync(resolve(process.cwd(), 'renovate.json'), 'utf8')) as RenovateConfig
+
+    expect(config.lockFileMaintenance?.commitMessageAction).toBe('lock file maintenance')
+  })
+})


### PR DESCRIPTION
## Summary
- make Renovate lock-file maintenance titles comply with the repository conventional-title contract
- add a regression test for that title contract
- scope Asset Library packaging cleanliness to the committed addon tree, so development tests can run with unrelated changes while dirty addon sources remain blocked
- test both the allowed unrelated-dirty case and rejected dirty-addon case

## Verification
- npx --yes --package renovate renovate-config-validator renovate.json
- bun run check
- bun run test: 1042 passed, 2 skipped
- bun run test:live: 25 passed
- bun run test:full: 47 passed
- git diff --check