### PR TITLE
fix: reject non-string Godot template arguments

### DIFF
--- a/src/tools/composite/animation.ts
+++ b/src/tools/composite/animation.ts
@@ -8,7 +8,7 @@ import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 import { parseSceneContent } from '../helpers/scene-parser.js'
-import { validateNoNewlines } from '../helpers/security.js'
+import { validateNoNewlines, validateStringArguments } from '../helpers/security.js'
 
 // ⚡ Bolt: Removed redundant pathExists. Instead return resolved path and use try/catch in handlers where needed.
 function resolveScene(projectRoot: string, scenePath: string): string {
@@ -16,12 +16,13 @@ function resolveScene(projectRoot: string, scenePath: string): string {
 }
 
 async function handleCreatePlayer(projectPath: string, args: Record<string, unknown>) {
+  validateStringArguments('Invalid characters in parameters', args.scene_path, args.name, args.parent)
   const scenePath = args.scene_path as string
   if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
   const playerName = (args.name as string) || 'AnimationPlayer'
   const parent = (args.parent as string) || '.'
 
-  validateNoNewlines('Invalid characters in parameters', playerName, parent)
+  validateNoNewlines('Invalid characters in parameters', scenePath, playerName, parent)
   if (playerName.includes('"') || parent.includes('"')) {
     throw new GodotMCPError('Invalid characters in parameters', 'INVALID_ARGS', 'Parameters must not contain quotes.')
   }
@@ -47,6 +48,8 @@ async function handleCreatePlayer(projectPath: string, args: Record<string, unkn
 }
 
 async function handleAddAnimation(projectPath: string, args: Record<string, unknown>) {
+  validateStringArguments(undefined, args.scene_path)
+  validateStringArguments('Invalid characters in anim_name', args.anim_name)
   const scenePath = args.scene_path as string
   if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
   const animName = args.anim_name as string
@@ -57,6 +60,7 @@ async function handleAddAnimation(projectPath: string, args: Record<string, unkn
   const duration = (args.duration as number) || 1.0
   const loop = args.loop !== false
 
+  validateNoNewlines(undefined, scenePath)
   validateNoNewlines('Invalid characters in anim_name', animName)
   if (animName.includes('"')) {
     throw new GodotMCPError('Invalid characters in anim_name', 'INVALID_ARGS', 'Parameters must not contain quotes.')
@@ -92,6 +96,14 @@ async function handleAddAnimation(projectPath: string, args: Record<string, unkn
 }
 
 async function handleAddTrack(projectPath: string, args: Record<string, unknown>) {
+  validateStringArguments(
+    'Invalid characters in parameters',
+    args.scene_path,
+    args.anim_name,
+    args.track_type,
+    args.node_path,
+    args.property,
+  )
   const scenePath = args.scene_path as string
   if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
   const animName = args.anim_name as string
@@ -102,7 +114,7 @@ async function handleAddTrack(projectPath: string, args: Record<string, unknown>
     throw new GodotMCPError('anim_name, node_path, and property required', 'INVALID_ARGS', 'All three are required.')
   }
 
-  validateNoNewlines('Invalid characters in parameters', animName, trackType, nodePath, property)
+  validateNoNewlines('Invalid characters in parameters', scenePath, animName, trackType, nodePath, property)
   if (animName.includes('"') || trackType.includes('"') || nodePath.includes('"') || property.includes('"')) {
     throw new GodotMCPError('Invalid characters in parameters', 'INVALID_ARGS', 'Parameters must not contain quotes.')
   }
@@ -150,8 +162,10 @@ async function handleAddKeyframe() {
 }
 
 async function handleListAnimations(projectPath: string, args: Record<string, unknown>) {
+  validateStringArguments(undefined, args.scene_path)
   const scenePath = args.scene_path as string
   if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
+  validateNoNewlines(undefined, scenePath)
 
   const fullPath = resolveScene(projectPath, scenePath)
   let content: string
@@ -216,6 +230,7 @@ const ANIMATION_ACTIONS: Record<string, (projectPath: string, args: Record<strin
 }
 
 export async function handleAnimation(action: string, args: Record<string, unknown>, config: GodotConfig) {
+  validateStringArguments(undefined, args.project_path)
   const projectPath = resolveProjectRoot(args.project_path, config.projectPath)
 
   if (Object.hasOwn(ANIMATION_ACTIONS, action)) {

--- a/src/tools/composite/physics.ts
+++ b/src/tools/composite/physics.ts
@@ -11,9 +11,10 @@ import { toGodotValue } from '../helpers/godot-types.js'
 import { resolveProjectRoot, safeResolve } from '../helpers/paths.js'
 import { parseProjectSettingsAsync, setSettingInContent } from '../helpers/project-settings.js'
 import { updateNodeInScene } from '../helpers/scene-parser.js'
-import { validateNoNewlines } from '../helpers/security.js'
+import { validateNoNewlines, validateStringArguments } from '../helpers/security.js'
 
 export async function handlePhysics(action: string, args: Record<string, unknown>, config: GodotConfig) {
+  validateStringArguments(undefined, args.project_path)
   const projectPath = (args.project_path as string) || config.projectPath || ''
 
   switch (action) {
@@ -43,6 +44,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
     }
 
     case 'collision_setup': {
+      validateStringArguments(undefined, args.scene_path, args.name)
       const scenePath = args.scene_path as string
       if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
       const nodeName = args.name as string
@@ -87,6 +89,7 @@ export async function handlePhysics(action: string, args: Record<string, unknown
     }
 
     case 'body_config': {
+      validateStringArguments(undefined, args.scene_path, args.name)
       const scenePath = args.scene_path as string
       if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
       const nodeName = args.name as string
@@ -125,6 +128,10 @@ export async function handlePhysics(action: string, args: Record<string, unknown
 
     case 'set_layer_name': {
       if (!projectPath) throw new GodotMCPError('No project path specified', 'INVALID_ARGS', 'Provide project_path.')
+      validateStringArguments(undefined, args.dimension, args.name)
+      if (args.layer_number !== undefined && typeof args.layer_number !== 'number') {
+        throw new GodotMCPError('Invalid layer_number: must be a number', 'INVALID_ARGS')
+      }
       const layerNumRaw = args.layer_number !== undefined ? String(args.layer_number) : '1'
       const dimension = (args.dimension as string) || '2d'
       const name = args.name as string

--- a/tests/security/physics_injection.test.ts
+++ b/tests/security/physics_injection.test.ts
@@ -19,6 +19,26 @@ describe('physics security', () => {
 
   afterEach(() => cleanup())
 
+  it('should reject non-string layer names before modifying project.godot', async () => {
+    const configPath = join(projectPath, 'project.godot')
+    const original = readFileSync(configPath, 'utf-8')
+
+    await expect(
+      handlePhysics(
+        'set_layer_name',
+        {
+          project_path: projectPath,
+          layer_number: 1,
+          dimension: '2d',
+          name: ['Enemies\n[application]'],
+        },
+        config,
+      ),
+    ).rejects.toThrow('Invalid arguments: expected string values')
+
+    expect(readFileSync(configPath, 'utf-8')).toBe(original)
+  })
+
   it('should not allow scene file injection via collision_layer', async () => {
     createTmpScene(projectPath, 'test.tscn', MINIMAL_TSCN)
     const maliciousPayload = '1\n[node name="Injected" type="Node"]\n'

--- a/tests/security/scene-injection.test.ts
+++ b/tests/security/scene-injection.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { GodotConfig } from '../../src/godot/types.js'
@@ -20,6 +20,25 @@ describe('Scene Injection Security Tests', () => {
   })
 
   describe('Animation Tool', () => {
+    it('should reject non-string template arguments before modifying the scene', async () => {
+      const scenePath = join(projectPath, 'scene.tscn')
+      const original = readFileSync(scenePath, 'utf-8')
+
+      await expect(
+        handleAnimation(
+          'create_player',
+          { scene_path: 'scene.tscn', name: ['Player\n[node name="Injected"]'] },
+          config,
+        ),
+      ).rejects.toThrow('Invalid characters in parameters')
+
+      await expect(
+        handleAnimation('add_animation', { scene_path: 'scene.tscn', anim_name: { value: 'Idle' } }, config),
+      ).rejects.toThrow('Invalid characters in anim_name')
+
+      expect(readFileSync(scenePath, 'utf-8')).toBe(original)
+    })
+
     it('should reject newlines and quotes in create_player', async () => {
       await expect(
         handleAnimation('create_player', { scene_path: 'scene.tscn', name: 'Player\n[node' }, config),


### PR DESCRIPTION
## Summary
- reject non-string MCP arguments before animation and physics handlers interpolate them into Godot text files
- validate project paths and action-specific string fields at the runtime boundary instead of coercing arbitrary values
- add regression tests proving array/object payloads cannot modify scene.tscn or project.godot

This supersedes #1081 without weakening the repository title check or coercing untrusted objects with String(value).

## Verification
- bun run check
- bun run test: 1044 passed, 2 skipped
- bun run test:live: 25 passed
- bun run test:full: 47 passed
- git diff --check