### PR TITLE
fix: keep Godot protocol harness compatible with MCP SDK

### DIFF
--- a/test-project-flags/project.godot
+++ b/test-project-flags/project.godot
@@ -1,0 +1,23 @@
+; Engine configuration file.
+; This fixture is intentionally minimal and is used by the stdio protocol harness.
+
+config_version=5
+
+[application]
+
+config/name="Better Godot MCP E2E Fixture"
+
+[display]
+
+window/size/viewport_width=640
+window/size/viewport_height=360
+
+[rendering]
+
+renderer/rendering_method="gl_compatibility"
+renderer/rendering_method.mobile="gl_compatibility"
+
+[input]
+
+[layer_names]
+2d_physics/layer_1="e2e_layer"

--- a/tests/e2e_mcp_protocol_test.py
+++ b/tests/e2e_mcp_protocol_test.py
@@ -10,16 +10,24 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import shutil
 import sys
+import tempfile
 from pathlib import Path
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
 REPO_ROOT = Path(__file__).parent.parent
-PROJECT_PATH = os.environ.get(
-    "GODOT_TEST_PROJECT", str(Path(__file__).parent.parent / "test-project-flags")
-)
+DEFAULT_PROJECT_PATH = REPO_ROOT / "test-project-flags"
+_TEMP_PROJECT_DIR: tempfile.TemporaryDirectory[str] | None = None
+_configured_project = os.environ.get("GODOT_TEST_PROJECT")
+if _configured_project:
+    PROJECT_PATH = _configured_project
+else:
+    _TEMP_PROJECT_DIR = tempfile.TemporaryDirectory(prefix="better-godot-e2e-")
+    shutil.copytree(DEFAULT_PROJECT_PATH, _TEMP_PROJECT_DIR.name, dirs_exist_ok=True)
+    PROJECT_PATH = _TEMP_PROJECT_DIR.name
 
 # Per-tool call plans: list of (label, args) tuples. Tools accept (action, ...extra).
 CALL_PLANS: dict[str, list[tuple[str, dict]]] = {
@@ -119,7 +127,7 @@ def short(text: str, n: int = 140) -> str:
 async def call_tool(session: ClientSession, tool: str, args: dict) -> tuple[bool, str]:
     try:
         res = await session.call_tool(tool, args)
-        if res.isError:
+        if getattr(res, "is_error", getattr(res, "isError", False)):
             body = res.content[0].text if res.content else "<no content>"
             return False, short(body)
         body = res.content[0].text if res.content else ""


### PR DESCRIPTION
## Summary
- keep the Python MCP protocol harness compatible with current `mcp` SDK results (`is_error`, with legacy fallback)
- run the default protocol fixture from an isolated temporary copy so repeated runs do not mutate the checkout or collide with generated resources
- add the minimal `project.godot` required by the default fixture

## Verification
- `uv run --with mcp --no-project python tests/e2e_mcp_protocol_test.py` — 47/47 PASS, 17 tools discovered
- `python` compile check — PASS