### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix numeric parameter injection via NaN/Infinity

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -39,3 +39,8 @@
 **Vulnerability:** Untyped JSON inputs (like arrays) could bypass injection validation checks (e.g., `typeof val === 'string' && val.includes('\n')`).
 **Learning:** Checking `typeof val === 'string'` before calling `.includes()` allows arrays (e.g. `["malicious\ncode"]`) to silently skip validation, but these arrays are later coerced to strings during template interpolation, leading to injection vulnerabilities.
 **Prevention:** Explicitly coerce untyped values to strings (e.g., `String(val)`) before applying security validations like `.includes()`.
+
+## 2026-08-29 - NaN/Infinity Parameter Injection
+**Vulnerability:** User-controlled numeric parameters were validated with `typeof val === 'number'`, but this check allows `NaN` and `Infinity`. When these values are interpolated into Godot file structures (like .tscn or .tres), they stringify to \NaN\ or \Infinity\, potentially causing serialization or parser errors.
+**Learning:** The `typeof val === 'number'` check is insufficient for numeric inputs that will be converted to strings in file templating.
+**Prevention:** Always use `!Number.isFinite(val)` alongside `typeof` checks for numeric inputs to ensure they are valid finite numbers before interpolation.

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
+  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "@n24q02m/better-godot-mcp",
@@ -251,7 +252,7 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
-    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
@@ -507,7 +508,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "zod": ["zod@4.5.4", "", {}, "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA=="],
+    "zod": ["zod@4.5.2", "", {}, "sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
-  "lockfileVersion": 2,
-  "configVersion": 1,
+  "lockfileVersion": 1,
   "workspaces": {
     "": {
       "name": "@n24q02m/better-godot-mcp",
@@ -252,7 +251,7 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
-    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
@@ -508,7 +507,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "zod": ["zod@4.5.2", "", {}, "sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg=="],
+    "zod": ["zod@4.5.4", "", {}, "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 

--- a/src/tools/composite/animation.ts
+++ b/src/tools/composite/animation.ts
@@ -54,8 +54,8 @@ async function handleAddAnimation(projectPath: string, args: Record<string, unkn
   if (!scenePath) throw new GodotMCPError('No scene_path specified', 'INVALID_ARGS', 'Provide scene_path.')
   const animName = args.anim_name as string
   if (!animName) throw new GodotMCPError('No anim_name specified', 'INVALID_ARGS', 'Provide animation name.')
-  if (args.duration !== undefined && typeof args.duration !== 'number') {
-    throw new GodotMCPError('duration must be a number', 'INVALID_ARGS')
+  if (args.duration !== undefined && (typeof args.duration !== 'number' || !Number.isFinite(args.duration))) {
+    throw new GodotMCPError('duration must be a finite number', 'INVALID_ARGS')
   }
   const duration = (args.duration as number) || 1.0
   const loop = args.loop !== false

--- a/src/tools/composite/input-map.ts
+++ b/src/tools/composite/input-map.ts
@@ -358,8 +358,8 @@ export async function handleInputMap(action: string, args: Record<string, unknow
           'Action names must contain only alphanumeric characters, underscores, and hyphens.',
         )
       }
-      if (args.deadzone !== undefined && typeof args.deadzone !== 'number') {
-        throw new GodotMCPError('deadzone must be a number', 'INVALID_ARGS')
+      if (args.deadzone !== undefined && (typeof args.deadzone !== 'number' || !Number.isFinite(args.deadzone))) {
+        throw new GodotMCPError('deadzone must be a finite number', 'INVALID_ARGS')
       }
       const deadzone = (args.deadzone as number) || 0.5
 

--- a/src/tools/composite/signals.ts
+++ b/src/tools/composite/signals.ts
@@ -69,8 +69,8 @@ async function handleConnectSignal(projectPath: string, args: Record<string, unk
   }
 
   const flags = args.flags as number | undefined
-  if (flags !== undefined && typeof flags !== 'number') {
-    throw new GodotMCPError('flags must be a number', 'INVALID_ARGS')
+  if (flags !== undefined && (typeof flags !== 'number' || !Number.isFinite(flags))) {
+    throw new GodotMCPError('flags must be a finite number', 'INVALID_ARGS')
   }
 
   validateParameters(signal, from, to, method, flags)

--- a/src/tools/composite/tilemap.ts
+++ b/src/tools/composite/tilemap.ts
@@ -22,8 +22,8 @@ export async function handleTilemap(action: string, args: Record<string, unknown
           'INVALID_ARGS',
           'Provide tileset_path (e.g., "tilesets/main.tres").',
         )
-      if (args.tile_size !== undefined && typeof args.tile_size !== 'number') {
-        throw new GodotMCPError('tile_size must be a number', 'INVALID_ARGS')
+      if (args.tile_size !== undefined && (typeof args.tile_size !== 'number' || !Number.isFinite(args.tile_size))) {
+        throw new GodotMCPError('tile_size must be a finite number', 'INVALID_ARGS')
       }
       const tileSize = (args.tile_size as number) || 16
 

--- a/tests/security/signals-injection.test.ts
+++ b/tests/security/signals-injection.test.ts
@@ -81,6 +81,6 @@ describe('signals security', () => {
         },
         config,
       ),
-      ).rejects.toThrow('flags must be a finite number')
+    ).rejects.toThrow('flags must be a finite number')
   })
 })

--- a/tests/security/signals-injection.test.ts
+++ b/tests/security/signals-injection.test.ts
@@ -81,6 +81,6 @@ describe('signals security', () => {
         },
         config,
       ),
-    ).rejects.toThrow('flags must be a number')
+      ).rejects.toThrow('flags must be a finite number')
   })
 })


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** User-controlled numeric parameters (`deadzone`, `flags`, `duration`, `tile_size`) were checked using `typeof args.param === 'number'`, which allows `NaN` and `Infinity`. When interpolated into Godot file structures (`.tscn`, `.tres`), these values stringify to `"NaN"` or `"Infinity"`, potentially causing serialization or parser errors.
🎯 **Impact:** Potential parser errors, serialization issues, or unexpected behavior in the Godot project due to invalid values in configuration or scene files.
🔧 **Fix:** Added `!Number.isFinite(val)` alongside `typeof` checks to ensure these numeric inputs are valid finite numbers before interpolation.
✅ **Verification:** Verified by updating tests in `tests/security/signals-injection.test.ts` and running the full test suite (`bun run test`), which passes.

---
*PR created automatically by Jules for task [791385210785580881](https://jules.google.com/task/791385210785580881) started by @n24q02m*