### PR TITLE
🛡️ Sentinel: [HIGH] Fix Command Injection via PID in killProcessTree

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,7 @@
 **Vulnerability:** User-controlled numeric parameters were validated with `typeof val === 'number'`, but this check allows `NaN` and `Infinity`. When these values are interpolated into Godot file structures (like .tscn or .tres), they stringify to \NaN\ or \Infinity\, potentially causing serialization or parser errors.
 **Learning:** The `typeof val === 'number'` check is insufficient for numeric inputs that will be converted to strings in file templating.
 **Prevention:** Always use `!Number.isFinite(val)` alongside `typeof` checks for numeric inputs to ensure they are valid finite numbers before interpolation.
+## 2025-05-30 - PID Validation Check Missing in killProcessTree
+**Vulnerability:** Command injection was possible through `killProcessTree` when `taskkill` was executed on Windows, if an untrusted or non-numeric PID string was somehow provided.
+**Learning:** JS typing (e.g. `pid: number`) does not guarantee runtime validity, especially if untyped data is parsed directly from MCP tool arguments.
+**Prevention:** Ensured `isValidPid(pid)` check is added explicitly at the top of the `killProcessTree` function.

--- a/src/godot/headless.ts
+++ b/src/godot/headless.ts
@@ -4,6 +4,7 @@
 
 import { execFile, execFileSync, spawn, spawnSync } from 'node:child_process'
 import { promisify } from 'node:util'
+import { isValidPid } from '../tools/helpers/security.js'
 import type { HeadlessResult } from './types.js'
 
 const DEFAULT_TIMEOUT_MS = 30_000
@@ -225,6 +226,8 @@ export function getTrackedPids(): number[] {
  * was already gone.
  */
 export function killProcessTree(pid: number): boolean {
+  if (!isValidPid(pid)) return false
+
   try {
     if (process.platform === 'win32') {
       try {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Command injection was possible in `killProcessTree` via `taskkill` on Windows if a malicious PID string was provided. JS type annotations (like `pid: number`) do not protect against untyped runtime objects parsed from arguments.
🎯 **Impact:** An attacker who injects an invalid PID (like `1234 & echo pwned`) could execute arbitrary commands on a Windows machine. 
🔧 **Fix:** Imported and added an explicit `isValidPid(pid)` check at the top of `killProcessTree` in `src/godot/headless.ts`.
✅ **Verification:** Verified by running all unit tests (including `tests/security/pid-injection.test.ts`), which now pass successfully.

---
*PR created automatically by Jules for task [14620758125041450961](https://jules.google.com/task/14620758125041450961) started by @n24q02m*