### PR TITLE
fix: bump mcp-core to 1.24.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@n24q02m/better-godot-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
-        "@n24q02m/mcp-core": "1.24.0",
+        "@n24q02m/mcp-core": "1.24.1",
         "zod": "^4.6.2",
       },
       "devDependencies": {
@@ -114,7 +114,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.24.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.30.0", "better-sqlite3": "^13.0.3", "env-paths": "^4.0.0", "jose": "^6.2.10" } }, "sha512-IIJnT+k3Ux7g/f8IClUHChG8qZVNlaB9Tth8qwkb0arfdnALYcxV1LBwY3Y0AEWE/dfifptNHnoslZ3hzvHZTg=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.24.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.30.0", "better-sqlite3": "^13.0.3", "env-paths": "^4.0.0", "jose": "^6.2.10" } }, "sha512-pGuz7RA++Tep6av4J3de+kED4rWlzJ5NFlJvNPeAbogjUkzX146ri7+4SSCGDvLmFHbKnFsg7jcEZ6sOt6a9/A=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.149.0", "", {}, "sha512-Efcc+iF0j3Bf67YjEqIqWXbX5XddXoK/Mw4K1/JuXwRCZ8N16VR7iT23nlCc9XrveFVh/E5Rqs2StT0V8v9LdA=="],
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
-    "@n24q02m/mcp-core": "1.24.0",
+    "@n24q02m/mcp-core": "1.24.1",
     "zod": "^4.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Auto bump lane - remediation plan `superpower/mcp-stack/plans/2026-09-12-mcp-final-remediation-plan.md` (.private @ 080e7506).

Registry evidence (readback 2026-09-12): mcp-core 1.24.1 latest on PyPI and npm, yanked=false, no prerelease.
better-godot-mcp-specific: wet-mcp also refreshes n24q02m-web-core lock to 2.7.0 (range pin >=2.5.1,<3 already allows it).

**READY-TO-MERGE**: merge is held until lane approval; a small post-approval runner does merge + release readback + tracker issue close.
