### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix array bypass in config set

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -53,3 +53,8 @@
 **Vulnerability:** Path traversal vulnerabilities allowed accessing directories outside of the intended project root in the nodes and scripts handling operations. Although `safeResolve` was used as `safeResolve(baseDir, args.project_path as string)`, it still didn't safely constrain `project_path` against the configured project root before subsequent usage, whereas `resolveProjectRoot` specifically exists for this purpose.
 **Learning:** For user-supplied project paths, relying solely on `safeResolve` with a local `baseDir` variable can still permit paths that escape the `config.projectPath`. Using `resolveProjectRoot` guarantees that the path does not escape the configured boundary, and safely handles types.
 **Prevention:** In actions taking a `project_path` argument, derive the base project directory using `resolveProjectRoot(args.project_path, config.projectPath)` (or `baseDir` if derived from `config.projectPath`) instead of using `safeResolve` with `args.project_path` directly.
+
+## 2026-10-01 - Array Bypass in Configuration Settings
+**Vulnerability:** In `src/tools/composite/config.ts`, `args.key` and `args.value` were unsafely cast to string via `as string`. An attacker could pass a JSON array like `["timeout"]` which bypasses strict type-checks intended for strings but implicitly coerces later.
+**Learning:** `as string` casts in TypeScript offer no runtime protection. If data originates from an untrusted source (like tool JSON arguments), it must be explicitly type-checked at runtime before assignment to typed records or configurations.
+**Prevention:** Use `validateStringArguments(undefined, args.key, args.value)` immediately when extracting string parameters from tool `args` mapping objects.

--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -8,6 +8,7 @@ import { detectGodot, isExecutable, isVersionSupported, tryGetVersion } from '..
 import type { GodotConfig } from '../../godot/types.js'
 import { formatJSON, formatSuccess, GodotMCPError, throwUnknownAction } from '../helpers/errors.js'
 import { pathExists } from '../helpers/paths.js'
+import { validateStringArguments } from '../helpers/security.js'
 
 // Mutable runtime config
 const runtimeConfig: Record<string, string> = {}
@@ -28,6 +29,7 @@ async function handleStatus(_args: Record<string, unknown>, config: GodotConfig)
  * Set a configuration value.
  */
 async function handleSet(args: Record<string, unknown>, config: GodotConfig) {
+  validateStringArguments(undefined, args.key, args.value)
   const key = args.key as string
   const value = args.value as string
 

--- a/tests/composite/config.test.ts
+++ b/tests/composite/config.test.ts
@@ -221,7 +221,7 @@ describe('config', () => {
     it('should reject paths that are not strings', async () => {
       await expect(
         handleConfig('set', { key: 'godot_path', value: ['node', '-e', 'pwned'] as unknown as string }, config),
-      ).rejects.toThrow('Invalid characters')
+      ).rejects.toThrow('expected string values')
     })
   })
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Array bypass/Type injection in `handleSet` configuration endpoint. `args.key` and `args.value` were explicitly cast using `as string` without strict runtime validation, allowing untyped JSON parameters (like arrays) to bypass string protections and later coercing unpredictably into the global `runtimeConfig`.
🎯 Impact: Could potentially allow manipulation of system runtime configuration typing, leading to unexpected behavior or evaluation if configuration values are later interpolated in downstream system commands or templates.
🔧 Fix: Imported and applied `validateStringArguments` at the entry point of `handleSet` to ensure the runtime type is strictly `string` before any mapping or path validation occurs.
✅ Verification: Ran `bun run test` (including modified coverage in `tests/composite/config.test.ts`) and fully validated that type enforcement correctly rejects non-string inputs.

---
*PR created automatically by Jules for task [12428847404562498108](https://jules.google.com/task/12428847404562498108) started by @n24q02m*