### PR TITLE
⚡ Bolt: [performance improvement] Guard .toLowerCase() with length check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -87,3 +87,6 @@ This ensures that "create" matches "create" even if "create_node" appears earlie
 ## 2026-07-20 - [Optimize Array construction in hot paths]
 **Learning:** In string serialization hot paths, such as serializing arrays to Godot strings, using standard iterative string concatenation (`result += ...`) creates many intermediate string allocations, triggering garbage collection pressure.
 **Action:** Replace iterative string concatenation for arrays with a pre-allocated array (`const items = new Array(len)`) and using `.join(', ')` to eliminate intermediate strings and improve GC efficiency.
+## 2026-09-12 - [Optimize case-insensitive check]
+**Learning:** Guarding expensive string operations like `.toLowerCase()` with fast-path length checks prevents unnecessary string allocations in hot paths where a short-circuit string comparison is intended (e.g. checking exactly `'/root'`).
+**Action:** Use a fast-path length check (`str.length === X && str.toLowerCase() === '...'`) when performing strict case-insensitive equality comparisons.

--- a/src/tools/composite/nodes.ts
+++ b/src/tools/composite/nodes.ts
@@ -65,7 +65,8 @@ function normalizeNodePath(path: string): { path: string; corrected: boolean } {
   // But wait, if someone has a node named "Root" that is NOT the scene root?
   // In Godot, the root of the scene being edited is often named after the scene or "Root".
   // LLMs often use "/root/SceneName/..."
-  if (normalized.toLowerCase() === '/root') {
+  // ⚡ Bolt: Guarding .toLowerCase() string allocation with a length check for the hot path exact match.
+  if (normalized.length === 5 && normalized.toLowerCase() === '/root') {
     return { path: '.', corrected: true }
   }
 


### PR DESCRIPTION
### 💡 What
Added a length guard before calling `.toLowerCase()` in `normalizeNodePath`'s hot-path string equality check (`normalized.length === 5 && normalized.toLowerCase() === '/root'`).

### 🎯 Why
Calling `.toLowerCase()` creates a new string in memory. If the string is being checked for exact equality against a target of known length, it's significantly faster to check the length first. If the length does not match, we avoid the string allocation entirely.

### 📊 Impact
Reduces unnecessary string allocations when checking paths that are not exactly 5 characters long, reducing garbage collection pressure in path resolution paths.

### 🔬 Measurement
Run `bun run test` to verify `src/tools/composite/nodes.ts` still normalizes paths perfectly while bypassing allocations for non-root paths.

---
*PR created automatically by Jules for task [15639706276141749083](https://jules.google.com/task/15639706276141749083) started by @n24q02m*